### PR TITLE
Move migrations from skaffold to k8s for stag/prod

### DIFF
--- a/backend/k8s/api.yaml
+++ b/backend/k8s/api.yaml
@@ -14,6 +14,7 @@ spec:
     - port: 30000
       nodePort: 30000
 ---
+# API deployment
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -36,3 +37,9 @@ spec:
           image: localhost:32000/test-observer-api
           ports:
             - containerPort: 30000
+      initContainers:
+        - name: wait-for-db-migrations
+          image: ghcr.io/groundnuty/k8s-wait-for:v2.0
+          args:
+            - "job"
+            - "test-observer-migrations"

--- a/backend/k8s/db.yaml
+++ b/backend/k8s/db.yaml
@@ -28,6 +28,7 @@ spec:
     app.kubernetes.io/name: test-observer-db
   clusterIP: None
 ---
+# Deploy db
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -62,3 +63,30 @@ spec:
           env:
             - name: POSTGRES_PASSWORD
               value: "password"
+          readinessProbe:
+            exec:
+              command:
+                - "pg_isready"
+---
+# Run migrations
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: test-observer-migrations
+  labels:
+    app.kubernetes.io/name: test-observer-migrations
+    app.kubernetes.io/part-of: test-observer
+spec:
+  template:
+    spec:
+      containers:
+        - name: test-observer-migrations
+          image: localhost:32000/test-observer-api
+          command: ["alembic", "upgrade", "head"]
+      initContainers:
+        - name: wait-for-db
+          image: ghcr.io/groundnuty/k8s-wait-for:v2.0
+          args:
+            - "pod"
+            - "-lapp.kubernetes.io/name=test-observer-db"
+      restartPolicy: Never

--- a/backend/skaffold.yaml
+++ b/backend/skaffold.yaml
@@ -24,10 +24,3 @@ build:
     - localhost:32000
 deploy:
   kubeContext: microk8s
-  kubectl:
-    hooks:
-      after:
-        - container:
-            # Run database migrations
-            command: ["sh", "-c", "alembic upgrade head"]
-            podName: test-observer-api*


### PR DESCRIPTION
As part of setting up the code to work on staging and production. Handling of db migrations needs to be moved from Skaffold to just plain k8s (since Skaffold is only for development). This PR moves db migrations into a k8s job. Additionally, it adds init containers that will wait for the database to be ready before running migrations, then for the migrations to be ready before running the api.