### PR TITLE
Add condition to check if C3 Link is found

### DIFF
--- a/frontend/lib/ui/artefact_dialog/test_execution_expandable.dart
+++ b/frontend/lib/ui/artefact_dialog/test_execution_expandable.dart
@@ -39,7 +39,8 @@ class TestExecutionExpandable extends ConsumerWidget {
                   urlText: 'CI',
                 ),
               const SizedBox(width: Spacing.level3),
-              if (c3Link != null)
+              if (c3Link != null &&
+                  c3Link != 'Failed to find C3 submission link')
                 InlineUrlText(
                   url: c3Link,
                   urlText: 'C3',


### PR DESCRIPTION
For older artefacts, before we added a check that the C3 link must be a valid URL, Jenkins was sending the text "Failed to find C3 submission link" as C3 link. So now, some snaps (one example: https://test-observer.canonical.com/#/snaps/11035) show the C3 link button, but it doesn't point anywhere.

To fix this, we add the condition that checks for this case.