### PR TITLE
Display test result info and add padding for scrollbar

### DIFF
--- a/frontend/lib/models/test_result.dart
+++ b/frontend/lib/models/test_result.dart
@@ -5,9 +5,14 @@ part 'test_result.g.dart';
 
 @freezed
 class TestResult with _$TestResult {
+  const TestResult._();
+
   const factory TestResult({
     required String name,
     required TestResultStatus status,
+    @Default('') String category,
+    @Default('') String comment,
+    @JsonKey(name: 'io_log') @Default('') String ioLog,
   }) = _TestResult;
 
   factory TestResult.fromJson(Map<String, Object?> json) =>

--- a/frontend/lib/ui/artefact_dialog/artefact_dialog_body.dart
+++ b/frontend/lib/ui/artefact_dialog/artefact_dialog_body.dart
@@ -4,6 +4,7 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../../models/artefact.dart';
 import '../../providers/artefact_builds.dart';
+import '../spacing.dart';
 import 'artefact_build_expandable.dart';
 
 class ArtefactDialogBody extends ConsumerWidget {
@@ -23,8 +24,12 @@ class ArtefactDialogBody extends ConsumerWidget {
           Expanded(
             child: ListView.builder(
               itemCount: artefactBuilds.length,
-              itemBuilder: (_, i) =>
-                  ArtefactBuildExpandable(artefactBuild: artefactBuilds[i]),
+              itemBuilder: (_, i) => Padding(
+                // Padding is to avoid scroll bar covering trailing buttons
+                padding: const EdgeInsets.only(right: Spacing.level3),
+                child:
+                    ArtefactBuildExpandable(artefactBuild: artefactBuilds[i]),
+              ),
             ),
           ),
         ],

--- a/frontend/lib/ui/artefact_dialog/test_result_expandable.dart
+++ b/frontend/lib/ui/artefact_dialog/test_result_expandable.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../../models/test_result.dart';
+import '../spacing.dart';
+
+class TestResultExpandable extends StatelessWidget {
+  const TestResultExpandable({super.key, required this.testResult});
+
+  final TestResult testResult;
+
+  @override
+  Widget build(BuildContext context) {
+    return YaruExpandable(
+      expandButtonPosition: YaruExpandableButtonPosition.start,
+      header: Text(testResult.name),
+      child: Padding(
+        padding: const EdgeInsets.only(left: Spacing.level5),
+        child: Column(
+          children: [
+            if (testResult.category != '')
+              YaruTile(
+                title: const Text('Category'),
+                subtitle: Text(testResult.category),
+              ),
+            if (testResult.comment != '')
+              YaruTile(
+                title: const Text('Comment'),
+                subtitle: Text(testResult.comment),
+              ),
+            if (testResult.ioLog != '')
+              YaruTile(
+                title: const Text('IO Log'),
+                subtitle: Text(testResult.ioLog),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/ui/artefact_dialog/test_result_filter_expandable.dart
+++ b/frontend/lib/ui/artefact_dialog/test_result_filter_expandable.dart
@@ -7,6 +7,7 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 import '../../models/test_result.dart';
 import '../../providers/test_results.dart';
 import '../spacing.dart';
+import 'test_result_expandable.dart';
 
 class TestResultsFilterExpandable extends ConsumerWidget {
   const TestResultsFilterExpandable({
@@ -47,12 +48,13 @@ class TestResultsFilterExpandable extends ConsumerWidget {
           ),
           expandButtonPosition: YaruExpandableButtonPosition.start,
           child: Padding(
-            padding: const EdgeInsets.only(left: Spacing.level5),
+            padding: const EdgeInsets.only(left: Spacing.level4),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: filteredTestResults
                   .map(
-                    (testResult) => YaruTile(title: Text(testResult.name)),
+                    (testResult) =>
+                        TestResultExpandable(testResult: testResult),
                   )
                   .toList(),
             ),


### PR DESCRIPTION
Display rest of info of test results on frontend. This is the last PR to resolve [RTW-202](https://warthogs.atlassian.net/browse/RTW-202)

Also in this PR, I added some padding on the right side so that CI and C3 buttons are not hidden behind the scrollbar.

[Screencast from 15-12-23 13:14:43.webm](https://github.com/canonical/test_observer/assets/4087200/bad725d4-3158-47dc-af4c-3ed28f93d157)


[RTW-202]: https://warthogs.atlassian.net/browse/RTW-202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ