### PR TITLE
Remove sys.exit() that breaks the promote endpoint

### DIFF
--- a/backend/test_observer/controllers/promoter/promoter.py
+++ b/backend/test_observer/controllers/promoter/promoter.py
@@ -73,7 +73,10 @@ def promote_artefacts(db: Session = Depends(get_db)):
                 status_code=500,
                 content={
                     artefact_key: processed_artefacts_error_messages[artefact_key]
-                    for artefact_key, artefact_status in processed_artefacts_status.items()
+                    for (
+                        artefact_key,
+                        artefact_status,
+                    ) in processed_artefacts_status.items()
                     if artefact_status is False
                 },
             )

--- a/backend/test_observer/external_apis/snapcraft.py
+++ b/backend/test_observer/external_apis/snapcraft.py
@@ -30,7 +30,6 @@ def get_channel_map_from_snapcraft(arch: str, snapstore: str, snap_name: str):
     json_resp = req.json()
     if not req.ok:
         logger.error(json_resp["error-list"][0]["message"])
-        sys.exit(1)
 
     snap_info = SnapInfo(**rename_keys(json_resp))
     return snap_info.channel_map

--- a/backend/test_observer/external_apis/snapcraft.py
+++ b/backend/test_observer/external_apis/snapcraft.py
@@ -29,6 +29,7 @@ def get_channel_map_from_snapcraft(arch: str, snapstore: str, snap_name: str):
     json_resp = req.json()
     if not req.ok:
         logger.error(json_resp["error-list"][0]["message"])
+        req.raise_for_status()
 
     snap_info = SnapInfo(**rename_keys(json_resp))
     return snap_info.channel_map

--- a/backend/test_observer/external_apis/snapcraft.py
+++ b/backend/test_observer/external_apis/snapcraft.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 import requests
 


### PR DESCRIPTION
This PR should fix the issue with artefacts not being promoted on the Test Observer boards.

The issue with it was the command `sys.exit()` which doesn't get caught as an exception and causes Internal Server Error which couldn't be handled. 

The snap that caused this was "cascade-configuration" which cannot be found on the channel '16'.

## Test

Two screenshots of the boards (one before the fix, one after the fix). We can notice two snaps are now in the stable board

![Screenshot from 2023-12-01 11-00-00](https://github.com/canonical/test_observer/assets/33193463/0a6d1df5-696b-4090-8534-fb739cc8c2b5)
![Screenshot from 2023-12-01 11-00-15](https://github.com/canonical/test_observer/assets/33193463/6707027a-d883-4a4a-9308-d598082c3f3f)
