### PR TITLE
Replace YaruExpandable with ExpansionTile to avoid eager building

### DIFF
--- a/frontend/lib/ui/artefact_dialog/artefact_build_expandable.dart
+++ b/frontend/lib/ui/artefact_dialog/artefact_build_expandable.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:intersperse/intersperse.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../../models/artefact_build.dart';
 import '../spacing.dart';
@@ -16,10 +15,12 @@ class ArtefactBuildExpandable extends StatelessWidget {
     final revisionText =
         artefactBuild.revision == null ? '' : ' (${artefactBuild.revision})';
 
-    return YaruExpandable(
-      expandButtonPosition: YaruExpandableButtonPosition.start,
-      isExpanded: true,
-      header: Row(
+    return ExpansionTile(
+      initiallyExpanded: true,
+      controlAffinity: ListTileControlAffinity.leading,
+      childrenPadding: const EdgeInsets.only(left: Spacing.level4),
+      shape: const Border(),
+      title: Row(
         children: [
           Text(
             artefactBuild.architecture + revisionText,
@@ -42,17 +43,12 @@ class ArtefactBuildExpandable extends StatelessWidget {
               .intersperse(const SizedBox(width: Spacing.level4)),
         ],
       ),
-      child: Padding(
-        padding: const EdgeInsets.only(left: Spacing.level4),
-        child: Column(
-          children: artefactBuild.testExecutions
-              .map(
-                (testExecution) =>
-                    TestExecutionExpandable(testExecution: testExecution),
-              )
-              .toList(),
-        ),
-      ),
+      children: artefactBuild.testExecutions
+          .map(
+            (testExecution) =>
+                TestExecutionExpandable(testExecution: testExecution),
+          )
+          .toList(),
     );
   }
 }

--- a/frontend/lib/ui/artefact_dialog/artefact_dialog.dart
+++ b/frontend/lib/ui/artefact_dialog/artefact_dialog.dart
@@ -35,41 +35,41 @@ class ArtefactDialog extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final family = AppRoutes.familyFromContext(context);
     final artefacts = ref.watch(familyArtefactsProvider(family));
-    return artefacts.when(
-      data: (artefacts) {
-        final artefact = artefacts[artefactId];
-        return SelectionArea(
-          child: Dialog(
-            child: SizedBox(
-              height: min(800, MediaQuery.of(context).size.height * 0.8),
-              width: min(1200, MediaQuery.of(context).size.width * 0.8),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: Spacing.level5,
-                  vertical: Spacing.level3,
-                ),
-                child: (artefact == null)
-                    ? _invalidArtefactErrorMessage
-                    : Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          ArtefactDialogHeader(artefact: artefact),
-                          const SizedBox(height: Spacing.level4),
-                          ArtefactDialogInfoSection(artefact: artefact),
-                          const SizedBox(height: Spacing.level4),
-                          Expanded(
-                            child: ArtefactDialogBody(artefact: artefact),
-                          ),
-                        ],
-                      ),
-              ),
+    return SelectionArea(
+      child: Dialog(
+        child: SizedBox(
+          height: min(800, MediaQuery.of(context).size.height * 0.8),
+          width: min(1200, MediaQuery.of(context).size.width * 0.8),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: Spacing.level5,
+              vertical: Spacing.level3,
+            ),
+            child: artefacts.when(
+              data: (artefacts) {
+                final artefact = artefacts[artefactId];
+                if (artefact == null) return _invalidArtefactErrorMessage;
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    ArtefactDialogHeader(artefact: artefact),
+                    const SizedBox(height: Spacing.level4),
+                    ArtefactDialogInfoSection(artefact: artefact),
+                    const SizedBox(height: Spacing.level4),
+                    Expanded(
+                      child: ArtefactDialogBody(artefact: artefact),
+                    ),
+                  ],
+                );
+              },
+              error: (e, stack) =>
+                  Center(child: Text('Error:\n$e\nStackTrace:\n$stack')),
+              loading: () =>
+                  const Center(child: YaruCircularProgressIndicator()),
             ),
           ),
-        );
-      },
-      error: (e, stack) =>
-          Center(child: Text('Error:\n$e\nStackTrace:\n$stack')),
-      loading: () => const Center(child: YaruCircularProgressIndicator()),
+        ),
+      ),
     );
   }
 }

--- a/frontend/lib/ui/artefact_dialog/test_execution_expandable.dart
+++ b/frontend/lib/ui/artefact_dialog/test_execution_expandable.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../../models/test_execution.dart';
 import '../../models/test_result.dart';
@@ -19,8 +18,11 @@ class TestExecutionExpandable extends ConsumerWidget {
     final ciLink = testExecution.ciLink;
     final c3Link = testExecution.c3Link;
 
-    return YaruExpandable(
-      header: Row(
+    return ExpansionTile(
+      controlAffinity: ListTileControlAffinity.leading,
+      childrenPadding: const EdgeInsets.only(left: Spacing.level4),
+      shape: const Border(),
+      title: Row(
         children: [
           testExecution.status.icon,
           const SizedBox(width: Spacing.level4),
@@ -48,20 +50,14 @@ class TestExecutionExpandable extends ConsumerWidget {
           ),
         ],
       ),
-      expandButtonPosition: YaruExpandableButtonPosition.start,
-      child: Padding(
-        padding: const EdgeInsets.only(left: Spacing.level4),
-        child: Column(
-          children: TestResultStatus.values
-              .map(
-                (status) => TestResultsFilterExpandable(
-                  statusToFilterBy: status,
-                  testExecutionId: testExecution.id,
-                ),
-              )
-              .toList(),
-        ),
-      ),
+      children: TestResultStatus.values
+          .map(
+            (status) => TestResultsFilterExpandable(
+              statusToFilterBy: status,
+              testExecutionId: testExecution.id,
+            ),
+          )
+          .toList(),
     );
   }
 }

--- a/frontend/lib/ui/artefact_dialog/test_execution_pop_over.dart
+++ b/frontend/lib/ui/artefact_dialog/test_execution_pop_over.dart
@@ -104,13 +104,16 @@ class TestExecutionPopOverState extends ConsumerState<TestExecutionPopOver> {
         ),
         const SizedBox(height: Spacing.level3),
         ElevatedButton(
-          onPressed: () => ref
-              .read(ArtefactBuildsProvider(widget.artefactId).notifier)
-              .changeReviewDecision(
-                widget.testExecution.id,
-                reviewCommentController.text,
-                reviewDecisions,
-              ),
+          onPressed: () {
+            ref
+                .read(ArtefactBuildsProvider(widget.artefactId).notifier)
+                .changeReviewDecision(
+                  widget.testExecution.id,
+                  reviewCommentController.text,
+                  reviewDecisions,
+                );
+            Navigator.pop(context);
+          },
           child: const Text('Submit Review'),
         ),
       ],

--- a/frontend/lib/ui/artefact_dialog/test_result_expandable.dart
+++ b/frontend/lib/ui/artefact_dialog/test_result_expandable.dart
@@ -11,9 +11,11 @@ class TestResultExpandable extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return YaruExpandable(
-      expandButtonPosition: YaruExpandableButtonPosition.start,
-      header: Row(
+    return ExpansionTile(
+      controlAffinity: ListTileControlAffinity.leading,
+      childrenPadding: const EdgeInsets.only(left: Spacing.level5),
+      shape: const Border(),
+      title: Row(
         children: [
           Text(testResult.name),
           const Spacer(),
@@ -22,28 +24,23 @@ class TestResultExpandable extends StatelessWidget {
           ),
         ],
       ),
-      child: Padding(
-        padding: const EdgeInsets.only(left: Spacing.level5),
-        child: Column(
-          children: [
-            if (testResult.category != '')
-              YaruTile(
-                title: const Text('Category'),
-                subtitle: Text(testResult.category),
-              ),
-            if (testResult.comment != '')
-              YaruTile(
-                title: const Text('Comment'),
-                subtitle: Text(testResult.comment),
-              ),
-            if (testResult.ioLog != '')
-              YaruTile(
-                title: const Text('IO Log'),
-                subtitle: Text(testResult.ioLog),
-              ),
-          ],
-        ),
-      ),
+      children: [
+        if (testResult.category != '')
+          YaruTile(
+            title: const Text('Category'),
+            subtitle: Text(testResult.category),
+          ),
+        if (testResult.comment != '')
+          YaruTile(
+            title: const Text('Comment'),
+            subtitle: Text(testResult.comment),
+          ),
+        if (testResult.ioLog != '')
+          YaruTile(
+            title: const Text('IO Log'),
+            subtitle: Text(testResult.ioLog),
+          ),
+      ],
     );
   }
 }

--- a/frontend/lib/ui/artefact_dialog/test_result_filter_expandable.dart
+++ b/frontend/lib/ui/artefact_dialog/test_result_filter_expandable.dart
@@ -41,24 +41,19 @@ class TestResultsFilterExpandable extends ConsumerWidget {
             .filter((testResult) => testResult.status == statusToFilterBy)
             .toList();
 
-        return YaruExpandable(
-          header: Text(
+        return ExpansionTile(
+          controlAffinity: ListTileControlAffinity.leading,
+          childrenPadding: const EdgeInsets.only(left: Spacing.level4),
+          shape: const Border(),
+          title: Text(
             '${statusToFilterBy.name} ${filteredTestResults.length}',
             style: headerStyle,
           ),
-          expandButtonPosition: YaruExpandableButtonPosition.start,
-          child: Padding(
-            padding: const EdgeInsets.only(left: Spacing.level4),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: filteredTestResults
-                  .map(
-                    (testResult) =>
-                        TestResultExpandable(testResult: testResult),
-                  )
-                  .toList(),
-            ),
-          ),
+          children: filteredTestResults
+              .map(
+                (testResult) => TestResultExpandable(testResult: testResult),
+              )
+              .toList(),
         );
       },
     );


### PR DESCRIPTION
Will hopefully improve the performance situation of TO frontend and resolve [RTW-213](https://warthogs.atlassian.net/browse/RTW-213).

Basically we use for all expandables in artefact dialog the widget [YaruExpandable](https://pub.dev/documentation/yaru_widgets/latest/yaru_widgets/YaruExpandable-class.html). Turns out this widget builds it's child immediately even if it wasn't expanded. That means all test results are needlessly fetched immediately when you open an artefact (nvm the ui overhead of actually running these build functions). Flutter's [ExpansionTile](https://api.flutter.dev/flutter/material/ExpansionTile-class.html) however doesn't build it's children unless they are expanded. So this PR mainly replaces all uses of `YaruExpandable` with `ExpansionTile`.

[Screencast from 2024-01-16 16-42-48.webm](https://github.com/canonical/test_observer/assets/4087200/f5a7b16d-5cc3-4f71-8fec-1a7769dda2fd)

Also added a small improvement to automatically close test execution review popover when the user clicks on submit.

[Screencast from 2024-01-16 16-59-01.webm](https://github.com/canonical/test_observer/assets/4087200/f5e7b203-f16f-44b4-bb40-c3cb1bbd2856)


[RTW-213]: https://warthogs.atlassian.net/browse/RTW-213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ