### PR TITLE
Kernel sru integration

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -27,7 +27,7 @@ Linting is done using ruff, formatting using black and type checking using mypy.
 
 ### 4. Start the development environment
 
-Assuming that your microk8s cluster is running, you can start the development environment by simply running `$ skaffold dev`. This command will build the docker images and push them to your microk8s registry, then apply your k8s manifest to start the cluster and pull those images. Additionally, skaffold will watch for file changes and either sync them directly inside the running containers or rebuild and redeploy k8s cluster for you automatically.
+Assuming that your microk8s cluster is running, you can start the development environment by simply running `$ skaffold dev --no-prune=false --cache-artifacts=false`. This command will build the docker images and push them to your microk8s registry, then apply your k8s manifest to start the cluster and pull those images. Additionally, skaffold will watch for file changes and either sync them directly inside the running containers or rebuild and redeploy k8s cluster for you automatically.
 
 ### 5. [Optional] seed the database
 
@@ -75,7 +75,7 @@ Since the database is in microk8s cluster, migrations have to be applied inside 
 
 ## Tests
 
-To run the tests, first make sure that you're running `skaffold dev` or `skaffold run`. Then execute the pytest command in the API pod:
+To run the tests, first make sure that you're running skaffold. Then execute the pytest command in the API pod:
 
 `$ kubectl exec -it service/test-observer-api -- pytest`
 

--- a/backend/migrations/versions/2024_02_29_0759-ae281506fe32_add_artefact_bug_link.py
+++ b/backend/migrations/versions/2024_02_29_0759-ae281506fe32_add_artefact_bug_link.py
@@ -1,0 +1,24 @@
+"""Add artefact bug link
+
+Revision ID: ae281506fe32
+Revises: 654e57018d35
+Create Date: 2024-02-29 07:59:37.397014+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "ae281506fe32"
+down_revision = "654e57018d35"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("artefact", sa.Column("bug_link", sa.String(), nullable=False))
+
+
+def downgrade() -> None:
+    op.drop_column("artefact", "bug_link")

--- a/backend/tasks/celery.py
+++ b/backend/tasks/celery.py
@@ -1,11 +1,32 @@
+import logging
 from os import environ
 
 from celery import Celery
+
+from test_observer.data_access.setup import SessionLocal
+from test_observer.kernel_swm_integration.swm_integrator import (
+    update_artefacts_with_tracker_info,
+)
+from test_observer.kernel_swm_integration.swm_reader import get_artefacts_swm_info
 
 DEVELOPMENT_BROKER_URL = "redis://test-observer-redis"
 broker_url = environ.get("CELERY_BROKER_URL", DEVELOPMENT_BROKER_URL)
 
 app = Celery("tasks", broker=broker_url)
+
+logger = logging.getLogger(__name__)
+
+
+@app.on_after_configure.connect
+def setup_periodic_tasks(sender, **kwargs):  # noqa
+    sender.add_periodic_task(300, integrate_with_kernel_swm.s())
+
+
+@app.task
+def integrate_with_kernel_swm():
+    swm_info = get_artefacts_swm_info()
+    update_artefacts_with_tracker_info(SessionLocal(), swm_info)
+
 
 if __name__ == "__main__":
     app.start()

--- a/backend/tasks/celery.py
+++ b/backend/tasks/celery.py
@@ -24,8 +24,9 @@ def setup_periodic_tasks(sender, **kwargs):  # noqa
 
 @app.task
 def integrate_with_kernel_swm():
-    swm_info = get_artefacts_swm_info()
-    update_artefacts_with_tracker_info(SessionLocal(), swm_info)
+    db = SessionLocal()
+    swm_info = get_artefacts_swm_info(db)
+    update_artefacts_with_tracker_info(db, swm_info)
 
 
 if __name__ == "__main__":

--- a/backend/test_observer/controllers/artefacts/models.py
+++ b/backend/test_observer/controllers/artefacts/models.py
@@ -17,6 +17,8 @@
 # Written by:
 #        Omar Selo <omar.selo@canonical.com>
 #        Nadzeya Hutsko <nadzeya.hutsko@canonical.com>
+from datetime import date
+
 from pydantic import AliasPath, BaseModel, ConfigDict, Field
 
 from test_observer.data_access.models_enums import (
@@ -46,6 +48,8 @@ class ArtefactDTO(BaseModel):
     stage: str = Field(validation_alias=AliasPath("stage", "name"))
     status: ArtefactStatus
     assignee: UserDTO | None
+    due_date: date | None
+    bug_link: str
 
 
 class EnvironmentDTO(BaseModel):

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -150,6 +150,7 @@ class Artefact(Base):
     # Default fields
     due_date: Mapped[date | None]
     status: Mapped[ArtefactStatus] = mapped_column(default=ArtefactStatus.UNDECIDED)
+    bug_link: Mapped[str] = mapped_column(default="")
 
     __table_args__ = (
         Index(

--- a/backend/test_observer/kernel_swm_integration/swm_integrator.py
+++ b/backend/test_observer/kernel_swm_integration/swm_integrator.py
@@ -1,0 +1,24 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from test_observer.data_access.models import Artefact
+
+from .swm_reader import ArtefactTrackerInfo
+
+
+def update_artefacts_with_tracker_info(
+    db: Session, artefacts_tracker_info: dict[int, ArtefactTrackerInfo]
+):
+    stmt = select(Artefact).where(Artefact.id.in_(artefacts_tracker_info.keys()))
+    artefacts = db.scalars(stmt)
+
+    for artefact in artefacts:
+        tracker_info = artefacts_tracker_info[artefact.id]
+        artefact.due_date = tracker_info["due_date"]
+        artefact.bug_link = _get_bug_link(tracker_info["bug_id"])
+
+    db.commit()
+
+
+def _get_bug_link(bug_id: str) -> str:
+    return f"https://bugs.launchpad.net/kernel-sru-workflow/+bug/{bug_id}"

--- a/backend/test_observer/kernel_swm_integration/swm_reader.py
+++ b/backend/test_observer/kernel_swm_integration/swm_reader.py
@@ -1,0 +1,56 @@
+from datetime import date, datetime
+from typing import TypedDict
+
+import requests
+
+
+class ArtefactTrackerInfo(TypedDict):
+    bug_id: str
+    due_date: date | None
+
+
+def get_artefacts_swm_info() -> dict[int, ArtefactTrackerInfo]:
+    json = _fetch_stable_workflow_manager_status()
+    return _extract_artefact_bug_info_from_swm(json)
+
+
+def _fetch_stable_workflow_manager_status() -> dict:
+    url = "https://kernel.ubuntu.com/swm/status.json"
+    return requests.get(url).json()
+
+
+def _extract_artefact_bug_info_from_swm(json: dict) -> dict[int, ArtefactTrackerInfo]:
+    result: dict[int, ArtefactTrackerInfo] = {}
+    for bug_id, tracker in json["trackers"].items():
+        artefact_id = _extract_artefact_id(tracker)
+
+        if artefact_id and _is_tracker_open(tracker):
+            result[artefact_id] = {
+                "bug_id": bug_id,
+                "due_date": _extract_due_date(tracker),
+            }
+
+    return result
+
+
+def _is_tracker_open(tracker: dict) -> bool:
+    closed_statuses = ("Fix Committed", "Fix Released")
+    status = tracker.get("task", {}).get("kernel-sru-workflow", {}).get("status")
+    return status not in closed_statuses
+
+
+def _extract_artefact_id(tracker: dict) -> int | None:
+    to_info = tracker.get("test-observer")
+    if to_info:
+        possible_keys = ("edge", "beta", "candidate", "stable", "proposed", "updates")
+        for key in possible_keys:
+            if key in to_info:
+                return to_info[key]
+    return None
+
+
+def _extract_due_date(tracker: dict) -> date | None:
+    date_string = tracker.get("test-observer", {}).get("due-date")
+    if date_string:
+        return datetime.strptime(date_string, "%Y-%m-%d").date()
+    return None

--- a/backend/test_observer/kernel_swm_integration/swm_reader.py
+++ b/backend/test_observer/kernel_swm_integration/swm_reader.py
@@ -36,7 +36,7 @@ def _extract_artefact_bug_info_from_swm(json: dict) -> dict[int, ArtefactTracker
 def _is_tracker_open(tracker: dict) -> bool:
     closed_statuses = ("Fix Committed", "Fix Released")
     status = tracker.get("task", {}).get("kernel-sru-workflow", {}).get("status")
-    return status not in closed_statuses
+    return status and status not in closed_statuses
 
 
 def _extract_artefact_id(tracker: dict) -> int | None:

--- a/backend/test_observer/kernel_swm_integration/swm_reader.py
+++ b/backend/test_observer/kernel_swm_integration/swm_reader.py
@@ -2,6 +2,10 @@ from datetime import date, datetime
 from typing import TypedDict
 
 import requests
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from test_observer.data_access.models import Stage
 
 
 class ArtefactTrackerInfo(TypedDict):
@@ -9,9 +13,9 @@ class ArtefactTrackerInfo(TypedDict):
     due_date: date | None
 
 
-def get_artefacts_swm_info() -> dict[int, ArtefactTrackerInfo]:
+def get_artefacts_swm_info(db: Session) -> dict[int, ArtefactTrackerInfo]:
     json = _fetch_stable_workflow_manager_status()
-    return _extract_artefact_bug_info_from_swm(json)
+    return _extract_artefact_bug_info_from_swm(json, db)
 
 
 def _fetch_stable_workflow_manager_status() -> dict:
@@ -19,10 +23,13 @@ def _fetch_stable_workflow_manager_status() -> dict:
     return requests.get(url).json()
 
 
-def _extract_artefact_bug_info_from_swm(json: dict) -> dict[int, ArtefactTrackerInfo]:
+def _extract_artefact_bug_info_from_swm(
+    json: dict, db: Session
+) -> dict[int, ArtefactTrackerInfo]:
     result: dict[int, ArtefactTrackerInfo] = {}
+    stage_names = _get_stage_names(db)
     for bug_id, tracker in json["trackers"].items():
-        artefact_id = _extract_artefact_id(tracker)
+        artefact_id = _extract_artefact_id(tracker, stage_names)
 
         if artefact_id and _is_tracker_open(tracker):
             result[artefact_id] = {
@@ -33,19 +40,22 @@ def _extract_artefact_bug_info_from_swm(json: dict) -> dict[int, ArtefactTracker
     return result
 
 
+def _get_stage_names(db: Session) -> list[str]:
+    return list(db.scalars(select(Stage.name)))
+
+
 def _is_tracker_open(tracker: dict) -> bool:
     closed_statuses = ("Fix Committed", "Fix Released")
     status = tracker.get("task", {}).get("kernel-sru-workflow", {}).get("status")
     return status and status not in closed_statuses
 
 
-def _extract_artefact_id(tracker: dict) -> int | None:
+def _extract_artefact_id(tracker: dict, stage_names: list[str]) -> int | None:
     to_info = tracker.get("test-observer")
     if to_info:
-        possible_keys = ("edge", "beta", "candidate", "stable", "proposed", "updates")
-        for key in possible_keys:
-            if key in to_info:
-                return to_info[key]
+        for stages in stage_names:
+            if stages in to_info:
+                return to_info[stages]
     return None
 
 

--- a/backend/tests/controllers/artefacts/test_artefacts.py
+++ b/backend/tests/controllers/artefacts/test_artefacts.py
@@ -17,7 +17,7 @@
 # Written by:
 #        Omar Selo <omar.selo@canonical.com>
 #        Nadzeya Hutsko <nadzeya.hutsko@canonical.com>
-from datetime import timedelta
+from datetime import date, timedelta
 
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -63,6 +63,8 @@ def test_get_latest_artefacts_by_family(
             "stage": relevant_artefact.stage.name,
             "status": relevant_artefact.status,
             "assignee": None,
+            "due_date": None,
+            "bug_link": "",
         }
     ]
 
@@ -73,6 +75,8 @@ def test_get_artefact(
     """Should be able to fetch an existing artefact"""
     artefact = generator.gen_artefact("edge", status=ArtefactStatus.APPROVED)
     artefact.assignee = generator.gen_user()
+    artefact.bug_link = "localhost/bug"
+    artefact.due_date = date(2024, 12, 24)
     db_session.commit()
 
     response = test_client.get(f"/v1/artefacts/{artefact.id}")
@@ -94,6 +98,8 @@ def test_get_artefact(
             "launchpad_email": artefact.assignee.launchpad_email,
             "name": artefact.assignee.name,
         },
+        "due_date": "2024-12-24",
+        "bug_link": artefact.bug_link,
     }
 
 
@@ -183,6 +189,8 @@ def test_artefact_signoff_approve(
         "stage": artefact.stage.name,
         "status": artefact.status,
         "assignee": None,
+        "due_date": None,
+        "bug_link": "",
     }
 
 

--- a/backend/tests/kernel_swm_integration/test_swm_integrator.py
+++ b/backend/tests/kernel_swm_integration/test_swm_integrator.py
@@ -1,0 +1,38 @@
+from datetime import date
+
+from sqlalchemy.orm import Session
+
+from test_observer.kernel_swm_integration.swm_integrator import (
+    update_artefacts_with_tracker_info,
+)
+from test_observer.kernel_swm_integration.swm_reader import ArtefactTrackerInfo
+from tests.data_generator import DataGenerator
+
+
+def test_update_artefacts_with_tracker_info(
+    db_session: Session, generator: DataGenerator
+):
+    tracker_info_1: ArtefactTrackerInfo = {
+        "bug_id": "1111111",
+        "due_date": date(2024, 2, 28),
+    }
+    tracker_info_2: ArtefactTrackerInfo = {
+        "bug_id": "2222222",
+        "due_date": date(2024, 2, 20),
+    }
+    artefact1 = generator.gen_artefact("beta")
+    artefact2 = generator.gen_artefact("proposed")
+    artefacts_swm_info = {artefact2.id: tracker_info_2, artefact1.id: tracker_info_1}
+
+    update_artefacts_with_tracker_info(db_session, artefacts_swm_info)
+
+    assert (
+        artefact1.bug_link
+        == f"https://bugs.launchpad.net/kernel-sru-workflow/+bug/{tracker_info_1['bug_id']}"
+    )
+    assert artefact1.due_date == tracker_info_1["due_date"]
+    assert (
+        artefact2.bug_link
+        == f"https://bugs.launchpad.net/kernel-sru-workflow/+bug/{tracker_info_2['bug_id']}"
+    )
+    assert artefact2.due_date == tracker_info_2["due_date"]

--- a/backend/tests/kernel_swm_integration/test_swm_reader.py
+++ b/backend/tests/kernel_swm_integration/test_swm_reader.py
@@ -16,7 +16,12 @@ def test_get_artefacts_swm_info(requests_mock: Mocker):
                     "test-observer": {
                         "beta": artefact_id,
                         "due-date": "2024-02-28",
-                    }
+                    },
+                    "task": {
+                        "kernel-sru-workflow": {
+                            "status": "In Progress",
+                        }
+                    },
                 }
             }
         },

--- a/backend/tests/kernel_swm_integration/test_swm_reader.py
+++ b/backend/tests/kernel_swm_integration/test_swm_reader.py
@@ -1,0 +1,32 @@
+from datetime import date
+
+from requests_mock import Mocker
+
+from test_observer.kernel_swm_integration.swm_reader import get_artefacts_swm_info
+
+
+def test_get_artefacts_swm_info(requests_mock: Mocker):
+    bug_id = "2052085"
+    artefact_id = 22996
+    requests_mock.get(
+        "https://kernel.ubuntu.com/swm/status.json",
+        json={
+            "trackers": {
+                bug_id: {
+                    "test-observer": {
+                        "beta": artefact_id,
+                        "due-date": "2024-02-28",
+                    }
+                }
+            }
+        },
+    )
+
+    artefacts_swm_info = get_artefacts_swm_info()
+
+    assert artefacts_swm_info == {
+        artefact_id: {
+            "bug_id": bug_id,
+            "due_date": date(2024, 2, 28),
+        }
+    }

--- a/backend/tests/kernel_swm_integration/test_swm_reader.py
+++ b/backend/tests/kernel_swm_integration/test_swm_reader.py
@@ -1,11 +1,12 @@
 from datetime import date
 
 from requests_mock import Mocker
+from sqlalchemy.orm import Session
 
 from test_observer.kernel_swm_integration.swm_reader import get_artefacts_swm_info
 
 
-def test_get_artefacts_swm_info(requests_mock: Mocker):
+def test_get_artefacts_swm_info(requests_mock: Mocker, db_session: Session):
     bug_id = "2052085"
     artefact_id = 22996
     requests_mock.get(
@@ -27,7 +28,7 @@ def test_get_artefacts_swm_info(requests_mock: Mocker):
         },
     )
 
-    artefacts_swm_info = get_artefacts_swm_info()
+    artefacts_swm_info = get_artefacts_swm_info(db_session)
 
     assert artefacts_swm_info == {
         artefact_id: {


### PR DESCRIPTION
Resolves the backend part of [RTW-211](https://warthogs.atlassian.net/browse/RTW-211).

Changes:
- Add bug link field to artefact
- Add logic to integrate with kernel swm. This is now different from how it worked [before](https://github.com/canonical/certification-dashboard-manager/blob/main/dashboard_manager/core/kernel_sru_sync.py). Namely, the swm json now references our artefact id and also includes due date. So we just get it from them. These additions were thanks to Andy Whitcroft from the kernel team.
- Add a celery task that periodically does this integration every 5 minutes.
- Return from api bug link and due date.

Testing:
- Apart from unit tests, I've also tested that the job does run periodically and update bug link and due date.

[RTW-211]: https://warthogs.atlassian.net/browse/RTW-211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ