### PR TITLE
Revert terraform provider back to 0.7.0

### DIFF
--- a/terraform/test-observer.tf
+++ b/terraform/test-observer.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     juju = {
-      version = "~> 0.10.0"
+      version = "~> 0.7.0"
       source  = "juju/juju"
     }
   }


### PR DESCRIPTION
Apparently 0.10.0 was causing some problems in staging