### PR TITLE
Fix flaky test because of unordered sets

### DIFF
--- a/backend/test_observer/controllers/test_executions/test_executions.py
+++ b/backend/test_observer/controllers/test_executions/test_executions.py
@@ -122,7 +122,7 @@ def reset_test_execution(
     test_execution.status = TestExecutionStatus.IN_PROGRESS
     test_execution.ci_link = request.ci_link
     test_execution.c3_link = None
-    test_execution.review_decision = set()
+    test_execution.review_decision = []
     test_execution.review_comment = ""
     db.execute(
         delete(TestResult).where(TestResult.test_execution_id == test_execution.id)
@@ -167,7 +167,7 @@ def patch_test_execution(
         test_execution.status = request.status
 
     if request.review_decision is not None:
-        test_execution.review_decision = request.review_decision
+        test_execution.review_decision = list(request.review_decision)
 
     if request.review_comment is not None:
         test_execution.review_comment = request.review_comment

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -239,7 +239,7 @@ class TestExecution(Base):
     status: Mapped[TestExecutionStatus] = mapped_column(
         default=TestExecutionStatus.NOT_STARTED
     )
-    review_decision: Mapped[set[TestExecutionReviewDecision]] = mapped_column(
+    review_decision: Mapped[list[TestExecutionReviewDecision]] = mapped_column(
         ARRAY(Enum(TestExecutionReviewDecision)),
         default=[],
     )

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -239,7 +239,7 @@ class TestExecution(Base):
     status: Mapped[TestExecutionStatus] = mapped_column(
         default=TestExecutionStatus.NOT_STARTED
     )
-    review_decision: Mapped[list[TestExecutionReviewDecision]] = mapped_column(
+    review_decision: Mapped[set[TestExecutionReviewDecision]] = mapped_column(
         ARRAY(Enum(TestExecutionReviewDecision)),
         default=[],
     )

--- a/backend/tests/controllers/test_executions/test_test_executions.py
+++ b/backend/tests/controllers/test_executions/test_test_executions.py
@@ -273,30 +273,27 @@ def test_report_test_execution_data(db_session: Session, test_client: TestClient
 def test_updates_test_execution(
     db_session: Session, test_client: TestClient, test_execution: TestExecution
 ):
+    new_review_decision = set(
+        [
+            TestExecutionReviewDecision.APPROVED_FAULTY_HARDWARE.name,
+            TestExecutionReviewDecision.APPROVED_INCONSISTENT_TEST.name,
+        ]
+    )
     test_client.patch(
         f"/v1/test-executions/{test_execution.id}",
         json={
             "ci_link": "http://ci_link/",
             "c3_link": "http://c3_link/",
             "status": TestExecutionStatus.PASSED.name,
-            "review_decision": [
-                TestExecutionReviewDecision.APPROVED_FAULTY_HARDWARE.name,
-                TestExecutionReviewDecision.APPROVED_INCONSISTENT_TEST.name,
-            ],
+            "review_decision": list(new_review_decision),
             "review_comment": "Tests fail because of broken keyboard",
         },
     )
-
     db_session.refresh(test_execution)
     assert test_execution.ci_link == "http://ci_link/"
     assert test_execution.c3_link == "http://c3_link/"
     assert test_execution.status == TestExecutionStatus.PASSED
-    assert len(test_execution.review_decision) == 2
-    for review_decision in [
-        TestExecutionReviewDecision.APPROVED_FAULTY_HARDWARE.name,
-        TestExecutionReviewDecision.APPROVED_INCONSISTENT_TEST.name,
-    ]:
-        assert review_decision in test_execution.review_decision
+    assert set(test_execution.review_decision) == new_review_decision
     assert test_execution.review_comment == "Tests fail because of broken keyboard"
 
 

--- a/backend/tests/controllers/test_executions/test_test_executions.py
+++ b/backend/tests/controllers/test_executions/test_test_executions.py
@@ -291,10 +291,12 @@ def test_updates_test_execution(
     assert test_execution.ci_link == "http://ci_link/"
     assert test_execution.c3_link == "http://c3_link/"
     assert test_execution.status == TestExecutionStatus.PASSED
-    assert test_execution.review_decision == [
+    assert len(test_execution.review_decision) == 2
+    for review_decision in [
         TestExecutionReviewDecision.APPROVED_FAULTY_HARDWARE.name,
         TestExecutionReviewDecision.APPROVED_INCONSISTENT_TEST.name,
-    ]
+    ]:
+        assert review_decision in test_execution.review_decision
     assert test_execution.review_comment == "Tests fail because of broken keyboard"
 
 

--- a/backend/tests/controllers/test_executions/test_test_executions.py
+++ b/backend/tests/controllers/test_executions/test_test_executions.py
@@ -283,7 +283,7 @@ def test_updates_test_execution(
             "ci_link": "http://ci_link/",
             "c3_link": "http://c3_link/",
             "status": TestExecutionStatus.PASSED.name,
-            "review_decision": list(new_review_decision),
+            "review_decision": new_review_decision,
             "review_comment": "Tests fail because of broken keyboard",
         },
     )

--- a/backend/tests/controllers/test_executions/test_test_executions.py
+++ b/backend/tests/controllers/test_executions/test_test_executions.py
@@ -273,12 +273,10 @@ def test_report_test_execution_data(db_session: Session, test_client: TestClient
 def test_updates_test_execution(
     db_session: Session, test_client: TestClient, test_execution: TestExecution
 ):
-    new_review_decision = set(
-        [
-            TestExecutionReviewDecision.APPROVED_FAULTY_HARDWARE.name,
-            TestExecutionReviewDecision.APPROVED_INCONSISTENT_TEST.name,
-        ]
-    )
+    new_review_decision = [
+        TestExecutionReviewDecision.APPROVED_FAULTY_HARDWARE.name,
+        TestExecutionReviewDecision.APPROVED_INCONSISTENT_TEST.name,
+    ]
     test_client.patch(
         f"/v1/test-executions/{test_execution.id}",
         json={
@@ -293,7 +291,7 @@ def test_updates_test_execution(
     assert test_execution.ci_link == "http://ci_link/"
     assert test_execution.c3_link == "http://c3_link/"
     assert test_execution.status == TestExecutionStatus.PASSED
-    assert set(test_execution.review_decision) == new_review_decision
+    assert test_execution.review_decision == set(new_review_decision)
     assert test_execution.review_comment == "Tests fail because of broken keyboard"
 
 

--- a/backend/tests/controllers/test_executions/test_test_executions.py
+++ b/backend/tests/controllers/test_executions/test_test_executions.py
@@ -291,7 +291,7 @@ def test_updates_test_execution(
     assert test_execution.ci_link == "http://ci_link/"
     assert test_execution.c3_link == "http://c3_link/"
     assert test_execution.status == TestExecutionStatus.PASSED
-    assert test_execution.review_decision == set(new_review_decision)
+    assert set(test_execution.review_decision) == set(new_review_decision)
     assert test_execution.review_comment == "Tests fail because of broken keyboard"
 
 


### PR DESCRIPTION
This PR fixes a flaky test that sometimes fails because [sets](https://docs.python.org/3/library/stdtypes.html#set-types-set-frozenset) in Python are unordered data structures. Because of this, the order they might return the results is unpredictable, and depends on the current hash value of the objects.

To account for this, we instead verify the length of the set and that the result expected indeed are present in the set.