### PR TITLE
Fix deb artefact page colors

### DIFF
--- a/frontend/lib/routing.dart
+++ b/frontend/lib/routing.dart
@@ -40,8 +40,8 @@ final appRouter = GoRouter(
         ),
         GoRoute(
           path: '${AppRoutes.debs}/:artefactId',
-          pageBuilder: (context, state) => DialogPage(
-            builder: (_) => ArtefactPage(
+          pageBuilder: (context, state) => NoTransitionPage(
+            child: ArtefactPage(
               artefactId: int.parse(state.pathParameters['artefactId']!),
             ),
           ),

--- a/frontend/lib/routing.dart
+++ b/frontend/lib/routing.dart
@@ -4,7 +4,6 @@ import 'package:go_router/go_router.dart';
 import 'models/family_name.dart';
 import 'ui/artefact_page/artefact_page.dart';
 import 'ui/dashboard/dashboard.dart';
-import 'ui/dialog_page.dart';
 import 'ui/skeleton.dart';
 
 final appRouter = GoRouter(


### PR DESCRIPTION
Hotfix for last deployment that broke colors on deb page:
![image](https://github.com/canonical/test_observer/assets/4087200/d056aade-2285-4633-bef8-8fac475dc48a)
