### PR TITLE
Increase SQLAlchemy connection pool size

### DIFF
--- a/backend/test_observer/data_access/setup.py
+++ b/backend/test_observer/data_access/setup.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import sessionmaker
 DEFAULT_DB_URL = "postgresql+pg8000://postgres:password@test-observer-db:5432/postgres"
 DB_URL = environ.get("DB_URL", DEFAULT_DB_URL)
 
-engine = create_engine(DB_URL, echo=True)
+engine = create_engine(DB_URL, pool_size=10, max_overflow=20)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 


### PR DESCRIPTION
This is to resolve or at least reduce this [error](https://sentry.is.canonical.com/canonical/test-observer-api/issues/58477/) from happening. Basically as mentioned in the [docs](https://docs.sqlalchemy.org/en/20/errors.html#queuepool-limit-of-size-x-overflow-y-reached-connection-timed-out-timeout-z) SQLAlchemy keeps a pool of database connections where the maximum it can handle at the same time is `pool_size + max_overflow` (default is 15). This PR changes that to be `10 + 20 = 30`. This should be safe even if we scale our application to 3 replicas because default [max connections allowed by postgres is 100](https://www.postgresql.org/docs/current/runtime-config-connection.html#GUC-MAX-CONNECTIONS). Incidentally, this should also improve backend performance as SQLAlchemy can make more connections so it should put less queries on hold.

Also I removed `echo=True` as it will probably result in a huge log and space usage on production