### PR TITLE
Trigger ci on workflow file change

### DIFF
--- a/.github/workflows/publish_api.yml
+++ b/.github/workflows/publish_api.yml
@@ -4,6 +4,7 @@ on:
     tags: ["v*.*.*"]
     paths:
       - 'backend/**'
+      - '.github/workflows/publish_api.yml'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/publish_frontend.yml
+++ b/.github/workflows/publish_frontend.yml
@@ -4,6 +4,7 @@ on:
     tags: ["v*.*.*"]
     paths:
       - 'frontend/**'
+      - '.github/workflows/publish_frontend.yml'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -5,6 +5,7 @@ on:
       - 'main'
     paths:
       - 'backend/**'
+      - '.github/workflows/test_backend.yml'
 # Cancel inprogress runs if new commit pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_frontend.yml
+++ b/.github/workflows/test_frontend.yml
@@ -5,6 +5,7 @@ on:
       - 'main'
     paths:
       - 'frontend/**'
+      - '.github/workflows/test_frontend.yml'
 # Cancel inprogress runs if new commit pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This is an improvement on a [previous PR](https://github.com/canonical/test_observer/pull/113) that skips unnecessary CI. Basically, we shouldn't skip CI if the workflow file itself changed.