### PR TITLE
Store individual test results

### DIFF
--- a/backend/migrations/versions/2023_12_06_0755-6f567e1fb081_add_testresult_model.py
+++ b/backend/migrations/versions/2023_12_06_0755-6f567e1fb081_add_testresult_model.py
@@ -1,0 +1,53 @@
+"""Add TestResult model
+
+Revision ID: 6f567e1fb081
+Revises: 871eec26dc90
+Create Date: 2023-12-06 07:55:11.163965+00:00
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "6f567e1fb081"
+down_revision = "871eec26dc90"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "test_result",
+        sa.Column("c3_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum("PASSED", "FAILED", "SKIPPED", name="testresultstatus"),
+            nullable=False,
+        ),
+        sa.Column("category", sa.String(), nullable=False),
+        sa.Column("comment", sa.String(), nullable=False),
+        sa.Column("io_log", sa.String(), nullable=False),
+        sa.Column("test_execution_id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["test_execution_id"],
+            ["test_execution.id"],
+            name=op.f("test_result_test_execution_id_fkey"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("test_result_pkey")),
+    )
+    op.create_index(
+        op.f("test_result_test_execution_id_ix"),
+        "test_result",
+        ["test_execution_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("test_result_test_execution_id_ix"), table_name="test_result")
+    op.drop_table("test_result")

--- a/backend/migrations/versions/2023_12_06_0755-6f567e1fb081_add_testresult_model.py
+++ b/backend/migrations/versions/2023_12_06_0755-6f567e1fb081_add_testresult_model.py
@@ -51,3 +51,4 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_index(op.f("test_result_test_execution_id_ix"), table_name="test_result")
     op.drop_table("test_result")
+    op.execute("DROP TYPE 'testresultstatus'")

--- a/backend/migrations/versions/2023_12_06_0755-6f567e1fb081_add_testresult_model.py
+++ b/backend/migrations/versions/2023_12_06_0755-6f567e1fb081_add_testresult_model.py
@@ -51,4 +51,4 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_index(op.f("test_result_test_execution_id_ix"), table_name="test_result")
     op.drop_table("test_result")
-    op.execute("DROP TYPE 'testresultstatus'")
+    op.execute("DROP TYPE testresultstatus")

--- a/backend/migrations/versions/2023_12_08_0734-b8e8c3053273_add_test_case_and_result_models.py
+++ b/backend/migrations/versions/2023_12_08_0734-b8e8c3053273_add_test_case_and_result_models.py
@@ -1,15 +1,15 @@
-"""Add TestResult model
+"""Add test case and result models
 
-Revision ID: 6f567e1fb081
+Revision ID: b8e8c3053273
 Revises: 871eec26dc90
-Create Date: 2023-12-06 07:55:11.163965+00:00
+Create Date: 2023-12-08 07:34:01.696593+00:00
 
 """
 import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "6f567e1fb081"
+revision = "b8e8c3053273"
 down_revision = "871eec26dc90"
 branch_labels = None
 depends_on = None
@@ -17,21 +17,35 @@ depends_on = None
 
 def upgrade() -> None:
     op.create_table(
-        "test_result",
-        sa.Column("c3_id", sa.Integer(), nullable=False),
+        "test_case",
         sa.Column("name", sa.String(), nullable=False),
+        sa.Column("category", sa.String(), nullable=False),
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id", name=op.f("test_case_pkey")),
+        sa.UniqueConstraint("name", name=op.f("test_case_name_key")),
+    )
+    op.create_table(
+        "test_result",
         sa.Column(
             "status",
             sa.Enum("PASSED", "FAILED", "SKIPPED", name="testresultstatus"),
             nullable=False,
         ),
-        sa.Column("category", sa.String(), nullable=False),
         sa.Column("comment", sa.String(), nullable=False),
         sa.Column("io_log", sa.String(), nullable=False),
         sa.Column("test_execution_id", sa.Integer(), nullable=False),
+        sa.Column("test_case_id", sa.Integer(), nullable=False),
         sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
         sa.Column("created_at", sa.DateTime(), nullable=False),
         sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["test_case_id"],
+            ["test_case.id"],
+            name=op.f("test_result_test_case_id_fkey"),
+            ondelete="CASCADE",
+        ),
         sa.ForeignKeyConstraint(
             ["test_execution_id"],
             ["test_execution.id"],
@@ -39,6 +53,12 @@ def upgrade() -> None:
             ondelete="CASCADE",
         ),
         sa.PrimaryKeyConstraint("id", name=op.f("test_result_pkey")),
+    )
+    op.create_index(
+        op.f("test_result_test_case_id_ix"),
+        "test_result",
+        ["test_case_id"],
+        unique=False,
     )
     op.create_index(
         op.f("test_result_test_execution_id_ix"),
@@ -50,5 +70,7 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_index(op.f("test_result_test_execution_id_ix"), table_name="test_result")
+    op.drop_index(op.f("test_result_test_case_id_ix"), table_name="test_result")
     op.drop_table("test_result")
+    op.drop_table("test_case")
     op.execute("DROP TYPE testresultstatus")

--- a/backend/test_observer/controllers/test_executions/logic.py
+++ b/backend/test_observer/controllers/test_executions/logic.py
@@ -1,4 +1,4 @@
-from test_observer.data_access.models import TestResult
+from test_observer.data_access.models import TestCase, TestResult
 from test_observer.data_access.models_enums import TestExecutionStatus, TestResultStatus
 
 from .models import C3TestResult, C3TestResultStatus
@@ -12,18 +12,24 @@ def compute_test_execution_status(
     return status
 
 
-def parse_c3_test_results(c3_test_results: list[C3TestResult]) -> list[TestResult]:
-    return [
-        TestResult(
-            c3_id=r.id,
-            name=r.name,
+def parse_c3_test_results(
+    c3_test_results: list[C3TestResult],
+) -> tuple[list[TestCase], list[TestResult]]:
+    test_cases: list[TestCase] = []
+    test_results: list[TestResult] = []
+    for r in c3_test_results:
+        test_case = TestCase(name=r.name, category=r.category)
+        test_cases.append(test_case)
+
+        test_result = TestResult(
+            test_case=test_case,
             status=parse_c3_test_result_status(r.status),
-            category=r.category,
             comment=r.comment,
             io_log=r.io_log,
         )
-        for r in c3_test_results
-    ]
+        test_results.append(test_result)
+
+    return test_cases, test_results
 
 
 def parse_c3_test_result_status(status: C3TestResultStatus) -> TestResultStatus:

--- a/backend/test_observer/controllers/test_executions/logic.py
+++ b/backend/test_observer/controllers/test_executions/logic.py
@@ -1,0 +1,36 @@
+from test_observer.data_access.models import TestResult
+from test_observer.data_access.models_enums import TestExecutionStatus, TestResultStatus
+
+from .models import C3TestResult, C3TestResultStatus
+
+
+def compute_test_execution_status(
+    test_results: list[TestResult],
+) -> TestExecutionStatus:
+    failed = any(r.status == C3TestResultStatus.FAIL for r in test_results)
+    status = TestExecutionStatus.FAILED if failed else TestExecutionStatus.PASSED
+    return status
+
+
+def parse_c3_test_results(c3_test_results: list[C3TestResult]) -> list[TestResult]:
+    return [
+        TestResult(
+            c3_id=r.id,
+            name=r.name,
+            status=parse_c3_test_result_status(r.status),
+            category=r.category,
+            comment=r.comment,
+            io_log=r.io_log,
+        )
+        for r in c3_test_results
+    ]
+
+
+def parse_c3_test_result_status(status: C3TestResultStatus) -> TestResultStatus:
+    match status:
+        case C3TestResultStatus.PASS:
+            return TestResultStatus.PASSED
+        case C3TestResultStatus.FAIL:
+            return TestResultStatus.FAILED
+        case C3TestResultStatus.SKIP:
+            return TestResultStatus.SKIPPED

--- a/backend/test_observer/controllers/test_executions/test_executions.py
+++ b/backend/test_observer/controllers/test_executions/test_executions.py
@@ -138,8 +138,10 @@ def end_test_execution(request: EndTestExecutionRequest, db: Session = Depends(g
     if test_execution is None:
         raise HTTPException(status_code=404, detail="Related TestExecution not found")
 
-    test_execution.test_results = parse_c3_test_results(request.test_results)
-    test_execution.status = compute_test_execution_status(test_execution.test_results)
+    test_cases, test_results = parse_c3_test_results(request.test_results)
+    db.add_all(test_cases)
+    test_execution.test_results = test_results
+    test_execution.status = compute_test_execution_status(test_results)
     db.commit()
 
 

--- a/backend/test_observer/controllers/test_executions/test_executions.py
+++ b/backend/test_observer/controllers/test_executions/test_executions.py
@@ -20,6 +20,7 @@
 
 
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import delete
 from sqlalchemy.orm import Session
 
 from test_observer.controllers.test_executions.logic import (
@@ -32,6 +33,7 @@ from test_observer.data_access.models import (
     Environment,
     Stage,
     TestExecution,
+    TestResult,
 )
 from test_observer.data_access.models_enums import TestExecutionStatus
 from test_observer.data_access.repository import get_or_create
@@ -119,6 +121,9 @@ def reset_test_execution(
     test_execution.status = TestExecutionStatus.IN_PROGRESS
     test_execution.ci_link = request.ci_link
     test_execution.c3_link = None
+    db.execute(
+        delete(TestResult).where(TestResult.test_execution_id == test_execution.id)
+    )
     db.commit()
 
 

--- a/backend/test_observer/controllers/test_executions/test_executions.py
+++ b/backend/test_observer/controllers/test_executions/test_executions.py
@@ -25,7 +25,7 @@ from sqlalchemy.orm import Session
 
 from test_observer.controllers.test_executions.logic import (
     compute_test_execution_status,
-    parse_c3_test_results,
+    store_test_results,
 )
 from test_observer.data_access.models import (
     Artefact,
@@ -138,10 +138,8 @@ def end_test_execution(request: EndTestExecutionRequest, db: Session = Depends(g
     if test_execution is None:
         raise HTTPException(status_code=404, detail="Related TestExecution not found")
 
-    test_cases, test_results = parse_c3_test_results(request.test_results)
-    db.add_all(test_cases)
-    test_execution.test_results = test_results
-    test_execution.status = compute_test_execution_status(test_results)
+    store_test_results(db, request.test_results, test_execution)
+    test_execution.status = compute_test_execution_status(test_execution.test_results)
     db.commit()
 
 

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -32,6 +32,7 @@ from sqlalchemy.sql import func
 from test_observer.data_access.models_enums import (
     ArtefactStatus,
     TestExecutionStatus,
+    TestResultStatus,
 )
 
 
@@ -221,6 +222,9 @@ class TestExecution(Base):
     )
     environment_id: Mapped[int] = mapped_column(ForeignKey("environment.id"))
     environment: Mapped["Environment"] = relationship(back_populates="test_executions")
+    test_results: Mapped[list["TestResult"]] = relationship(
+        back_populates="test_execution", cascade="all, delete"
+    )
     # Default fields
     status: Mapped[TestExecutionStatus] = mapped_column(
         default=TestExecutionStatus.NOT_STARTED
@@ -233,7 +237,42 @@ class TestExecution(Base):
             self,
             "artefact_build_id",
             "environment_id",
+            "test_result_id",
             "status",
             "ci_link",
             "c3_link",
+        )
+
+
+class TestResult(Base):
+    """
+    A table to represent individual test results/runs
+    """
+
+    __tablename__ = "test_result"
+
+    c3_id: Mapped[int]
+    name: Mapped[str]
+    status: Mapped[TestResultStatus]
+    category: Mapped[str]
+    comment: Mapped[str]
+    io_log: Mapped[str]
+
+    test_execution_id: Mapped[int] = mapped_column(
+        ForeignKey("test_execution.id", ondelete="CASCADE"), index=True
+    )
+    test_execution: Mapped["TestExecution"] = relationship(
+        back_populates="test_results"
+    )
+
+    def __repr__(self) -> str:
+        return data_model_repr(
+            self,
+            "c3_id",
+            "name",
+            "status",
+            "category",
+            "comment",
+            "io_log",
+            "test_execution_id",
         )

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -244,6 +244,20 @@ class TestExecution(Base):
         )
 
 
+class TestCase(Base):
+    """
+    A table to represent test cases (not the runs themselves)
+    """
+
+    __tablename__ = "test_case"
+
+    name: Mapped[str] = mapped_column(unique=True)
+    category: Mapped[str]
+
+    def __repr__(self) -> str:
+        return data_model_repr(self, "name", "category")
+
+
 class TestResult(Base):
     """
     A table to represent individual test results/runs
@@ -251,10 +265,7 @@ class TestResult(Base):
 
     __tablename__ = "test_result"
 
-    c3_id: Mapped[int]
-    name: Mapped[str]
     status: Mapped[TestResultStatus]
-    category: Mapped[str]
     comment: Mapped[str]
     io_log: Mapped[str]
 
@@ -265,14 +276,17 @@ class TestResult(Base):
         back_populates="test_results"
     )
 
+    test_case_id: Mapped[int] = mapped_column(
+        ForeignKey("test_case.id", ondelete="CASCADE"), index=True
+    )
+    test_case: Mapped["TestCase"] = relationship()
+
     def __repr__(self) -> str:
         return data_model_repr(
             self,
-            "c3_id",
-            "name",
             "status",
-            "category",
             "comment",
             "io_log",
             "test_execution_id",
+            "test_case_id",
         )

--- a/backend/test_observer/data_access/models_enums.py
+++ b/backend/test_observer/data_access/models_enums.py
@@ -39,3 +39,9 @@ class ArtefactStatus(str, Enum):
     APPROVED = "APPROVED"
     MARKED_AS_FAILED = "MARKED_AS_FAILED"
     UNDECIDED = "UNDECIDED"
+
+
+class TestResultStatus(str, Enum):
+    PASSED = "PASSED"
+    FAILED = "FAILED"
+    SKIPPED = "SKIPPED"

--- a/backend/tests/controllers/test_executions/test_test_executions.py
+++ b/backend/tests/controllers/test_executions/test_test_executions.py
@@ -214,7 +214,8 @@ def test_report_test_execution_data(db_session: Session, test_client: TestClient
     test_execution = TestExecution(
         environment=environment, artefact_build=artefact_build, ci_link=ci_link
     )
-    db_session.add_all([artefact_build, environment, test_execution])
+    test_case = TestCase(name="test-name-1", category="")
+    db_session.add_all([artefact_build, environment, test_execution, test_case])
     db_session.commit()
 
     response = test_client.put(
@@ -225,9 +226,9 @@ def test_report_test_execution_data(db_session: Session, test_client: TestClient
             "test_results": [
                 {
                     "id": 1,
-                    "name": "test-name-1",
+                    "name": test_case.name,
                     "status": "pass",
-                    "category": "",
+                    "category": test_case.category,
                     "comment": "",
                     "io_log": "",
                 },

--- a/backend/tests/controllers/test_executions/test_test_executions.py
+++ b/backend/tests/controllers/test_executions/test_test_executions.py
@@ -33,6 +33,7 @@ from test_observer.data_access.models import (
 from test_observer.data_access.models_enums import (
     FamilyName,
     TestExecutionStatus,
+    TestResultStatus,
 )
 from tests.helpers import create_artefact
 
@@ -219,6 +220,10 @@ def test_report_test_execution_data(db_session: Session, test_client: TestClient
 
     assert response.status_code == 200
     assert test_execution.status == TestExecutionStatus.PASSED
+    assert test_execution.test_results[0].name == "test-name-1"
+    assert test_execution.test_results[0].status == TestResultStatus.PASSED
+    assert test_execution.test_results[1].name == "test-name-2"
+    assert test_execution.test_results[1].status == TestResultStatus.SKIPPED
 
 
 def test_updates_test_execution(db_session: Session, test_client: TestClient):

--- a/backend/tests/controllers/test_executions/test_test_executions.py
+++ b/backend/tests/controllers/test_executions/test_test_executions.py
@@ -28,6 +28,7 @@ from test_observer.data_access.models import (
     ArtefactBuild,
     Environment,
     Stage,
+    TestCase,
     TestExecution,
     TestResult,
 )
@@ -160,12 +161,11 @@ def test_uses_existing_models(db_session: Session, test_client: TestClient):
         ci_link="http://should-be-changed",
         c3_link="http://should-be-nulled",
     )
+    test_case = TestCase(name="some-test", category="")
     test_result = TestResult(
+        test_case=test_case,
         test_execution=test_execution,
-        c3_id=1,
-        name="to-be-deleted",
         status=TestResultStatus.PASSED,
-        category="",
         comment="",
         io_log="",
     )
@@ -176,6 +176,7 @@ def test_uses_existing_models(db_session: Session, test_client: TestClient):
             environment,
             artefact_build,
             test_execution,
+            test_case,
             test_result,
         ]
     )
@@ -199,7 +200,7 @@ def test_uses_existing_models(db_session: Session, test_client: TestClient):
     assert test_execution.c3_link is None
     assert (
         db_session.query(TestResult)
-        .filter(TestResult.name == "to-be-deleted")
+        .filter(TestResult.test_case_id == test_case.id)
         .one_or_none()
         is None
     )
@@ -244,9 +245,9 @@ def test_report_test_execution_data(db_session: Session, test_client: TestClient
 
     assert response.status_code == 200
     assert test_execution.status == TestExecutionStatus.PASSED
-    assert test_execution.test_results[0].name == "test-name-1"
+    assert test_execution.test_results[0].test_case.name == "test-name-1"
     assert test_execution.test_results[0].status == TestResultStatus.PASSED
-    assert test_execution.test_results[1].name == "test-name-2"
+    assert test_execution.test_results[1].test_case.name == "test-name-2"
     assert test_execution.test_results[1].status == TestResultStatus.SKIPPED
 
 


### PR DESCRIPTION
This PR continues on [RTW-196](https://warthogs.atlassian.net/browse/RTW-196). It basically will store individual `TestResults` on TO so that TO can serve it to the frontend later on.

[RTW-196]: https://warthogs.atlassian.net/browse/RTW-196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ