### PR TITLE
Hot fix for user assignment

### DIFF
--- a/backend/migrations/versions/2024_01_12_1040-bb2a51214402_.py
+++ b/backend/migrations/versions/2024_01_12_1040-bb2a51214402_.py
@@ -1,0 +1,28 @@
+"""empty message
+
+Revision ID: bb2a51214402
+Revises: c9851b127edc
+Create Date: 2024-01-12 10:40:00.596887+00:00
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "bb2a51214402"
+down_revision = "c9851b127edc"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute('ALTER TABLE "user" RENAME TO app_user')
+    op.drop_constraint("user_launchpad_email_key", "app_user", type_="unique")
+    op.create_unique_constraint(
+        op.f("app_user_launchpad_email_key"), "app_user", ["launchpad_email"]
+    )
+
+
+def downgrade() -> None:
+    op.execute('ALTER TABLE app_user RENAME TO "user"')
+    op.drop_constraint(op.f("app_user_launchpad_email_key"), "user", type_="unique")
+    op.create_unique_constraint("user_launchpad_email_key", "user", ["launchpad_email"])

--- a/backend/scripts/seed_data.py
+++ b/backend/scripts/seed_data.py
@@ -11,13 +11,21 @@ from test_observer.controllers.test_executions.models import (
     EndTestExecutionRequest,
     StartTestExecutionRequest,
 )
+from test_observer.controllers.users.models import CreateUserRequest
 from test_observer.data_access.models_enums import FamilyName
 
 BASE_URL = "http://localhost:30000/v1"
+CREATE_USER_URL = f"{BASE_URL}/users"
 START_TEST_EXECUTION_URL = f"{BASE_URL}/test-executions/start-test"
 END_TEST_EXECUTION_URL = f"{BASE_URL}/test-executions/end-test"
 
-START_REQUESTS = [
+CREATE_USER_REQUESTS = [
+    CreateUserRequest(launchpad_email="omar.selo@canonical.com"),
+    CreateUserRequest(launchpad_email="nadzeya.hutsko@canonical.com"),
+    CreateUserRequest(launchpad_email="andrej.velichkovski@canonical.com"),
+]
+
+START_TEST_EXECUTION_REQUESTS = [
     StartTestExecutionRequest(
         family=FamilyName.SNAP,
         name="core22",
@@ -162,7 +170,7 @@ START_REQUESTS = [
     ),
 ]
 
-END_REQUESTS = [
+END_TEST_EXECUTION_REQUESTS = [
     EndTestExecutionRequest(
         id=1,
         ci_link="http://example1",
@@ -283,12 +291,17 @@ END_REQUESTS = [
 
 
 def seed_data(client: TestClient | requests.Session):
-    for start_request in START_REQUESTS:
+    for create_user in CREATE_USER_REQUESTS:
+        client.post(
+            CREATE_USER_URL, json=create_user.model_dump(mode="json")
+        ).raise_for_status()
+
+    for start_request in START_TEST_EXECUTION_REQUESTS:
         client.put(
             START_TEST_EXECUTION_URL, json=start_request.model_dump(mode="json")
         ).raise_for_status()
 
-    for end_request in END_REQUESTS:
+    for end_request in END_TEST_EXECUTION_REQUESTS:
         client.put(
             END_TEST_EXECUTION_URL, json=end_request.model_dump(mode="json")
         ).raise_for_status()

--- a/backend/test_observer/controllers/test_executions/test_executions.py
+++ b/backend/test_observer/controllers/test_executions/test_executions.py
@@ -115,6 +115,7 @@ def start_test_execution(
 
         if artefact.assignee_id is None and (users := db.query(User).all()):
             artefact.assignee = random.choice(users)
+            db.commit()
 
         return {"id": test_execution.id}
     except ValueError as exc:

--- a/backend/test_observer/controllers/users/users.py
+++ b/backend/test_observer/controllers/users/users.py
@@ -11,7 +11,7 @@ router = APIRouter()
 
 
 # include_in_schema=False to hide this endpoints from docs as its internal use
-@router.post("/", response_model=UserDTO, include_in_schema=False)
+@router.post("", response_model=UserDTO, include_in_schema=False)
 def add_user(
     request: CreateUserRequest,
     db: Session = Depends(get_db),

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -82,7 +82,8 @@ class User(Base):
     ORM representing users that can be assigned to review artefacts
     """
 
-    __tablename__ = "user"
+    # user is a reserved name in PostgreSQL
+    __tablename__ = "app_user"
 
     launchpad_email: Mapped[str] = mapped_column(unique=True)
     launchpad_handle: Mapped[str]
@@ -144,7 +145,7 @@ class Artefact(Base):
     builds: Mapped[list["ArtefactBuild"]] = relationship(
         back_populates="artefact", cascade="all, delete"
     )
-    assignee_id: Mapped[int | None] = mapped_column(ForeignKey("user.id"))
+    assignee_id: Mapped[int | None] = mapped_column(ForeignKey("app_user.id"))
     assignee: Mapped[User | None] = relationship(back_populates="assignments")
     # Default fields
     due_date: Mapped[date | None]

--- a/backend/tests/controllers/users/test_users.py
+++ b/backend/tests/controllers/users/test_users.py
@@ -7,7 +7,7 @@ from test_observer.data_access.models import User
 
 def test_create_user(db_session: Session, test_client: TestClient):
     email = "omar.selo@canonical.com"
-    response = test_client.post("/v1/users/", json={"launchpad_email": email})
+    response = test_client.post("/v1/users", json={"launchpad_email": email})
 
     assert response.status_code == 200
     assert (
@@ -24,7 +24,7 @@ def test_create_user(db_session: Session, test_client: TestClient):
 
 def test_email_not_in_launchpad(test_client: TestClient):
     email = "john@doe.com"
-    response = test_client.post("/v1/users/", json={"launchpad_email": email})
+    response = test_client.post("/v1/users", json={"launchpad_email": email})
 
     assert response.status_code == 422
     assert response.json()["detail"] == "Email not registered in launchpad"


### PR DESCRIPTION
Includes:
- Rename `user` table to `app_user` to avoid postgresql reserved name
- Commit db changes when assigning user to an artefact
- Add some users to seed script