### PR TITLE
Only leader should change relation data

### DIFF
--- a/backend/charm/src/charm.py
+++ b/backend/charm/src/charm.py
@@ -98,10 +98,11 @@ class TestObserverBackendCharm(CharmBase):
         raise SystemExit(0)
 
     def _on_config_changed(self, event):
-        for relation in self.model.relations["test-observer-rest-api"]:
-            host = self.config["hostname"]
-            port = str(self.config["port"])
-            relation.data[self.app].update({"hostname": host, "port": port})
+        if self.unit.is_leader():
+            for relation in self.model.relations["test-observer-rest-api"]:
+                host = self.config["hostname"]
+                port = str(self.config["port"])
+                relation.data[self.app].update({"hostname": host, "port": port})
 
         self._update_layer_and_restart(event)
 


### PR DESCRIPTION
After deploying the TF changes to scale TO to 3 units, it started to fail on staging with the error `api/1 is not leader and cannot write application data.`. This PR basically adds a check so that only the leader unit can make changes to relation data.