### PR TITLE
Show assigned users on frontend

### DIFF
--- a/frontend/lib/models/artefact.dart
+++ b/frontend/lib/models/artefact.dart
@@ -3,6 +3,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:yaru/yaru.dart';
 
 import 'stage_name.dart';
+import 'user.dart';
 
 part 'artefact.freezed.dart';
 part 'artefact.g.dart';
@@ -21,6 +22,7 @@ class Artefact with _$Artefact {
     @Default(null) String? repo,
     required ArtefactStatus status,
     required StageName stage,
+    required User? assignee,
   }) = _Artefact;
 
   factory Artefact.fromJson(Map<String, Object?> json) =>

--- a/frontend/lib/models/user.dart
+++ b/frontend/lib/models/user.dart
@@ -22,7 +22,7 @@ class User with _$User {
     final numOfNames = names.length;
     switch (numOfNames) {
       case 0:
-        return 'NA';
+        return 'N/A';
       case 1:
         return names[0][0].capitalize();
       default:

--- a/frontend/lib/models/user.dart
+++ b/frontend/lib/models/user.dart
@@ -1,0 +1,43 @@
+import 'package:dartx/dartx.dart';
+import 'package:flutter/material.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'user.freezed.dart';
+part 'user.g.dart';
+
+Color generateColorFromString(String str) {
+  final hash = str.hashCode;
+  final r = ((hash >> 16) & 0xFF);
+  final g = ((hash >> 8) & 0xFF);
+  final b = (hash & 0xFF);
+  return Color.fromRGBO(r, g, b, 1.0);
+}
+
+@freezed
+class User with _$User {
+  const User._();
+
+  const factory User({
+    required int id,
+    required String name,
+    @JsonKey(name: 'launchpad_email') required String launchpadEmail,
+    @JsonKey(name: 'launchpad_handle') required String launchpadHandle,
+  }) = _User;
+
+  factory User.fromJson(Map<String, Object?> json) => _$UserFromJson(json);
+
+  String get initials {
+    final names = name.split(' ');
+    final numOfNames = names.length;
+    switch (numOfNames) {
+      case 0:
+        return 'NA';
+      case 1:
+        return names[0][0].capitalize();
+      default:
+        return names[0][0].capitalize() + names[numOfNames - 1][0].capitalize();
+    }
+  }
+
+  Color get color => generateColorFromString('$id');
+}

--- a/frontend/lib/models/user.dart
+++ b/frontend/lib/models/user.dart
@@ -1,17 +1,8 @@
 import 'package:dartx/dartx.dart';
-import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'user.freezed.dart';
 part 'user.g.dart';
-
-Color generateColorFromString(String str) {
-  final hash = str.hashCode;
-  final r = ((hash >> 16) & 0xFF);
-  final g = ((hash >> 8) & 0xFF);
-  final b = (hash & 0xFF);
-  return Color.fromRGBO(r, g, b, 1.0);
-}
 
 @freezed
 class User with _$User {
@@ -38,6 +29,4 @@ class User with _$User {
         return names[0][0].capitalize() + names[numOfNames - 1][0].capitalize();
     }
   }
-
-  Color get color => generateColorFromString('$id');
 }

--- a/frontend/lib/ui/artefact_dialog/artefact_dialog_header.dart
+++ b/frontend/lib/ui/artefact_dialog/artefact_dialog_header.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../models/artefact.dart';
 import '../dialog_header.dart';
 import '../spacing.dart';
+import '../user_avatar.dart';
 import 'artefact_signoff_button.dart';
 
 class ArtefactDialogHeader extends StatelessWidget {
@@ -12,12 +13,15 @@ class ArtefactDialogHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final assignee = artefact.assignee;
     return DialogHeader(
       heading: Row(
         children: [
           Text(artefact.name, style: Theme.of(context).textTheme.headlineLarge),
           const SizedBox(width: Spacing.level4),
           ArtefactSignoffButton(artefact: artefact),
+          const SizedBox(width: Spacing.level4),
+          if (assignee != null) UserAvatar(user: assignee),
         ],
       ),
     );

--- a/frontend/lib/ui/dashboard/artefact_card.dart
+++ b/frontend/lib/ui/dashboard/artefact_card.dart
@@ -5,6 +5,7 @@ import 'package:intersperse/intersperse.dart';
 
 import '../../models/artefact.dart';
 import '../spacing.dart';
+import '../user_avatar.dart';
 import 'artefact_status_chip.dart';
 
 class ArtefactCard extends ConsumerWidget {
@@ -51,21 +52,7 @@ class ArtefactCard extends ConsumerWidget {
                 children: [
                   ArtefactStatusChip(status: artefact.status),
                   const Spacer(),
-                  if (assignee != null)
-                    CircleAvatar(
-                      backgroundColor: assignee.color,
-                      child: Tooltip(
-                        message:
-                            '${assignee.name}\n${assignee.launchpadEmail}\n${assignee.launchpadHandle}',
-                        child: Text(
-                          assignee.initials,
-                          style: Theme.of(context)
-                              .textTheme
-                              .labelLarge
-                              ?.apply(fontWeightDelta: 4),
-                        ),
-                      ),
-                    ),
+                  if (assignee != null) UserAvatar(user: assignee),
                 ],
               ),
             ],

--- a/frontend/lib/ui/dashboard/artefact_card.dart
+++ b/frontend/lib/ui/dashboard/artefact_card.dart
@@ -15,6 +15,8 @@ class ArtefactCard extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final assignee = artefact.assignee;
+
     return GestureDetector(
       onTap: () {
         final currentRoute = GoRouterState.of(context).fullPath;
@@ -45,7 +47,27 @@ class ArtefactCard extends ConsumerWidget {
                   )
                   .intersperse(const SizedBox(height: Spacing.level2)),
               const Spacer(),
-              ArtefactStatusChip(status: artefact.status),
+              Row(
+                children: [
+                  ArtefactStatusChip(status: artefact.status),
+                  const Spacer(),
+                  if (assignee != null)
+                    CircleAvatar(
+                      backgroundColor: assignee.color,
+                      child: Tooltip(
+                        message:
+                            '${assignee.name}\n${assignee.launchpadEmail}\n${assignee.launchpadHandle}',
+                        child: Text(
+                          assignee.initials,
+                          style: Theme.of(context)
+                              .textTheme
+                              .labelLarge
+                              ?.apply(fontWeightDelta: 4),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
             ],
           ),
         ),

--- a/frontend/lib/ui/user_avatar.dart
+++ b/frontend/lib/ui/user_avatar.dart
@@ -2,6 +2,11 @@ import 'package:flutter/material.dart';
 
 import '../models/user.dart';
 
+Color userIdToColor(int userId) {
+  const colorGroups = Colors.accents;
+  return colorGroups[userId % colorGroups.length];
+}
+
 class UserAvatar extends StatelessWidget {
   const UserAvatar({super.key, required this.user});
 
@@ -10,7 +15,7 @@ class UserAvatar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return CircleAvatar(
-      backgroundColor: user.color,
+      backgroundColor: userIdToColor(user.id),
       child: Tooltip(
         message:
             '${user.name}\n${user.launchpadEmail}\n${user.launchpadHandle}',

--- a/frontend/lib/ui/user_avatar.dart
+++ b/frontend/lib/ui/user_avatar.dart
@@ -18,7 +18,7 @@ class UserAvatar extends StatelessWidget {
       backgroundColor: userIdToColor(user.id),
       child: Tooltip(
         message:
-            '${user.name}\n${user.launchpadEmail}\n${user.launchpadHandle}',
+            '${user.name}\n${user.launchpadHandle}\n${user.launchpadEmail}',
         child: Text(
           user.initials,
           style:

--- a/frontend/lib/ui/user_avatar.dart
+++ b/frontend/lib/ui/user_avatar.dart
@@ -2,9 +2,17 @@ import 'package:flutter/material.dart';
 
 import '../models/user.dart';
 
+const possibleColors = [
+  Colors.redAccent,
+  Colors.yellowAccent,
+  Colors.blueAccent,
+  Colors.orangeAccent,
+  Colors.greenAccent,
+  Colors.purpleAccent,
+];
+
 Color userIdToColor(int userId) {
-  const colorGroups = Colors.accents;
-  return colorGroups[userId % colorGroups.length];
+  return possibleColors[userId % possibleColors.length];
 }
 
 class UserAvatar extends StatelessWidget {

--- a/frontend/lib/ui/user_avatar.dart
+++ b/frontend/lib/ui/user_avatar.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+import '../models/user.dart';
+
+class UserAvatar extends StatelessWidget {
+  const UserAvatar({super.key, required this.user});
+
+  final User user;
+
+  @override
+  Widget build(BuildContext context) {
+    return CircleAvatar(
+      backgroundColor: user.color,
+      child: Tooltip(
+        message:
+            '${user.name}\n${user.launchpadEmail}\n${user.launchpadHandle}',
+        child: Text(
+          user.initials,
+          style:
+              Theme.of(context).textTheme.labelLarge?.apply(fontWeightDelta: 4),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Resolves [RTW-209](https://warthogs.atlassian.net/browse/RTW-209)

Changes:
- Show initials of users assigned to artefacts in artefact cards and dialog
- Show random [flutter material accent color](https://api.flutter.dev/flutter/material/Colors-class.html) depending on user id
- Show tooltip displaying user information when hovering over a user circle avatar


![Screenshot from 2024-01-15 16-45-59](https://github.com/canonical/test_observer/assets/4087200/bb1df536-0bc0-4cca-a570-80d0d42ce868)
![Screenshot from 2024-01-15 16-46-11](https://github.com/canonical/test_observer/assets/4087200/8913b470-e65a-473b-a165-6b48c79a3d94)

For reference the different color accents are all shown below (They're mostly different with a few slightly similar colors. But I felt it's fine):
![Screenshot from 2024-01-15 16-45-34](https://github.com/canonical/test_observer/assets/4087200/68305d94-43ea-401a-9405-ca27d37bcafa)


[RTW-209]: https://warthogs.atlassian.net/browse/RTW-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ