### PR TITLE
Add sentry client for TO frontend

### DIFF
--- a/frontend/charm/config.yaml
+++ b/frontend/charm/config.yaml
@@ -15,3 +15,8 @@ options:
     description: Scheme for accessing Test Observer API (used to construct URLs for API requests)
     default: "https://"
     type: string
+
+  sentry_dsn:
+    description: Sentry DSN name for sending errors to sentry server
+    default: ""
+    type: string

--- a/frontend/charm/src/charm.py
+++ b/frontend/charm/src/charm.py
@@ -97,7 +97,7 @@ class TestObserverFrontendCharm(ops.CharmBase):
         logger.debug("REST API relation broken")
         self._handle_no_api_relation()
 
-    def nginx_config(self, base_uri: str) -> str:
+    def nginx_config(self, base_uri: str, sentry_dsn: str) -> str:
         """Return a config where the backend port `base_uri` is adjusted."""
         return f"""
         server {{
@@ -114,6 +114,7 @@ class TestObserverFrontendCharm(ops.CharmBase):
                 add_header Cache-Control "no-store, no-cache, must-revalidate, post-check=0, pre-check=0";
 
                 sub_filter 'http://api-placeholder:30000/' '{base_uri}';
+                sub_filter 'http://sentry-dsn-placeholder/', '{sentry_dsn}';
                 sub_filter_once on;
             }}
 
@@ -164,7 +165,7 @@ class TestObserverFrontendCharm(ops.CharmBase):
         if self.container.can_connect():
             self.container.push(
                 "/etc/nginx/sites-available/test-observer-frontend",
-                self.nginx_config(base_uri=self._api_url),
+                self.nginx_config(base_uri=self._api_url, sentry_dsn=self.config["sentry_dsn"]),
                 make_dirs=True,
             )
             self.container.add_layer(self.pebble_service_name, self._pebble_layer, combine=True)

--- a/frontend/lib/helpers.dart
+++ b/frontend/lib/helpers.dart
@@ -1,0 +1,8 @@
+// ignore_for_file: avoid_web_libraries_in_flutter
+
+import 'dart:html';
+import 'dart:js_util' as js_util;
+
+String? getSentryDSN() {
+  return js_util.getProperty(window, 'sentryDSN');
+}

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,8 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 import 'app.dart';
+import 'helpers.dart';
 
-void main() {
-  runApp(const ProviderScope(child: App()));
+Future<void> main() async {
+  final sentryDSN = getSentryDSN();
+
+  if (sentryDSN != null &&
+      sentryDSN.isNotEmpty &&
+      sentryDSN != 'http://sentry-dsn-placeholder/') {
+    await SentryFlutter.init(
+      (options) {
+        options.dsn = sentryDSN;
+        options.sampleRate = 0.1;
+      },
+      appRunner: () => runApp(const ProviderScope(child: App())),
+    );
+  } else {
+    runApp(const ProviderScope(child: App()));
+  }
 }

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -368,6 +368,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.13.6"
   http_multi_server:
     dependency: transitive
     description:
@@ -480,6 +488,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  package_info_plus:
+    dependency: transitive
+    description:
+      name: package_info_plus
+      sha256: f62d7253edc197fe3c88d7c2ddab82d68f555e778d55390ccc3537eca8e8d637
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.3+1"
+  package_info_plus_linux:
+    dependency: transitive
+    description:
+      name: package_info_plus_linux
+      sha256: "04b575f44233d30edbb80a94e57cad9107aada334fc02aabb42b6becd13c43fc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
+  package_info_plus_macos:
+    dependency: transitive
+    description:
+      name: package_info_plus_macos
+      sha256: a2ad8b4acf4cd479d4a0afa5a74ea3f5b1c7563b77e52cc32b3ee6956d5482a6
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: f7a0c8f1e7e981bc65f8b64137a53fd3c195b18d429fba960babc59a5a1c7ae8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
+  package_info_plus_web:
+    dependency: transitive
+    description:
+      name: package_info_plus_web
+      sha256: f0829327eb534789e0a16ccac8936a80beed4e2401c4d3a74f3f39094a822d3b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.6"
+  package_info_plus_windows:
+    dependency: transitive
+    description:
+      name: package_info_plus_windows
+      sha256: "79524f11c42dd9078b96d797b3cf79c0a2883a50c4920dc43da8562c115089bc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   path:
     dependency: transitive
     description:
@@ -584,6 +640,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.6"
+  sentry:
+    dependency: transitive
+    description:
+      name: sentry
+      sha256: "377edcc3d7910745849b1621dcec7d34fc27b6c03e9e9009499dc2968ce19cd7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.0"
+  sentry_flutter:
+    dependency: "direct main"
+    description:
+      name: sentry_flutter
+      sha256: "03beda44836bd694493a915f57b9a9b1d222d1a5f6694735008c918ea3d81b9f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
   shelf:
     dependency: transitive
     description:
@@ -813,6 +885,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: a6f0236dbda0f63aa9a25ad1ff9a9d8a4eaaa5012da0dc59d21afdb1dc361ca4
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
   window_manager:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   dio: ^5.1.2
   flutter:
     sdk: flutter
+  sentry_flutter: 5.0.0
   flutter_riverpod: ^2.3.6
   freezed_annotation: ^2.2.0
   go_router: ^7.0.0

--- a/frontend/web/index.html
+++ b/frontend/web/index.html
@@ -35,6 +35,7 @@
   <script>
     // Actual URL is set at runtime with some nginx config level trickery.
     window.testObserverAPIBaseURI = 'http://api-placeholder:30000/';
+    window.sentryDSN = 'http://sentry-dsn-placeholder/';
   </script>
 
   <script>

--- a/terraform/test-observer.tf
+++ b/terraform/test-observer.tf
@@ -26,9 +26,14 @@ variable "external_ingress_hostname" {
 }
 
 locals {
-  sentry_dsn_map = {
+  sentry_dsn_api_map = {
     production  = "https://dd931d36e0c24681aaeed6abd312c896@sentry.is.canonical.com//66"
     staging     = "https://84a48d05b2444e47a7fa176b577bf85a@sentry.is.canonical.com//68",
+    development = ""
+  }
+  sentry_dsn_frontend_map = {
+    production  = "https://a9c1a8bf355d4ced94243e0ee1d73d06@sentry.is.canonical.com//69"
+    staging     = "https://34ece6e8dd51401fbf2a5d17f933e870@sentry.is.canonical.com//70",
     development = ""
   }
 }
@@ -77,7 +82,7 @@ resource "juju_application" "test-observer-api" {
   config = {
     hostname   = var.environment == "staging" ? "test-observer-api-staging.${var.external_ingress_hostname}" : "test-observer-api.${var.external_ingress_hostname}"
     port       = var.environment == "development" ? 30000 : 443
-    sentry_dsn = "${local.sentry_dsn_map[var.environment]}"
+    sentry_dsn = "${local.sentry_dsn_api_map[var.environment]}"
   }
 
   units = 1
@@ -96,6 +101,7 @@ resource "juju_application" "test-observer-frontend" {
   config = {
     hostname                 = var.environment == "staging" ? "test-observer-staging.${var.external_ingress_hostname}" : "test-observer.${var.external_ingress_hostname}"
     test-observer-api-scheme = var.environment == "development" ? "http://" : "https://"
+    sentry_dsn = "${local.sentry_dsn_frontend_map[var.environment]}"
   }
 
   units = 1


### PR DESCRIPTION
This PR resolves https://warthogs.atlassian.net/browse/RTW-133 and adds sentry reporting to TO frontend.

Since for our sentry instance (v9.2.1) there's no flutter or dart client, I've decided to use the oldest available `sentry_flutter` package that is also compatible with our flutter version. The client was configured according to this doc: https://pub.dev/packages/sentry_flutter/versions/5.0.0

Sentry projects were created for both [production](https://sentry.is.canonical.com/canonical/test-observer-frontend/) and [staging](https://sentry.is.canonical.com/canonical/test-observer-frontend-staging/) frontend instances.