### PR TITLE
Show text message when test results are not available

### DIFF
--- a/frontend/lib/models/test_execution.dart
+++ b/frontend/lib/models/test_execution.dart
@@ -51,6 +51,18 @@ enum TestExecutionStatus {
   @JsonValue('PASSED')
   passed;
 
+  bool get isCompleted {
+    switch (this) {
+      case notStarted:
+      case inProgress:
+      case notTested:
+        return false;
+      case passed:
+      case failed:
+        return true;
+    }
+  }
+
   String get name {
     switch (this) {
       case notStarted:

--- a/frontend/lib/ui/artefact_page/test_execution_expandable.dart
+++ b/frontend/lib/ui/artefact_page/test_execution_expandable.dart
@@ -50,14 +50,27 @@ class TestExecutionExpandable extends ConsumerWidget {
           ),
         ],
       ),
-      children: TestResultStatus.values
-          .map(
-            (status) => TestResultsFilterExpandable(
-              statusToFilterBy: status,
-              testExecutionId: testExecution.id,
-            ),
-          )
-          .toList(),
+      children: (!testExecution.status.isCompleted)
+          ? [
+              Align(
+                alignment: Alignment.topLeft,
+                child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Text(
+                    'This test execution is not completed. No test results are available yet.',
+                    style: Theme.of(context).textTheme.bodyLarge,
+                  ),
+                ),
+              ),
+            ]
+          : TestResultStatus.values
+              .map(
+                (status) => TestResultsFilterExpandable(
+                  statusToFilterBy: status,
+                  testExecutionId: testExecution.id,
+                ),
+              )
+              .toList(),
     );
   }
 }

--- a/frontend/lib/ui/artefact_page/test_execution_expandable.dart
+++ b/frontend/lib/ui/artefact_page/test_execution_expandable.dart
@@ -13,64 +13,64 @@ class TestExecutionExpandable extends ConsumerWidget {
 
   final TestExecution testExecution;
 
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Row getTestExecutionTitle(BuildContext context) {
     final ciLink = testExecution.ciLink;
     final c3Link = testExecution.c3Link;
+
+    return Row(
+      children: [
+        if (!testExecution.status.isCompleted) const SizedBox(width: 36.0),
+        testExecution.status.icon,
+        const SizedBox(width: Spacing.level4),
+        Text(
+          testExecution.environment.name,
+          style: Theme.of(context).textTheme.titleLarge,
+        ),
+        const Spacer(),
+        Row(
+          children: [
+            TestExecutionReviewButton(testExecution: testExecution),
+            const SizedBox(width: Spacing.level4),
+            if (ciLink != null)
+              InlineUrlText(
+                url: ciLink,
+                urlText: 'CI',
+              ),
+            const SizedBox(width: Spacing.level3),
+            if (c3Link != null)
+              InlineUrlText(
+                url: c3Link,
+                urlText: 'C3',
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!testExecution.status.isCompleted) {
+      return ListTile(
+        onTap: () {},
+        shape: const Border(),
+        title: getTestExecutionTitle(context),
+      );
+    }
 
     return ExpansionTile(
       controlAffinity: ListTileControlAffinity.leading,
       childrenPadding: const EdgeInsets.only(left: Spacing.level4),
       shape: const Border(),
-      title: Row(
-        children: [
-          testExecution.status.icon,
-          const SizedBox(width: Spacing.level4),
-          Text(
-            testExecution.environment.name,
-            style: Theme.of(context).textTheme.titleLarge,
-          ),
-          const Spacer(),
-          Row(
-            children: [
-              TestExecutionReviewButton(testExecution: testExecution),
-              const SizedBox(width: Spacing.level4),
-              if (ciLink != null)
-                InlineUrlText(
-                  url: ciLink,
-                  urlText: 'CI',
-                ),
-              const SizedBox(width: Spacing.level3),
-              if (c3Link != null)
-                InlineUrlText(
-                  url: c3Link,
-                  urlText: 'C3',
-                ),
-            ],
-          ),
-        ],
-      ),
-      children: (testExecution.status.isCompleted)
-          ? TestResultStatus.values
-              .map(
-                (status) => TestResultsFilterExpandable(
-                  statusToFilterBy: status,
-                  testExecutionId: testExecution.id,
-                ),
-              )
-              .toList()
-          : [
-              Align(
-                alignment: Alignment.topLeft,
-                child: Padding(
-                  padding: const EdgeInsets.all(8.0),
-                  child: Text(
-                    'This test execution is not completed. No test results are available yet.',
-                    style: Theme.of(context).textTheme.bodyLarge,
-                  ),
-                ),
-              ),
-            ],
+      title: getTestExecutionTitle(context),
+      children: TestResultStatus.values
+          .map(
+            (status) => TestResultsFilterExpandable(
+              statusToFilterBy: status,
+              testExecutionId: testExecution.id,
+            ),
+          )
+          .toList(),
     );
   }
 }

--- a/frontend/lib/ui/artefact_page/test_execution_expandable.dart
+++ b/frontend/lib/ui/artefact_page/test_execution_expandable.dart
@@ -50,8 +50,16 @@ class TestExecutionExpandable extends ConsumerWidget {
           ),
         ],
       ),
-      children: (!testExecution.status.isCompleted)
-          ? [
+      children: (testExecution.status.isCompleted)
+          ? TestResultStatus.values
+              .map(
+                (status) => TestResultsFilterExpandable(
+                  statusToFilterBy: status,
+                  testExecutionId: testExecution.id,
+                ),
+              )
+              .toList()
+          : [
               Align(
                 alignment: Alignment.topLeft,
                 child: Padding(
@@ -62,15 +70,7 @@ class TestExecutionExpandable extends ConsumerWidget {
                   ),
                 ),
               ),
-            ]
-          : TestResultStatus.values
-              .map(
-                (status) => TestResultsFilterExpandable(
-                  statusToFilterBy: status,
-                  testExecutionId: testExecution.id,
-                ),
-              )
-              .toList(),
+            ],
     );
   }
 }

--- a/frontend/lib/ui/artefact_page/test_execution_expandable.dart
+++ b/frontend/lib/ui/artefact_page/test_execution_expandable.dart
@@ -8,12 +8,13 @@ import '../spacing.dart';
 import 'test_execution_review.dart';
 import 'test_result_filter_expandable.dart';
 
-class TestExecutionExpandable extends ConsumerWidget {
-  const TestExecutionExpandable({super.key, required this.testExecution});
+class _TestExecutionTileTitle extends StatelessWidget {
+  const _TestExecutionTileTitle({required this.testExecution});
 
   final TestExecution testExecution;
 
-  Row getTestExecutionTileTitle(BuildContext context) {
+  @override
+  Widget build(BuildContext context) {
     final ciLink = testExecution.ciLink;
     final c3Link = testExecution.c3Link;
 
@@ -27,26 +28,28 @@ class TestExecutionExpandable extends ConsumerWidget {
           style: Theme.of(context).textTheme.titleLarge,
         ),
         const Spacer(),
-        Row(
-          children: [
-            TestExecutionReviewButton(testExecution: testExecution),
-            const SizedBox(width: Spacing.level4),
-            if (ciLink != null)
-              InlineUrlText(
-                url: ciLink,
-                urlText: 'CI',
-              ),
-            const SizedBox(width: Spacing.level3),
-            if (c3Link != null)
-              InlineUrlText(
-                url: c3Link,
-                urlText: 'C3',
-              ),
-          ],
-        ),
+        TestExecutionReviewButton(testExecution: testExecution),
+        const SizedBox(width: Spacing.level4),
+        if (ciLink != null)
+          InlineUrlText(
+            url: ciLink,
+            urlText: 'CI',
+          ),
+        const SizedBox(width: Spacing.level3),
+        if (c3Link != null)
+          InlineUrlText(
+            url: c3Link,
+            urlText: 'C3',
+          ),
       ],
     );
   }
+}
+
+class TestExecutionExpandable extends ConsumerWidget {
+  const TestExecutionExpandable({super.key, required this.testExecution});
+
+  final TestExecution testExecution;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -54,7 +57,7 @@ class TestExecutionExpandable extends ConsumerWidget {
       return ListTile(
         onTap: () {},
         shape: const Border(),
-        title: getTestExecutionTileTitle(context),
+        title: _TestExecutionTileTitle(testExecution: testExecution),
       );
     }
 
@@ -62,7 +65,7 @@ class TestExecutionExpandable extends ConsumerWidget {
       controlAffinity: ListTileControlAffinity.leading,
       childrenPadding: const EdgeInsets.only(left: Spacing.level4),
       shape: const Border(),
-      title: getTestExecutionTileTitle(context),
+      title: _TestExecutionTileTitle(testExecution: testExecution),
       children: TestResultStatus.values
           .map(
             (status) => TestResultsFilterExpandable(

--- a/frontend/lib/ui/artefact_page/test_execution_expandable.dart
+++ b/frontend/lib/ui/artefact_page/test_execution_expandable.dart
@@ -13,7 +13,7 @@ class TestExecutionExpandable extends ConsumerWidget {
 
   final TestExecution testExecution;
 
-  Row getTestExecutionTitle(BuildContext context) {
+  Row getTestExecutionTileTitle(BuildContext context) {
     final ciLink = testExecution.ciLink;
     final c3Link = testExecution.c3Link;
 
@@ -54,7 +54,7 @@ class TestExecutionExpandable extends ConsumerWidget {
       return ListTile(
         onTap: () {},
         shape: const Border(),
-        title: getTestExecutionTitle(context),
+        title: getTestExecutionTileTitle(context),
       );
     }
 
@@ -62,7 +62,7 @@ class TestExecutionExpandable extends ConsumerWidget {
       controlAffinity: ListTileControlAffinity.leading,
       childrenPadding: const EdgeInsets.only(left: Spacing.level4),
       shape: const Border(),
-      title: getTestExecutionTitle(context),
+      title: getTestExecutionTileTitle(context),
       children: TestResultStatus.values
           .map(
             (status) => TestResultsFilterExpandable(


### PR DESCRIPTION
This PR resolves RTW-247. It adds a condition on whether the test execution is completed (failed or passed) in which case it shows the test filters (Passed / Skipped / Failed) otherwise it shows a text that 'This test execution is not completed. No test results are available yet.'.

Only modifications on the frontend are performed.

### Screenshot of the modified artefact page

![Screenshot from 2024-03-06 09-33-43](https://github.com/canonical/test_observer/assets/33193463/c9d96039-a85c-4ca9-9a9b-2ab1672e95cd)
