### PR TITLE
Only consider latest builds when checking if signoff is allowed

### DIFF
--- a/backend/test_observer/controllers/artefacts/artefacts.py
+++ b/backend/test_observer/controllers/artefacts/artefacts.py
@@ -20,6 +20,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session, joinedload
 
+from test_observer.data_access import queries
 from test_observer.data_access.models import Artefact, ArtefactBuild
 from test_observer.data_access.models_enums import ArtefactStatus, FamilyName
 from test_observer.data_access.repository import get_artefacts_by_family
@@ -74,26 +75,31 @@ def get_artefact(artefact_id: int, db: Session = Depends(get_db)):
 def patch_artefact(
     artefact_id: int, request: ArtefactPatch, db: Session = Depends(get_db)
 ):
-    query_options = []
-    if request.status in {ArtefactStatus.APPROVED, ArtefactStatus.MARKED_AS_FAILED}:
-        # Load test executions as we need to check them
-        query_options.append(
-            joinedload(Artefact.builds).joinedload(ArtefactBuild.test_executions),
-        )
-    artefact = db.get(Artefact, artefact_id, options=query_options)
-    if artefact is None:
+    artefact = db.get(Artefact, artefact_id)
+
+    if not artefact:
         raise HTTPException(status_code=404, detail="Artefact not found")
 
-    _validate_artefact_status(artefact, request.status)
+    latest_builds = list(
+        db.scalars(
+            queries.latest_artefact_builds.where(
+                ArtefactBuild.artefact_id == artefact_id
+            ).options(joinedload(ArtefactBuild.test_executions))
+        )
+    )
+
+    _validate_artefact_status(latest_builds, request.status)
 
     artefact.status = request.status
     db.commit()
     return artefact
 
 
-def _validate_artefact_status(artefact: Artefact, status: ArtefactStatus) -> None:
+def _validate_artefact_status(
+    builds: list[ArtefactBuild], status: ArtefactStatus
+) -> None:
     if status == ArtefactStatus.APPROVED and not are_all_test_executions_approved(
-        artefact
+        builds
     ):
         raise HTTPException(
             status_code=400,
@@ -102,7 +108,7 @@ def _validate_artefact_status(artefact: Artefact, status: ArtefactStatus) -> Non
 
     if (
         status == ArtefactStatus.MARKED_AS_FAILED
-        and not is_there_a_rejected_test_execution(artefact)
+        and not is_there_a_rejected_test_execution(builds)
     ):
         raise HTTPException(
             400,
@@ -113,17 +119,17 @@ def _validate_artefact_status(artefact: Artefact, status: ArtefactStatus) -> Non
 @router.get("/{artefact_id}/builds", response_model=list[ArtefactBuildDTO])
 def get_artefact_builds(artefact_id: int, db: Session = Depends(get_db)):
     """Get latest artefact builds of an artefact together with their test executions"""
-    artefact_builds = (
-        db.query(ArtefactBuild)
-        .filter(ArtefactBuild.artefact_id == artefact_id)
-        .distinct(ArtefactBuild.architecture)
-        .order_by(ArtefactBuild.architecture, ArtefactBuild.revision.desc())
-        .all()
+    latest_builds = list(
+        db.scalars(
+            queries.latest_artefact_builds.where(
+                ArtefactBuild.artefact_id == artefact_id
+            ).options(joinedload(ArtefactBuild.test_executions))
+        )
     )
 
-    for artefact_build in artefact_builds:
+    for artefact_build in latest_builds:
         artefact_build.test_executions.sort(
             key=lambda test_execution: test_execution.id
         )
 
-    return artefact_builds
+    return latest_builds

--- a/backend/test_observer/controllers/artefacts/artefacts.py
+++ b/backend/test_observer/controllers/artefacts/artefacts.py
@@ -18,6 +18,7 @@
 #        Omar Selo <omar.selo@canonical.com>
 #        Nadzeya Hutsko <nadzeya.hutsko@canonical.com>
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
 from sqlalchemy.orm import Session, joinedload
 
 from test_observer.data_access import queries
@@ -85,7 +86,7 @@ def patch_artefact(
             queries.latest_artefact_builds.where(
                 ArtefactBuild.artefact_id == artefact_id
             ).options(joinedload(ArtefactBuild.test_executions))
-        )
+        ).unique()
     )
 
     _validate_artefact_status(latest_builds, request.status)
@@ -124,7 +125,7 @@ def get_artefact_builds(artefact_id: int, db: Session = Depends(get_db)):
             queries.latest_artefact_builds.where(
                 ArtefactBuild.artefact_id == artefact_id
             ).options(joinedload(ArtefactBuild.test_executions))
-        )
+        ).unique()
     )
 
     for artefact_build in latest_builds:

--- a/backend/test_observer/controllers/artefacts/artefacts.py
+++ b/backend/test_observer/controllers/artefacts/artefacts.py
@@ -18,7 +18,6 @@
 #        Omar Selo <omar.selo@canonical.com>
 #        Nadzeya Hutsko <nadzeya.hutsko@canonical.com>
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
 from sqlalchemy.orm import Session, joinedload
 
 from test_observer.data_access import queries

--- a/backend/test_observer/controllers/artefacts/logic.py
+++ b/backend/test_observer/controllers/artefacts/logic.py
@@ -1,32 +1,19 @@
-from itertools import groupby
-from operator import attrgetter
-
-from test_observer.data_access.models import Artefact, ArtefactBuild
+from test_observer.data_access.models import ArtefactBuild
 from test_observer.data_access.models_enums import TestExecutionReviewDecision
 
 
-def are_all_test_executions_approved(artefact: Artefact) -> bool:
+def are_all_test_executions_approved(builds: list[ArtefactBuild]) -> bool:
     return all(
         test_execution.review_decision
         and TestExecutionReviewDecision.REJECTED not in test_execution.review_decision
-        for build in _artefact_latest_builds(artefact)
+        for build in builds
         for test_execution in build.test_executions
     )
 
 
-def is_there_a_rejected_test_execution(artefact: Artefact) -> bool:
+def is_there_a_rejected_test_execution(builds: list[ArtefactBuild]) -> bool:
     return any(
         TestExecutionReviewDecision.REJECTED in test_execution.review_decision
-        for build in _artefact_latest_builds(artefact)
+        for build in builds
         for test_execution in build.test_executions
     )
-
-
-def _artefact_latest_builds(artefact: Artefact) -> list[ArtefactBuild]:
-    return [
-        max(group, key=attrgetter("revision"))
-        for _, group in groupby(
-            artefact.builds,
-            attrgetter("artefact_id", "architecture"),
-        )
-    ]

--- a/backend/test_observer/controllers/promoter/promoter.py
+++ b/backend/test_observer/controllers/promoter/promoter.py
@@ -25,7 +25,8 @@ from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
-from test_observer.data_access.models import Artefact
+from test_observer.data_access import queries
+from test_observer.data_access.models import Artefact, ArtefactBuild
 from test_observer.data_access.models_enums import FamilyName
 from test_observer.data_access.repository import (
     get_artefacts_by_family,
@@ -126,7 +127,11 @@ def run_snap_promoter(session: Session, artefact: Artefact) -> None:
     store = artefact.store
     assert store is not None, f"Store is not set for the artefact {artefact.id}"
 
-    for build in artefact.builds:
+    latest_builds = session.scalars(
+        queries.latest_artefact_builds.where(ArtefactBuild.artefact_id == artefact.id)
+    )
+
+    for build in latest_builds:
         arch = build.architecture
         channel_map = get_channel_map_from_snapcraft(
             arch=arch,
@@ -182,8 +187,9 @@ def run_deb_promoter(session: Session, artefact: Artefact) -> None:
     assert series is not None, f"Series is not set for the artefact {artefact.id}"
     assert repo is not None, f"Repo is not set for the artefact {artefact.id}"
 
-    for build in artefact.builds:
-        arch = build.architecture
+    architectures = session.scalars(queries.artefact_architectures(artefact.id))
+
+    for arch in architectures:
         for pocket in POCKET_PROMOTION_MAP:
             with ArchiveManager(
                 arch=arch,

--- a/backend/test_observer/controllers/reports/reports.py
+++ b/backend/test_observer/controllers/reports/reports.py
@@ -7,9 +7,9 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 
+from test_observer.data_access import queries
 from test_observer.data_access.models import (
     Artefact,
-    ArtefactBuild,
     Environment,
     Family,
     Stage,
@@ -53,12 +53,7 @@ def get_testresults_report(
     if end_date is None:
         end_date = datetime.now()
 
-    latest_builds = (
-        select(ArtefactBuild)
-        .distinct(ArtefactBuild.artefact_id, ArtefactBuild.architecture)
-        .order_by(ArtefactBuild.artefact_id, ArtefactBuild.architecture)
-        .subquery()
-    )
+    latest_builds = queries.latest_artefact_builds.subquery()
 
     cursor = db.execute(
         select(*TESTRESULTS_REPORT_COLUMNS)

--- a/backend/test_observer/data_access/queries.py
+++ b/backend/test_observer/data_access/queries.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Select, select
+
+from test_observer.data_access.models import ArtefactBuild
+
+latest_artefact_builds = (
+    select(ArtefactBuild)
+    .distinct(ArtefactBuild.artefact_id, ArtefactBuild.architecture)
+    .order_by(ArtefactBuild.artefact_id, ArtefactBuild.architecture)
+)
+
+
+def artefact_architectures(artefact_id: int) -> Select[tuple[str]]:
+    return (
+        select(ArtefactBuild.architecture)
+        .distinct()
+        .where(ArtefactBuild.id == artefact_id)
+    )

--- a/backend/test_observer/data_access/queries.py
+++ b/backend/test_observer/data_access/queries.py
@@ -5,7 +5,11 @@ from test_observer.data_access.models import ArtefactBuild
 latest_artefact_builds = (
     select(ArtefactBuild)
     .distinct(ArtefactBuild.artefact_id, ArtefactBuild.architecture)
-    .order_by(ArtefactBuild.artefact_id, ArtefactBuild.architecture)
+    .order_by(
+        ArtefactBuild.artefact_id,
+        ArtefactBuild.architecture,
+        ArtefactBuild.revision.desc(),
+    )
 )
 
 

--- a/backend/tests/controllers/promoter/test_promoter.py
+++ b/backend/tests/controllers/promoter/test_promoter.py
@@ -83,7 +83,7 @@ def test_run_to_move_artefact_snap(
                         "size": 130830336,
                         "url": "https://api.snapcraft.io/api/v1/snaps/download/...",
                     },
-                    "revision": artefact.builds[0].revision,
+                    "revision": artefact.builds[1].revision,
                     "type": "app",
                     "version": "1.1.1",
                 },


### PR DESCRIPTION
Looks like the previous [PR](https://github.com/canonical/test_observer/pull/129) to fix the issue of "when checking if an artefact status change is allowed or not we shouldn't take into consideration old hidden builds." doesn't work. Main reason is that turns out `itertools.groupby` requires input to be sorted. This PR should fix the issue, and I've consolidated this logic in one place.