### PR TITLE
Set naming conventions for database constraints

### DIFF
--- a/backend/migrations/versions/2023_12_05_0951-808f2035f714_add_naming_conventions.py
+++ b/backend/migrations/versions/2023_12_05_0951-808f2035f714_add_naming_conventions.py
@@ -1,0 +1,58 @@
+"""Add naming conventions
+
+Revision ID: 808f2035f714
+Revises: 8317277d4333
+Create Date: 2023-12-05 09:51:28.009193+00:00
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "808f2035f714"
+down_revision = "8317277d4333"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_index("ix_artefact_name", table_name="artefact")
+    op.create_index(op.f("artefact_name_ix"), "artefact", ["name"], unique=False)
+    op.drop_index("ix_artefact_build_architecture", table_name="artefact_build")
+    op.create_index(
+        op.f("artefact_build_architecture_ix"),
+        "artefact_build",
+        ["architecture"],
+        unique=False,
+    )
+    op.drop_constraint("unique_environment", "environment", type_="unique")
+    op.create_unique_constraint(
+        op.f("environment_name_architecture_key"),
+        "environment",
+        ["name", "architecture"],
+    )
+    op.drop_index("ix_family_name", table_name="family")
+    op.create_index(op.f("family_name_ix"), "family", ["name"], unique=True)
+    op.drop_index("ix_stage_name", table_name="stage")
+    op.create_index(op.f("stage_name_ix"), "stage", ["name"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("stage_name_ix"), table_name="stage")
+    op.create_index("ix_stage_name", "stage", ["name"], unique=False)
+    op.drop_index(op.f("family_name_ix"), table_name="family")
+    op.create_index("ix_family_name", "family", ["name"], unique=False)
+    op.drop_constraint(
+        op.f("environment_name_architecture_key"), "environment", type_="unique"
+    )
+    op.create_unique_constraint(
+        "unique_environment", "environment", ["name", "architecture"]
+    )
+    op.drop_index(op.f("artefact_build_architecture_ix"), table_name="artefact_build")
+    op.create_index(
+        "ix_artefact_build_architecture",
+        "artefact_build",
+        ["architecture"],
+        unique=False,
+    )
+    op.drop_index(op.f("artefact_name_ix"), table_name="artefact")
+    op.create_index("ix_artefact_name", "artefact", ["name"], unique=False)

--- a/backend/migrations/versions/2023_12_05_1000-f59da052cbac_rename_unconventional_index_names.py
+++ b/backend/migrations/versions/2023_12_05_1000-f59da052cbac_rename_unconventional_index_names.py
@@ -1,0 +1,69 @@
+"""Rename unconventional index names
+
+Revision ID: f59da052cbac
+Revises: 808f2035f714
+Create Date: 2023-12-05 10:00:21.171939+00:00
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f59da052cbac"
+down_revision = "808f2035f714"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_index(
+        "idx_artefact_id_architecture_null_revision",
+        table_name="artefact_build",
+        postgresql_where="(revision IS NULL)",
+    )
+    op.drop_index(
+        "idx_artefact_id_architecture_revision",
+        table_name="artefact_build",
+        postgresql_where="(revision IS NOT NULL)",
+    )
+    op.create_index(
+        op.f("artefact_build_artefact_id_architecture_ix"),
+        "artefact_build",
+        ["artefact_id", "architecture"],
+        unique=True,
+        postgresql_where=sa.text("revision IS NULL"),
+    )
+    op.create_index(
+        op.f("artefact_build_artefact_id_architecture_revision_ix"),
+        "artefact_build",
+        ["artefact_id", "architecture", "revision"],
+        unique=True,
+        postgresql_where=sa.text("revision IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("artefact_build_artefact_id_architecture_revision_ix"),
+        table_name="artefact_build",
+        postgresql_where=sa.text("revision IS NOT NULL"),
+    )
+    op.drop_index(
+        op.f("artefact_build_artefact_id_architecture_ix"),
+        table_name="artefact_build",
+        postgresql_where=sa.text("revision IS NULL"),
+    )
+    op.create_index(
+        "idx_artefact_id_architecture_revision",
+        "artefact_build",
+        ["artefact_id", "architecture", "revision"],
+        unique=False,
+        postgresql_where="(revision IS NOT NULL)",
+    )
+    op.create_index(
+        "idx_artefact_id_architecture_null_revision",
+        "artefact_build",
+        ["artefact_id", "architecture"],
+        unique=False,
+        postgresql_where="(revision IS NULL)",
+    )

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -20,7 +20,7 @@
 from datetime import date, datetime
 from typing import TypeVar
 
-from sqlalchemy import ForeignKey, Index, String, UniqueConstraint, column
+from sqlalchemy import ForeignKey, Index, MetaData, String, UniqueConstraint, column
 from sqlalchemy.orm import (
     DeclarativeBase,
     Mapped,
@@ -42,6 +42,18 @@ class Base(DeclarativeBase):
     created_at: Mapped[datetime] = mapped_column(default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
         default=func.now(), onupdate=func.now()
+    )
+
+    metadata = MetaData(
+        # Use a naming convention so that alembic knows the name of constraints
+        # Use PostgreSQL specific conventions cause we already have keys named this way
+        naming_convention={
+            "ix": "%(table_name)s_%(column_0_N_name)s_ix",
+            "uq": "%(table_name)s_%(column_0_N_name)s_key",
+            "ck": "%(table_name)s_%(column_0_N_name)s_check",
+            "fk": "%(table_name)s_%(column_0_N_name)s_fkey",
+            "pk": "%(table_name)s_pkey",
+        },
     )
 
 
@@ -149,7 +161,7 @@ class ArtefactBuild(Base):
     __table_args__ = (
         # Unique constraint when revision is NULL
         Index(
-            "idx_artefact_id_architecture_null_revision",
+            None,
             "artefact_id",
             "architecture",
             unique=True,
@@ -157,7 +169,7 @@ class ArtefactBuild(Base):
         ),
         # Unique constraint when revision is NOT NULL
         Index(
-            "idx_artefact_id_architecture_revision",
+            None,
             "artefact_id",
             "architecture",
             "revision",


### PR DESCRIPTION
Right now database constraints (primary keys, foreign keys, indexes, etc) don't have a fixed naming convention in SQLAlchemy. This results in Alembic automatically creating these constraints without an actual name. That makes the database choose the name. This makes constraints a bit [more challenging to work with on alembic](https://alembic.sqlalchemy.org/en/latest/naming.html). This PR basically adds these naming conventions to SQLAlchemy and renames those that are not following these conventions.