### PR TITLE
Add api requests retries on frontend

### DIFF
--- a/frontend/lib/providers/dio.dart
+++ b/frontend/lib/providers/dio.dart
@@ -4,6 +4,7 @@ import 'dart:html';
 import 'dart:js_util' as js_util;
 
 import 'package:dio/dio.dart';
+import 'package:dio_smart_retry/dio_smart_retry.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'dio.g.dart';
@@ -12,5 +13,6 @@ part 'dio.g.dart';
 Dio dio(DioRef ref) {
   final baseUrl = js_util.getProperty<String>(window, 'testObserverAPIBaseURI');
   final dio = Dio(BaseOptions(baseUrl: baseUrl));
+  dio.interceptors.add(RetryInterceptor(dio: dio));
   return dio;
 }

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -241,6 +241,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.3.3"
+  dio_smart_retry:
+    dependency: "direct main"
+    description:
+      name: dio_smart_retry
+      sha256: "3d71450c19b4d91ef4c7d726a55a284bfc11eb3634f1f25006cdfab3f8595653"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
   fake_async:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
 dependencies:
   dartx: ^1.1.0
   dio: ^5.1.2
+  dio_smart_retry: ^6.0.0
   flutter:
     sdk: flutter
   flutter_riverpod: ^2.3.6


### PR DESCRIPTION
Occasionally, api requests sent by frontend have transient failures. This can result in errors as shown below:
![image](https://github.com/canonical/test_observer/assets/4087200/2b991701-48b2-4e7d-904f-204a5915344b)

To avoid or minimize such errors this PR adds retries.