### PR TITLE
Update upload-charm action to v2.4 to support node16 on github

### DIFF
--- a/.github/workflows/publish_api.yml
+++ b/.github/workflows/publish_api.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.2.0
+        uses: canonical/charming-actions/upload-charm@2.4.0
         with:
           charm-path: "backend/charm"
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"

--- a/.github/workflows/publish_frontend.yml
+++ b/.github/workflows/publish_frontend.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.2.0
+        uses: canonical/charming-actions/upload-charm@2.4.0
         with:
           charm-path: "frontend/charm"
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"


### PR DESCRIPTION
Github is deprecating node12 so apparently this is needed soon? now?