### PR TITLE
Inject sentry_dsn as a string and expand vars in it

### DIFF
--- a/backend/charm/src/charm.py
+++ b/backend/charm/src/charm.py
@@ -185,7 +185,7 @@ class TestObserverBackendCharm(CharmBase):
                             ]
                         ),
                         "startup": "enabled",
-                        "environment": self._app_environment(),
+                        "environment": self._app_environment,
                     }
                 },
             }

--- a/terraform/test-observer.tf
+++ b/terraform/test-observer.tf
@@ -77,7 +77,7 @@ resource "juju_application" "test-observer-api" {
   config = {
     hostname   = var.environment == "staging" ? "test-observer-api-staging.${var.external_ingress_hostname}" : "test-observer-api.${var.external_ingress_hostname}"
     port       = var.environment == "development" ? 30000 : 443
-    sentry_dsn = {local.sentry_dsn_map[var.environment]}
+    sentry_dsn = "${local.sentry_dsn_map[var.environment]}"
   }
 
   units = 1


### PR DESCRIPTION
Without this, I was getting the following error when trying to deploy locally:
```
│   80:     sentry_dsn = {local.sentry_dsn_map[var.environment]}                
│                                                                               
│ Expected an equals sign ("=") to mark the beginning of the attribute value.   
╵ 
```