### PR TITLE
Fix/ci missing docker buildx

### DIFF
--- a/.github/workflows/publish_api.yml
+++ b/.github/workflows/publish_api.yml
@@ -17,6 +17,9 @@ jobs:
       IMAGE_NAME: ${{ github.repository }}/api
 
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Checkout repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/publish_api.yml
+++ b/.github/workflows/publish_api.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "fix/ci-missing-docker-buildx 4fd233f"]
     tags: ["v*.*.*"]
 
 env:

--- a/.github/workflows/publish_frontend.yml
+++ b/.github/workflows/publish_frontend.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "fix/ci-missing-docker-buildx 4fd233f"]
     tags: ["v*.*.*"]
 
 env:

--- a/.github/workflows/publish_frontend.yml
+++ b/.github/workflows/publish_frontend.yml
@@ -17,6 +17,9 @@ jobs:
       IMAGE_NAME: ${{ github.repository }}/frontend
 
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Checkout repository
         uses: actions/checkout@v3
 


### PR DESCRIPTION
It seems that self hosted runners do not include `buildx` unlike GH runners, so docker build phase is failing on both [api](https://github.com/canonical/test_observer/actions/runs/6671002387/job/18132005227) and [frontend](https://github.com/canonical/test_observer/actions/runs/6671002401/job/18132005236). This PR hopefully fixes that. But I wasn't able to test it, as the usual hack of running actions on none main branch doesn't work anymore due to [repo-policy-compliance](https://github.com/canonical/repo-policy-compliance) requiring CI to only run on protected branches.