### PR TITLE
Drop charm revisions in TF, we'll use juju refresh

### DIFF
--- a/terraform/test-observer.tf
+++ b/terraform/test-observer.tf
@@ -61,10 +61,9 @@ resource "juju_application" "test-observer-api" {
   model = juju_model.test-observer.name
 
   charm {
-    name     = "test-observer-api"
-    channel  = "latest/edge"
-    series   = "jammy"
-    revision = 20
+    name    = "test-observer-api"
+    channel = "latest/edge"
+    series  = "jammy"
   }
 
   config = {
@@ -80,10 +79,9 @@ resource "juju_application" "test-observer-frontend" {
   model = juju_model.test-observer.name
 
   charm {
-    name     = "test-observer-frontend"
-    channel  = "latest/edge"
-    series   = "jammy"
-    revision = 13
+    name    = "test-observer-frontend"
+    channel = "latest/edge"
+    series  = "jammy"
   }
 
   config = {


### PR DESCRIPTION
No need for revisions in TF configuration if we'll just upgrade using `juju refresh`. Also we need a new charms release so that we can test refreshing to get the new resources.