### PR TITLE
Implement frontend for showing previous test results

### DIFF
--- a/frontend/lib/models/test_result.dart
+++ b/frontend/lib/models/test_result.dart
@@ -1,7 +1,23 @@
+import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:yaru/yaru.dart';
+import 'package:yaru_icons/yaru_icons.dart';
 
 part 'test_result.freezed.dart';
 part 'test_result.g.dart';
+
+@freezed
+class PreviousTestResult with _$PreviousTestResult {
+  const PreviousTestResult._();
+
+  const factory PreviousTestResult({
+    required TestResultStatus status,
+    required String version,
+  }) = _PreviousTestResult;
+
+  factory PreviousTestResult.fromJson(Map<String, Object?> json) =>
+      _$PreviousTestResultFromJson(json);
+}
 
 @freezed
 class TestResult with _$TestResult {
@@ -13,6 +29,9 @@ class TestResult with _$TestResult {
     @Default('') String category,
     @Default('') String comment,
     @JsonKey(name: 'io_log') @Default('') String ioLog,
+    @JsonKey(name: 'previous_results')
+    @Default([])
+    List<PreviousTestResult> previousResults,
   }) = _TestResult;
 
   factory TestResult.fromJson(Map<String, Object?> json) =>
@@ -35,6 +54,22 @@ enum TestResultStatus {
         return 'Passed';
       case skipped:
         return 'Skipped';
+    }
+  }
+
+  Icon get icon {
+    const size = 15.0;
+    switch (this) {
+      case passed:
+        return Icon(YaruIcons.ok, color: YaruColors.light.success, size: size);
+      case failed:
+        return const Icon(YaruIcons.error, color: YaruColors.red, size: size);
+      case skipped:
+        return const Icon(
+          YaruIcons.error,
+          color: YaruColors.coolGrey,
+          size: size,
+        );
     }
   }
 }

--- a/frontend/lib/ui/artefact_dialog/test_result_expandable.dart
+++ b/frontend/lib/ui/artefact_dialog/test_result_expandable.dart
@@ -13,7 +13,15 @@ class TestResultExpandable extends StatelessWidget {
   Widget build(BuildContext context) {
     return YaruExpandable(
       expandButtonPosition: YaruExpandableButtonPosition.start,
-      header: Text(testResult.name),
+      header: Row(
+        children: [
+          Text(testResult.name),
+          const Spacer(),
+          PreviousTestResultsWidget(
+            previousResults: testResult.previousResults,
+          ),
+        ],
+      ),
       child: Padding(
         padding: const EdgeInsets.only(left: Spacing.level5),
         child: Column(
@@ -36,6 +44,26 @@ class TestResultExpandable extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+class PreviousTestResultsWidget extends StatelessWidget {
+  const PreviousTestResultsWidget({super.key, required this.previousResults});
+
+  final List<PreviousTestResult> previousResults;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: previousResults
+          .map(
+            (e) => Tooltip(
+              message: 'Version: ${e.version}',
+              child: e.status.icon,
+            ),
+          )
+          .toList(),
     );
   }
 }


### PR DESCRIPTION
This PR resolves [RTW-120](https://warthogs.atlassian.net/browse/RTW-120) and it implements the frontend for showing previous test results for each test case.

# Screenshots

![Screenshot from 2024-01-12 11-38-10](https://github.com/canonical/test_observer/assets/33193463/9f103fe7-cf91-4203-a40a-164b66323ee9)
![Screenshot from 2024-01-12 11-38-26](https://github.com/canonical/test_observer/assets/33193463/8b7c9e8f-50d9-46e7-9842-41ef2d4da816)

[RTW-120]: https://warthogs.atlassian.net/browse/RTW-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ