### PR TITLE
Make patch test execution endpoint parameters optional

### DIFF
--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -81,6 +81,6 @@ class EndTestExecutionRequest(BaseModel):
 
 
 class TestExecutionsPatchRequest(BaseModel):
-    c3_link: HttpUrl | None
-    ci_link: HttpUrl | None
-    status: TestExecutionStatus | None
+    c3_link: HttpUrl | None = None
+    ci_link: HttpUrl | None = None
+    status: TestExecutionStatus | None = None


### PR DESCRIPTION
Fixes issue described by https://github.com/canonical/hwcert-jenkins-jobs/pull/236#pullrequestreview-1767430599