### PR TITLE
Moves to self-hosted runners

### DIFF
--- a/.github/workflows/frontend_charm_analysis.yml
+++ b/.github/workflows/frontend_charm_analysis.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   lint-report:
     name: Lint and format report
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, linux, large]
     steps:
       - uses: actions/checkout@v3
       - name: Install tox
@@ -23,7 +23,7 @@ jobs:
 
   static-analysis:
     name: Static analysis
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v3
       - name: Install tox
@@ -36,7 +36,7 @@ jobs:
 
   unit-tests-with-coverage:
     name: Unit tests
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v3
       - name: Install tox

--- a/.github/workflows/frontend_charm_integration_tests.yml
+++ b/.github/workflows/frontend_charm_integration_tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   integration-test:
     name: Integration tests
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, linux, large]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/publish_api.yml
+++ b/.github/workflows/publish_api.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish_frontend.yml
+++ b/.github/workflows/publish_frontend.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   build-and-push-frontend-image:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -6,7 +6,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, large]
     defaults:
       run:
         working-directory: backend

--- a/.github/workflows/test_frontend.yml
+++ b/.github/workflows/test_frontend.yml
@@ -6,7 +6,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, large]
     defaults:
       run:
         working-directory: frontend


### PR DESCRIPTION
Moves from GitHub hosted runners to self-hosted runners.

As you can see, the changes in the repo are straightforward. The "large" runners are faster than GitHub hosted runners (2x to 3x faster juju & microk8s bootstrap time in the case of the integration tests I reopened efforts on in a different branch). I intentionally did not specify the `large` where I thought we don't require it (and builds indeed seem to pass happily), since we get workers then assigned from a larger pool.

To get the repo working with these runners requires the repository to conform to these rules: https://github.com/canonical/repo-policy-compliance -- the thing that might bite at first is [signed commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) being required for all the commits from the point this is merged (but there are at least no open PRs at the moment, so strikes as a good time to introduce this).