### PR TITLE
Reject empty string for required artefact fields

### DIFF
--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -73,7 +73,7 @@ class StartTestExecutionRequest(BaseModel):
         family = self.family
 
         for required_field in required_fields[family]:
-            if getattr(self, required_field) is None:
+            if not getattr(self, required_field):
                 raise ValueError(f"{required_field} is required for {family} family")
 
         return self


### PR DESCRIPTION
Right now we have some snap artefacts with the store value "". This ofc is causing [issues](https://sentry.is.canonical.com/canonical/test-observer-api/issues/57632/events/?query=is%3Aunresolved). I'll investigate what the actual store value for these snaps should be and fix them. But I'd also like to add a check to avoid this issue appearing again.