### PR TITLE
Ignore old builds when validating if artefact status change is allowed

### DIFF
--- a/backend/test_observer/controllers/artefacts/logic.py
+++ b/backend/test_observer/controllers/artefacts/logic.py
@@ -1,4 +1,7 @@
-from test_observer.data_access.models import Artefact
+from itertools import groupby
+from operator import attrgetter
+
+from test_observer.data_access.models import Artefact, ArtefactBuild
 from test_observer.data_access.models_enums import TestExecutionReviewDecision
 
 
@@ -6,7 +9,7 @@ def are_all_test_executions_approved(artefact: Artefact) -> bool:
     return all(
         test_execution.review_decision
         and TestExecutionReviewDecision.REJECTED not in test_execution.review_decision
-        for build in artefact.builds
+        for build in _artefact_latest_builds(artefact)
         for test_execution in build.test_executions
     )
 
@@ -14,6 +17,16 @@ def are_all_test_executions_approved(artefact: Artefact) -> bool:
 def is_there_a_rejected_test_execution(artefact: Artefact) -> bool:
     return any(
         TestExecutionReviewDecision.REJECTED in test_execution.review_decision
-        for build in artefact.builds
+        for build in _artefact_latest_builds(artefact)
         for test_execution in build.test_executions
     )
+
+
+def _artefact_latest_builds(artefact: Artefact) -> list[ArtefactBuild]:
+    return [
+        max(group, key=attrgetter("revision"))
+        for _, group in groupby(
+            artefact.builds,
+            attrgetter("artefact_id", "architecture"),
+        )
+    ]


### PR DESCRIPTION
Hot fix for the issue discussed [here](https://chat.canonical.com/canonical/pl/ttrjdfmcdpbodeyomwxkpgsbcy). Basically, when checking if an artefact status change is allowed or not we shouldn't take into consideration old hidden builds.