### PR TITLE
Fix/frontend api connection on dev

### DIFF
--- a/backend/skaffold.yaml
+++ b/backend/skaffold.yaml
@@ -1,7 +1,7 @@
 apiVersion: skaffold/v4beta4
 kind: Config
 metadata:
-  name: test-observer-frontend
+  name: test-observer-api
 build:
   artifacts:
     - image: localhost:32000/test-observer-api

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,5 @@
 FROM ubuntu:22.04 as builder
 
-ENV TEST_OBSERVER_API_BASE_URI=http://localhost:30000
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
 RUN apt-get install -y curl git wget unzip libgconf-2-4 gdb libstdc++6 libglu1-mesa fonts-droid-fallback lib32stdc++6 python3

--- a/frontend/charm/src/charm.py
+++ b/frontend/charm/src/charm.py
@@ -113,7 +113,7 @@ class TestObserverFrontendCharm(ops.CharmBase):
                 expires -1;
                 add_header Cache-Control "no-store, no-cache, must-revalidate, post-check=0, pre-check=0";
 
-                sub_filter 'http://api-placeholder:30000/' '{base_uri}';
+                sub_filter 'http://localhost:30000/' '{base_uri}';
                 sub_filter_once on;
             }}
 

--- a/frontend/lib/providers/dio.dart
+++ b/frontend/lib/providers/dio.dart
@@ -10,7 +10,7 @@ part 'dio.g.dart';
 
 @riverpod
 Dio dio(DioRef ref) {
-  final baseUrl = js_util.getProperty(window, 'testObserverAPIBaseURI');
-  final dio = Dio(BaseOptions(baseUrl: baseUrl ?? 'http://localhost:30000'));
+  final baseUrl = js_util.getProperty<String>(window, 'testObserverAPIBaseURI');
+  final dio = Dio(BaseOptions(baseUrl: baseUrl));
   return dio;
 }

--- a/frontend/web/index.html
+++ b/frontend/web/index.html
@@ -34,7 +34,7 @@
 
   <script>
     // Actual URL is set at runtime with some nginx config level trickery.
-    window.testObserverAPIBaseURI = 'http://api-placeholder:30000/';
+    window.testObserverAPIBaseURI = 'http://localhost:30000/';
   </script>
 
   <script>


### PR DESCRIPTION
It seems that front-end right now can't connect to back-end when running flutter normally outside of charms. This is because it depends on the charm's nginx swapping the place holder back-end url with the correct one. So this PR sets the placeholder url to be localhost so that if the url is not changed through the charm, it would work fine on development environment.