### PR TITLE
Scale down API instance to one

### DIFF
--- a/terraform/test-observer.tf
+++ b/terraform/test-observer.tf
@@ -85,7 +85,7 @@ resource "juju_application" "test-observer-api" {
     sentry_dsn = "${local.sentry_dsn_map[var.environment]}"
   }
 
-  units = 3
+  units = 1
 }
 
 resource "juju_application" "test-observer-frontend" {


### PR DESCRIPTION
The followers of the API leader seem to be stuck on both staging and production. This seems to be related to a bug found when this instance was scaled to 3 units. Since these followers are stuck and sometimes return invalid results, we scale down to just one instance until we resolve the issue.