### PR TITLE
Enable publishing the images with self hosted runners again

### DIFF
--- a/.github/workflows/publish_api.yml
+++ b/.github/workflows/publish_api.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "publish-images-with-self-hosted-runner"]
     tags: ["v*.*.*"]
 
 env:
@@ -8,7 +8,7 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, large]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish_frontend.yml
+++ b/.github/workflows/publish_frontend.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "publish-images-with-self-hosted-runner"]
     tags: ["v*.*.*"]
 
 env:
@@ -8,7 +8,7 @@ env:
 
 jobs:
   build-and-push-frontend-image:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, large]
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
This re-introduces the self hosted runners, since after a discussion with @jdkandersson I was left with the impression that the self hosted runners _should_ be able to reach ghcr.io through the firewall (the actual issue we look to be hitting does not get us as far as attempting to connect to ghcr.io since the base image is actually coming from docker.io).

Corresponding Mattermost thread tracking the problem:
https://chat.canonical.com/canonical/pl/jz5ds1ko5pboirjau9dp5pdado