### PR TITLE
Make get_or_create save instances in the DB permanently

### DIFF
--- a/backend/test_observer/data_access/repository.py
+++ b/backend/test_observer/data_access/repository.py
@@ -123,5 +123,5 @@ def get_or_create(
     except IntegrityError:
         # Query and return the existing instance
         instance = db.query(model).filter_by(**filter_kwargs).one()
-
+    db.commit()
     return instance


### PR DESCRIPTION
It turned out that the `get_or_create` method doesn't create a permanent record in the DB. Even despite the fact that we get an object ID, the changes are not committed and the object is not saved in the DB.
Here I fix this problem according to the [documentation](https://docs.sqlalchemy.org/en/20/orm/session_transaction.html#nested-transaction).
> Session.begin_nested() is typically used as a context manager where specific per-instance errors may be caught, in conjunction with a rollback emitted for that portion of the transaction’s state, without rolling back the whole transaction, as in the example below:

```python
for record in records:
    try:
        with session.begin_nested():
            session.merge(record)
    except:
        print("Skipped record %s" % record)
session.commit()
```

This PR is draft since we need to fix the tests to actually check if the object was saved in the DB and it's not that obvious