### PR TITLE
Receive ci link at start test & rename jenkins to ci

### DIFF
--- a/backend/migrations/versions/2023_12_01_0949-8d8643821588_rename_jenkins_link_to_ci_link.py
+++ b/backend/migrations/versions/2023_12_01_0949-8d8643821588_rename_jenkins_link_to_ci_link.py
@@ -1,0 +1,22 @@
+"""Rename jenkins_link to ci_link
+
+Revision ID: 8d8643821588
+Revises: 49221114815a
+Create Date: 2023-12-01 09:49:44.849714+00:00
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "8d8643821588"
+down_revision = "49221114815a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("test_execution", "jenkins_link", new_column_name="ci_link")
+
+
+def downgrade() -> None:
+    op.alter_column("test_execution", "ci_link", new_column_name="jenkins_link")

--- a/backend/scripts/seed_data.py
+++ b/backend/scripts/seed_data.py
@@ -18,6 +18,7 @@ REQUESTS = [
         arch="armhf",
         execution_stage="beta",
         environment="rpi2",
+        ci_link="http://localhost",
     ),
     StartTestExecutionRequest(
         family=FamilyName.SNAP,
@@ -29,6 +30,7 @@ REQUESTS = [
         arch="armhf",
         execution_stage="beta",
         environment="rpi2",
+        ci_link="http://localhost",
     ),
     StartTestExecutionRequest(
         family=FamilyName.SNAP,
@@ -40,6 +42,7 @@ REQUESTS = [
         arch="armhf",
         execution_stage="beta",
         environment="rpi2",
+        ci_link="http://localhost",
     ),
     StartTestExecutionRequest(
         family=FamilyName.SNAP,
@@ -51,6 +54,7 @@ REQUESTS = [
         arch="amd64",
         execution_stage="edge",
         environment="dawson-i",
+        ci_link="http://localhost",
     ),
     StartTestExecutionRequest(
         family=FamilyName.SNAP,
@@ -62,6 +66,7 @@ REQUESTS = [
         arch="arm64",
         execution_stage="candidate",
         environment="cm3",
+        ci_link="http://localhost",
     ),
     StartTestExecutionRequest(
         family=FamilyName.SNAP,
@@ -73,6 +78,7 @@ REQUESTS = [
         arch="arm64",
         execution_stage="stable",
         environment="cm3",
+        ci_link="http://localhost",
     ),
     StartTestExecutionRequest(
         family=FamilyName.SNAP,
@@ -84,6 +90,7 @@ REQUESTS = [
         arch="arm64",
         execution_stage="stable",
         environment="dragonboard",
+        ci_link="http://localhost",
     ),
     StartTestExecutionRequest(
         family=FamilyName.DEB,
@@ -94,6 +101,7 @@ REQUESTS = [
         arch="arm64",
         execution_stage="proposed",
         environment="rpi400",
+        ci_link="http://localhost",
     ),
     StartTestExecutionRequest(
         family=FamilyName.DEB,
@@ -104,6 +112,7 @@ REQUESTS = [
         arch="arm64",
         execution_stage="updates",
         environment="rpi400",
+        ci_link="http://localhost",
     ),
 ]
 
@@ -111,7 +120,7 @@ REQUESTS = [
 def seed_data(client: TestClient | requests.Session):
     for request in REQUESTS:
         client.put(
-            START_TEST_EXECUTION_URL, json=request.model_dump()
+            START_TEST_EXECUTION_URL, data=request.model_dump_json()
         ).raise_for_status()
 
 

--- a/backend/scripts/seed_data.py
+++ b/backend/scripts/seed_data.py
@@ -120,7 +120,7 @@ REQUESTS = [
 def seed_data(client: TestClient | requests.Session):
     for request in REQUESTS:
         client.put(
-            START_TEST_EXECUTION_URL, data=request.model_dump_json()
+            START_TEST_EXECUTION_URL, json=request.model_dump(mode="json")
         ).raise_for_status()
 
 

--- a/backend/test_observer/controllers/artefacts/models.py
+++ b/backend/test_observer/controllers/artefacts/models.py
@@ -47,7 +47,7 @@ class TestExecutionDTO(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
-    jenkins_link: str | None
+    ci_link: str | None
     c3_link: str | None
     environment: EnvironmentDTO
     status: TestExecutionStatus

--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -18,7 +18,7 @@
 #        Omar Selo <omar.selo@canonical.com>
 
 
-from pydantic import BaseModel, field_serializer, model_validator
+from pydantic import BaseModel, HttpUrl, field_serializer, model_validator
 
 from test_observer.data_access.models_enums import FamilyName, TestExecutionStatus
 
@@ -35,6 +35,7 @@ class StartTestExecutionRequest(BaseModel):
     arch: str
     execution_stage: str
     environment: str
+    ci_link: HttpUrl
 
     @field_serializer("family")
     def serialize_dt(self, family: FamilyName):

--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -57,6 +57,6 @@ class StartTestExecutionRequest(BaseModel):
 
 
 class TestExecutionsPatchRequest(BaseModel):
-    c3_link: str
-    jenkins_link: str
-    status: TestExecutionStatus
+    c3_link: HttpUrl | None
+    ci_link: HttpUrl | None
+    status: TestExecutionStatus | None

--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -18,6 +18,8 @@
 #        Omar Selo <omar.selo@canonical.com>
 
 
+from typing import Annotated
+
 from pydantic import BaseModel, HttpUrl, field_serializer, model_validator
 
 from test_observer.data_access.models_enums import FamilyName, TestExecutionStatus
@@ -35,7 +37,7 @@ class StartTestExecutionRequest(BaseModel):
     arch: str
     execution_stage: str
     environment: str
-    ci_link: HttpUrl
+    ci_link: Annotated[str, HttpUrl]
 
     @field_serializer("family")
     def serialize_dt(self, family: FamilyName):

--- a/backend/test_observer/controllers/test_executions/test_executions.py
+++ b/backend/test_observer/controllers/test_executions/test_executions.py
@@ -105,8 +105,18 @@ def patch_test_execution(
     request: TestExecutionsPatchRequest,
     db: Session = Depends(get_db),
 ):
-    test_execution = db.query(TestExecution).filter(TestExecution.id == id).one()
-    test_execution.c3_link = request.c3_link
-    test_execution.ci_link = request.ci_link
-    test_execution.status = request.status
+    test_execution = db.get(TestExecution, id)
+
+    if test_execution is None:
+        raise HTTPException(status_code=404, detail="TestExecution not found")
+
+    if request.c3_link is not None:
+        test_execution.c3_link = str(request.c3_link)
+
+    if request.ci_link is not None:
+        test_execution.ci_link = str(request.ci_link)
+
+    if request.status is not None:
+        test_execution.status = request.status
+
     db.commit()

--- a/backend/test_observer/controllers/test_executions/test_executions.py
+++ b/backend/test_observer/controllers/test_executions/test_executions.py
@@ -91,6 +91,7 @@ def start_test_execution(
             },
             creation_kwargs={
                 "status": TestExecutionStatus.IN_PROGRESS,
+                "ci_link": request.ci_link,
             },
         )
         return {"id": test_execution.id}

--- a/backend/test_observer/controllers/test_executions/test_executions.py
+++ b/backend/test_observer/controllers/test_executions/test_executions.py
@@ -107,6 +107,6 @@ def patch_test_execution(
 ):
     test_execution = db.query(TestExecution).filter(TestExecution.id == id).one()
     test_execution.c3_link = request.c3_link
-    test_execution.ci_link = request.jenkins_link
+    test_execution.ci_link = request.ci_link
     test_execution.status = request.status
     db.commit()

--- a/backend/test_observer/controllers/test_executions/test_executions.py
+++ b/backend/test_observer/controllers/test_executions/test_executions.py
@@ -106,6 +106,6 @@ def patch_test_execution(
 ):
     test_execution = db.query(TestExecution).filter(TestExecution.id == id).one()
     test_execution.c3_link = request.c3_link
-    test_execution.jenkins_link = request.jenkins_link
+    test_execution.ci_link = request.jenkins_link
     test_execution.status = request.status
     db.commit()

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -198,7 +198,7 @@ class TestExecution(Base):
 
     __tablename__ = "test_execution"
 
-    jenkins_link: Mapped[str] = mapped_column(String(200), nullable=True)
+    ci_link: Mapped[str] = mapped_column(String(200), nullable=True)
     c3_link: Mapped[str] = mapped_column(String(200), nullable=True)
     # Relationships
     artefact_build_id: Mapped[int] = mapped_column(
@@ -222,6 +222,6 @@ class TestExecution(Base):
             "artefact_build_id",
             "environment_id",
             "status",
-            "jenkins_link",
+            "ci_link",
             "c3_link",
         )

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -198,8 +198,8 @@ class TestExecution(Base):
 
     __tablename__ = "test_execution"
 
-    ci_link: Mapped[str] = mapped_column(String(200), nullable=True)
-    c3_link: Mapped[str] = mapped_column(String(200), nullable=True)
+    ci_link: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    c3_link: Mapped[str | None] = mapped_column(String(200), nullable=True)
     # Relationships
     artefact_build_id: Mapped[int] = mapped_column(
         ForeignKey("artefact_build.id", ondelete="CASCADE")

--- a/backend/tests/controllers/artefacts/test_artefacts.py
+++ b/backend/tests/controllers/artefacts/test_artefacts.py
@@ -94,7 +94,7 @@ def test_get_artefact_builds(db_session: Session, test_client: TestClient):
             "test_executions": [
                 {
                     "id": test_execution.id,
-                    "jenkins_link": test_execution.jenkins_link,
+                    "ci_link": test_execution.ci_link,
                     "c3_link": test_execution.c3_link,
                     "status": test_execution.status.value,
                     "environment": {

--- a/backend/tests/controllers/test_executions/test_test_executions.py
+++ b/backend/tests/controllers/test_executions/test_test_executions.py
@@ -154,7 +154,7 @@ def test_uses_existing_models(db_session: Session, test_client: TestClient):
 
     test_execution_id = test_client.put(
         "/v1/test-executions/start-test",
-        data=request.model_dump_json(),
+        json=request.model_dump(mode="json"),
     ).json()["id"]
 
     test_execution = (

--- a/backend/tests/controllers/test_executions/test_test_executions.py
+++ b/backend/tests/controllers/test_executions/test_test_executions.py
@@ -187,6 +187,6 @@ def test_updates_test_execution(db_session: Session, test_client: TestClient):
     )
 
     db_session.refresh(test_execution)
-    assert test_execution.jenkins_link == "some jenkins link"
+    assert test_execution.ci_link == "some jenkins link"
     assert test_execution.c3_link == "some c3 link"
     assert test_execution.status == TestExecutionStatus.PASSED

--- a/backend/tests/controllers/test_executions/test_test_executions.py
+++ b/backend/tests/controllers/test_executions/test_test_executions.py
@@ -184,13 +184,13 @@ def test_updates_test_execution(db_session: Session, test_client: TestClient):
     test_client.patch(
         f"/v1/test-executions/{test_execution.id}",
         json={
-            "jenkins_link": "some jenkins link",
-            "c3_link": "some c3 link",
+            "ci_link": "http://ci_link/",
+            "c3_link": "http://c3_link/",
             "status": TestExecutionStatus.PASSED.name,
         },
     )
 
     db_session.refresh(test_execution)
-    assert test_execution.ci_link == "some jenkins link"
-    assert test_execution.c3_link == "some c3 link"
+    assert test_execution.ci_link == "http://ci_link/"
+    assert test_execution.c3_link == "http://c3_link/"
     assert test_execution.status == TestExecutionStatus.PASSED

--- a/backend/tests/controllers/test_executions/test_test_executions.py
+++ b/backend/tests/controllers/test_executions/test_test_executions.py
@@ -46,6 +46,7 @@ def test_creates_all_data_models(db_session: Session, test_client: TestClient):
             "arch": "arm64",
             "execution_stage": "beta",
             "environment": "cm3",
+            "ci_link": "http://localhost",
         },
     )
 
@@ -109,6 +110,7 @@ def test_invalid_artefact_format(test_client: TestClient):
             "arch": "arm64",
             "execution_stage": "beta",
             "environment": "cm3",
+            "ci_link": "http://localhost",
         },
     )
     assert response.status_code == 422
@@ -125,6 +127,7 @@ def test_uses_existing_models(db_session: Session, test_client: TestClient):
         arch="arm64",
         execution_stage="beta",
         environment="cm3",
+        ci_link="http://localhost/",
     )
     stage = (
         db_session.query(Stage).filter(Stage.name == request.execution_stage).first()
@@ -151,7 +154,7 @@ def test_uses_existing_models(db_session: Session, test_client: TestClient):
 
     test_execution_id = test_client.put(
         "/v1/test-executions/start-test",
-        json=request.model_dump(),
+        data=request.model_dump_json(),
     ).json()["id"]
 
     test_execution = (
@@ -163,6 +166,7 @@ def test_uses_existing_models(db_session: Session, test_client: TestClient):
     assert test_execution.artefact_build_id == artefact_build.id
     assert test_execution.environment_id == environment.id
     assert test_execution.status == TestExecutionStatus.IN_PROGRESS
+    assert test_execution.ci_link == "http://localhost/"
 
 
 def test_updates_test_execution(db_session: Session, test_client: TestClient):

--- a/frontend/lib/models/test_execution.dart
+++ b/frontend/lib/models/test_execution.dart
@@ -12,7 +12,7 @@ part 'test_execution.g.dart';
 class TestExecution with _$TestExecution {
   const factory TestExecution({
     required int id,
-    @JsonKey(name: 'jenkins_link') required String? jenkinsLink,
+    @JsonKey(name: 'ci_link') required String? ciLink,
     @JsonKey(name: 'c3_link') required String? c3Link,
     required TestExecutionStatus status,
     required Environment environment,

--- a/frontend/lib/ui/dashboard/artefact_dialog.dart
+++ b/frontend/lib/ui/dashboard/artefact_dialog.dart
@@ -271,7 +271,7 @@ class _TestExecutionView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final jenkinsLink = testExecution.jenkinsLink;
+    final ciLink = testExecution.ciLink;
     final c3Link = testExecution.c3Link;
 
     return YaruExpandable(
@@ -286,10 +286,10 @@ class _TestExecutionView extends StatelessWidget {
           const Spacer(),
           Row(
             children: [
-              if (jenkinsLink != null)
+              if (ciLink != null)
                 InlineUrlText(
-                  url: jenkinsLink,
-                  urlText: 'Jenkins',
+                  url: ciLink,
+                  urlText: 'CI',
                 ),
               const SizedBox(width: Spacing.level3),
               if (c3Link != null)


### PR DESCRIPTION
Resolves [RTW-149](https://warthogs.atlassian.net/browse/RTW-194)

Changes include:
- Renaming jenkins link to ci link everywhere
- Taking ci link at the start of test execution
- Making test execution patch request parameters optional so that it's more flexible

[RTW-149]: https://warthogs.atlassian.net/browse/RTW-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ