### PR TITLE
Include c3 link in the request body of the end-test API endpoint

### DIFF
--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -99,6 +99,7 @@ class C3TestResult(BaseModel):
 class EndTestExecutionRequest(BaseModel):
     id: int
     ci_link: Annotated[str, HttpUrl]
+    c3_link: Annotated[str, HttpUrl] | None = None
     test_results: list[C3TestResult]
 
 

--- a/backend/test_observer/controllers/test_executions/test_executions.py
+++ b/backend/test_observer/controllers/test_executions/test_executions.py
@@ -141,6 +141,10 @@ def end_test_execution(request: EndTestExecutionRequest, db: Session = Depends(g
     delete_previous_results(db, test_execution)
     store_test_results(db, request.test_results, test_execution)
     test_execution.status = compute_test_execution_status(test_execution.test_results)
+
+    if request.c3_link is not None:
+        test_execution.c3_link = request.c3_link
+
     db.commit()
 
 

--- a/backend/tests/controllers/test_executions/test_test_executions.py
+++ b/backend/tests/controllers/test_executions/test_test_executions.py
@@ -228,6 +228,7 @@ def test_uses_existing_models(db_session: Session, test_client: TestClient):
 
 def test_report_test_execution_data(db_session: Session, test_client: TestClient):
     ci_link = "http://localhost"
+    c3_link = "http://c3.localhost"
     artefact = create_artefact(db_session, stage_name="beta")
     artefact_build = ArtefactBuild(architecture="some arch", artefact=artefact)
     environment = Environment(name="some environment", architecture="some arch")
@@ -243,6 +244,7 @@ def test_report_test_execution_data(db_session: Session, test_client: TestClient
         json={
             "id": 1,
             "ci_link": ci_link,
+            "c3_link": c3_link,
             "test_results": [
                 {
                     "id": 1,
@@ -266,6 +268,7 @@ def test_report_test_execution_data(db_session: Session, test_client: TestClient
 
     assert response.status_code == 200
     assert test_execution.status == TestExecutionStatus.PASSED
+    assert test_execution.c3_link == c3_link
     assert test_execution.test_results[0].test_case.name == "test-name-1"
     assert test_execution.test_results[0].status == TestResultStatus.PASSED
     assert test_execution.test_results[1].test_case.name == "test-name-2"


### PR DESCRIPTION
Currently to send the C3 link we make an additional PATCH request to the `/test-execution/ID` endpoint. This introduces some extra network overhead, which is not necessary, as we already have the communication from C3 to TO with the `end-test/ID` endpoint. It resolves [RTW-240](https://warthogs.atlassian.net/browse/RTW-240).

This implementation adds the C3 link as an optional parameter in the request body of the `end-test/ID/` endpoint. It is optional to ensure backwards compatibility with all clients making use of this API without sending the c3 link in the request body.

[RTW-240]: https://warthogs.atlassian.net/browse/RTW-240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ