### PR TITLE
Fix random test failure

### DIFF
--- a/backend/tests/data_access/test_repository.py
+++ b/backend/tests/data_access/test_repository.py
@@ -109,6 +109,6 @@ def test_get_artefacts_by_family_name_latest(db_session: Session):
     # Assert
     assert len(artefacts) == len(expected_artefacts)
     assert {
-        (artefact.name, artefact.stage.name, artefact.created_at)
+        (artefact.name, artefact.stage.name, artefact.created_at, artefact.version)
         for artefact in artefacts
     } == expected_artefacts


### PR DESCRIPTION
Fixes random test failure due to `randint` occasionally creating the same artefact and breaking unique constraint. In previous [PR](https://github.com/canonical/test_observer/pull/28), I fixed it for `test_retreive_family`. But turns out the issue also existed in a different test `test_get_artefacts_by_family_name_latest`. So it failed again https://github.com/canonical/test_observer/actions/runs/5342333621/jobs/9684048424.