### PR TITLE
Better show migrations error log

### DIFF
--- a/backend/charm/src/charm.py
+++ b/backend/charm/src/charm.py
@@ -2,8 +2,6 @@
 
 import logging
 
-from ops import BlockedStatus
-
 from charms.data_platform_libs.v0.data_interfaces import (
     DatabaseRequires,
     RelationChangedEvent,
@@ -12,7 +10,7 @@ from charms.data_platform_libs.v0.data_interfaces import (
 from charms.nginx_ingress_integrator.v0.nginx_route import require_nginx_route
 from ops.charm import CharmBase
 from ops.main import main
-from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.pebble import Layer, ExecError
 from requests import get
 

--- a/backend/charm/src/charm.py
+++ b/backend/charm/src/charm.py
@@ -2,6 +2,8 @@
 
 import logging
 
+from ops import BlockedStatus
+
 from charms.data_platform_libs.v0.data_interfaces import (
     DatabaseRequires,
     RelationChangedEvent,
@@ -11,7 +13,7 @@ from charms.nginx_ingress_integrator.v0.nginx_route import require_nginx_route
 from ops.charm import CharmBase
 from ops.main import main
 from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
-from ops.pebble import Layer
+from ops.pebble import Layer, ExecError
 from requests import get
 
 # Log messages can be retrieved using juju debug-log
@@ -80,11 +82,14 @@ class TestObserverBackendCharm(CharmBase):
             environment=self._postgres_relation_data(),
         )
 
-        stdout, _ = process.wait_output()
-
-        logger.info(stdout)
-
-        self.unit.status = ActiveStatus()
+        try:
+            stdout, _ = process.wait_output()
+            logger.info(stdout)
+            self.unit.status = ActiveStatus()
+        except ExecError as e:
+            logger.error(e.stdout)
+            logger.error(e.stderr)
+            self.unit.status = BlockedStatus("Database migration failed")
 
     def _on_database_changed(self, event):
         self._migrate_database()
@@ -134,9 +139,7 @@ class TestObserverBackendCharm(CharmBase):
         """
         This creates a dictionary of environment variables needed by the application
         """
-        env = {
-            "SENTRY_DSN": self.config["sentry_dsn"]
-        }
+        env = {"SENTRY_DSN": self.config["sentry_dsn"]}
         env.update(self._postgres_relation_data())
         return env
 


### PR DESCRIPTION
Right now database migrations have failed on test observer staging. But the logs are truncated and don't show everything. Hopefully, this change will show the full logs when migrations fail again.