### PR TITLE
Fix publish api and frontend GitHub workflows

### DIFF
--- a/.github/workflows/publish_api.yml
+++ b/.github/workflows/publish_api.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, large]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish_api.yml
+++ b/.github/workflows/publish_api.yml
@@ -17,6 +17,9 @@ jobs:
       IMAGE_NAME: ${{ github.repository }}/api
 
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Checkout repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/publish_api.yml
+++ b/.github/workflows/publish_api.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "fix/ci-missing-docker-buildx 4fd233f"]
     tags: ["v*.*.*"]
 
 env:

--- a/.github/workflows/publish_api.yml
+++ b/.github/workflows/publish_api.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: ["main", "fix-ci-missing-docker-buildx"]
+    branches: ["main"]
     tags: ["v*.*.*"]
 
 env:

--- a/.github/workflows/publish_api.yml
+++ b/.github/workflows/publish_api.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: ["main", "fix/ci-missing-docker-buildx 4fd233f"]
+    branches: ["main", "fix-ci-missing-docker-buildx"]
     tags: ["v*.*.*"]
 
 env:

--- a/.github/workflows/publish_api.yml
+++ b/.github/workflows/publish_api.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: [self-hosted, linux, large]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish_frontend.yml
+++ b/.github/workflows/publish_frontend.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   build-and-push-frontend-image:
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, large]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish_frontend.yml
+++ b/.github/workflows/publish_frontend.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "fix/ci-missing-docker-buildx 4fd233f"]
     tags: ["v*.*.*"]
 
 env:

--- a/.github/workflows/publish_frontend.yml
+++ b/.github/workflows/publish_frontend.yml
@@ -17,6 +17,9 @@ jobs:
       IMAGE_NAME: ${{ github.repository }}/frontend
 
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Checkout repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/publish_frontend.yml
+++ b/.github/workflows/publish_frontend.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: ["main", "fix-ci-missing-docker-buildx"]
+    branches: ["main"]
     tags: ["v*.*.*"]
 
 env:

--- a/.github/workflows/publish_frontend.yml
+++ b/.github/workflows/publish_frontend.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   build-and-push-frontend-image:
-    runs-on: [self-hosted, linux, large]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish_frontend.yml
+++ b/.github/workflows/publish_frontend.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: ["main", "fix/ci-missing-docker-buildx 4fd233f"]
+    branches: ["main", "fix-ci-missing-docker-buildx"]
     tags: ["v*.*.*"]
 
 env:


### PR DESCRIPTION
The GitHub workflows that build and publish OCI images and charms started failing after switching to self hosted runners. Initially, the errors were about [missing `buildx`](https://github.com/canonical/test_observer/actions/runs/6671002387/job/18132005227#step:6:124). After fixing that, another error occurred where [pulling OCI base images would timeout](https://github.com/canonical/test_observer/actions/runs/6705133395/job/18218953128#step:7:152). I posted a [question on mattermost](https://chat.canonical.com/canonical/pl/arxnjqqh1tr58mwc5qwbkuu14w) but got no response so far. Since I don't want this to be a blocker right now, I decided to switch back to none self hosted runners.