### PR TITLE
Fix frontend api request block due to mixed content

### DIFF
--- a/backend/test_observer/controllers/application/version.py
+++ b/backend/test_observer/controllers/application/version.py
@@ -1,10 +1,11 @@
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
+
 from fastapi import APIRouter
 
 router = APIRouter()
 
 
-@router.get("/")
+@router.get("")
 async def get_version():
     try:
         return {"version": version(__package__)}

--- a/backend/test_observer/controllers/artefacts/artefacts.py
+++ b/backend/test_observer/controllers/artefacts/artefacts.py
@@ -29,7 +29,7 @@ from .models import ArtefactBuildDTO, ArtefactDTO
 router = APIRouter()
 
 
-@router.get("/", response_model=list[ArtefactDTO])
+@router.get("", response_model=list[ArtefactDTO])
 def get_artefacts(family: FamilyName | None = None, db: Session = Depends(get_db)):
     """Get latest artefacts by family"""
     query = db.query(Stage)

--- a/backend/test_observer/main.py
+++ b/backend/test_observer/main.py
@@ -20,20 +20,25 @@
 
 import os
 
+import sentry_sdk
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-import sentry_sdk
-
 
 from test_observer.controllers.router import router
-
 
 SENTRY_DSN = os.getenv("SENTRY_DSN")
 if SENTRY_DSN:
     sentry_sdk.init(SENTRY_DSN)  # type: ignore
 
-
-app = FastAPI()
+app = FastAPI(
+    # Redirecting slashes can return a http schemed host when the request is https.
+    # A browser may block such a request means that the frontend loads without data.
+    # See https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content/How_to_fix_website_with_mixed_content
+    # By stopping redirects, the api will get a 404 if it doesn't use the exact path.
+    # This is useful to remind developers to use the exact path during development.
+    # To be a standard all paths should not end with a trailing slash.
+    redirect_slashes=False,
+)
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
Right now [TO staging fails to fetch data from API](https://test-observer-staging.canonical.com/#/snaps) because the API request is [blocked by the browser](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content/How_to_fix_website_with_mixed_content). After digging into what's going on, I found that frontend tries to request artefacts through the following url `https://test-observer-api-staging.canonical.com/v1/artefacts?family=snap`. The api then responds with a 307 redirect to `http://test-observer-api-staging.canonical.com/v1/artefacts/?family=snap` because fastapi redirects request to match trailing slash of endpoint. But the issue is that the redirect switches from https scheme to http. The browser detects this and blocks the request.

Note that this problem doesn't exist on local development because local development doesn't use a tls certificate. So all requests are http. Hence there is no mixed content shenanigans.