### PR TITLE
Support test execution reruns

### DIFF
--- a/backend/test_observer/controllers/test_executions/test_executions.py
+++ b/backend/test_observer/controllers/test_executions/test_executions.py
@@ -99,9 +99,24 @@ def start_test_execution(
                 "ci_link": request.ci_link,
             },
         )
+
+        if test_execution.ci_link != request.ci_link:
+            reset_test_execution(request, db, test_execution)
+
         return {"id": test_execution.id}
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def reset_test_execution(
+    request: StartTestExecutionRequest,
+    db: Session,
+    test_execution: TestExecution,
+):
+    test_execution.status = TestExecutionStatus.IN_PROGRESS
+    test_execution.ci_link = request.ci_link
+    test_execution.c3_link = None
+    db.commit()
 
 
 @router.put("/end-test")

--- a/backend/tests/controllers/test_executions/test_test_executions.py
+++ b/backend/tests/controllers/test_executions/test_test_executions.py
@@ -152,8 +152,14 @@ def test_uses_existing_models(db_session: Session, test_client: TestClient):
         revision=request.revision,
         artefact=artefact,
     )
+    test_execution = TestExecution(
+        environment=environment,
+        artefact_build=artefact_build,
+        ci_link="http://should-be-changed",
+        c3_link="http://should-be-nulled",
+    )
 
-    db_session.add_all([artefact, environment, artefact_build])
+    db_session.add_all([artefact, environment, artefact_build, test_execution])
     db_session.commit()
 
     test_execution_id = test_client.put(
@@ -171,6 +177,7 @@ def test_uses_existing_models(db_session: Session, test_client: TestClient):
     assert test_execution.environment_id == environment.id
     assert test_execution.status == TestExecutionStatus.IN_PROGRESS
     assert test_execution.ci_link == "http://localhost/"
+    assert test_execution.c3_link is None
 
 
 def test_report_test_execution_data(db_session: Session, test_client: TestClient):


### PR DESCRIPTION
As discussed on [MM](https://chat.canonical.com/canonical/pl/chkaajxf978kfmayn3ycn9746w). We need to support test execution reruns. The idea is to update the test execution correctly.