### PR TITLE
Fix ORM model and add alembic check

### DIFF
--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -33,11 +33,11 @@ jobs:
         with:
           poetry-version: "1.5.1"
       - run: poetry install
-      - run: poetry run black --check test_observer tests migrations scripts
-      - run: poetry run ruff test_observer tests migrations scripts
-      - run: poetry run mypy --explicit-package-bases test_observer tests migrations scripts
-      - run: poetry run pytest
-      - run: poetry run alembic upgrade head
+      # - run: poetry run black --check test_observer tests migrations scripts
+      # - run: poetry run ruff test_observer tests migrations scripts
+      # - run: poetry run mypy --explicit-package-bases test_observer tests migrations scripts
+      # - run: poetry run pytest
+      - run: alembic upgrade head
       - name: Check if alembic migrations are up to date
         run: poetry run alembic check
         env:

--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -6,6 +6,8 @@ concurrency:
   cancel-in-progress: true
 jobs:
   test:
+    env:
+      TEST_DB_URL: postgresql+pg8000://postgres:password@localhost:5432/postgres
     runs-on: [self-hosted, linux, large]
     defaults:
       run:
@@ -35,5 +37,6 @@ jobs:
       - run: poetry run ruff test_observer tests migrations scripts
       - run: poetry run mypy --explicit-package-bases test_observer tests migrations scripts
       - run: poetry run pytest
-        env:
-          TEST_DB_URL: postgresql+pg8000://postgres:password@localhost:5432/postgres
+      - run: poetry run alembic upgrade head
+      - name: Check if alembic migrations are up to date
+        run: poetry run alembic check

--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -33,10 +33,10 @@ jobs:
       - run: poetry install
         env:
           TEST_DB_URL: postgresql+pg8000://postgres:password@localhost:5432/postgres
-      # - run: poetry run black --check test_observer tests migrations scripts
-      # - run: poetry run ruff test_observer tests migrations scripts
-      # - run: poetry run mypy --explicit-package-bases test_observer tests migrations scripts
-      # - run: poetry run pytest
+      - run: poetry run black --check test_observer tests migrations scripts
+      - run: poetry run ruff test_observer tests migrations scripts
+      - run: poetry run mypy --explicit-package-bases test_observer tests migrations scripts
+      - run: poetry run pytest
       - run: poetry run alembic upgrade head
         env:
           DB_URL: postgresql+pg8000://postgres:password@localhost:5432/postgres

--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -40,3 +40,5 @@ jobs:
       - run: poetry run alembic upgrade head
       - name: Check if alembic migrations are up to date
         run: poetry run alembic check
+        env:
+          TEST_DB_URL: postgresql+pg8000://postgres:password@localhost:5432/postgres

--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -31,12 +31,12 @@ jobs:
         with:
           poetry-version: "1.5.1"
       - run: poetry install
-        env:
-          TEST_DB_URL: postgresql+pg8000://postgres:password@localhost:5432/postgres
       - run: poetry run black --check test_observer tests migrations scripts
       - run: poetry run ruff test_observer tests migrations scripts
       - run: poetry run mypy --explicit-package-bases test_observer tests migrations scripts
       - run: poetry run pytest
+        env:
+          TEST_DB_URL: postgresql+pg8000://postgres:password@localhost:5432/postgres
       - run: poetry run alembic upgrade head
         env:
           DB_URL: postgresql+pg8000://postgres:password@localhost:5432/postgres

--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -6,8 +6,6 @@ concurrency:
   cancel-in-progress: true
 jobs:
   test:
-    env:
-      TEST_DB_URL: postgresql+pg8000://postgres:password@localhost:5432/postgres
     runs-on: [self-hosted, linux, large]
     defaults:
       run:
@@ -33,12 +31,16 @@ jobs:
         with:
           poetry-version: "1.5.1"
       - run: poetry install
+        env:
+          TEST_DB_URL: postgresql+pg8000://postgres:password@localhost:5432/postgres
       # - run: poetry run black --check test_observer tests migrations scripts
       # - run: poetry run ruff test_observer tests migrations scripts
       # - run: poetry run mypy --explicit-package-bases test_observer tests migrations scripts
       # - run: poetry run pytest
-      - run: alembic upgrade head
+      - run: poetry run alembic upgrade head
+        env:
+          DB_URL: postgresql+pg8000://postgres:password@localhost:5432/postgres
       - name: Check if alembic migrations are up to date
         run: poetry run alembic check
         env:
-          TEST_DB_URL: postgresql+pg8000://postgres:password@localhost:5432/postgres
+          DB_URL: postgresql+pg8000://postgres:password@localhost:5432/postgres

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -109,9 +109,8 @@ class Artefact(Base):
     status: Mapped[ArtefactStatus | None]
 
     __table_args__ = (
-        UniqueConstraint(
-            "name", "version", "track", "series", "repo", name="unique_artefact"
-        ),
+        UniqueConstraint("name", "version", "track", name="unique_snap"),
+        UniqueConstraint("name", "version", "series", "repo", name="unique_deb"),
     )
 
     def __repr__(self) -> str:


### PR DESCRIPTION
It seems that I had modified Artefacts table through a migration, but forgot to make the same change on the ORM. The specific change was creating two uniqueness constraints one for snaps and another for debs, as they can't be grouped into one. I detect this issue when I tried to generate a migration automatically through alembic. To prevent this issue from happening again, I added a CI check that will fail if alembic detects a difference between ORM models and what the migrations actually do.