### PR TITLE
Artefact filters in url query parameters

### DIFF
--- a/frontend/lib/models/filter.dart
+++ b/frontend/lib/models/filter.dart
@@ -52,4 +52,13 @@ class Filter<T> with _$Filter<T> {
       ],
     );
   }
+
+  Filter<T> copyWithOptionValues(Set<String> values) {
+    return copyWith(
+      options: [
+        for (final option in options)
+          (name: option.name, value: values.contains(option.name)),
+      ],
+    );
+  }
 }

--- a/frontend/lib/models/filter.dart
+++ b/frontend/lib/models/filter.dart
@@ -1,4 +1,3 @@
-import 'package:dartx/dartx.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'filter.freezed.dart';
@@ -10,55 +9,12 @@ class Filter<T> with _$Filter<T> {
   const factory Filter({
     required String name,
     required String? Function(T) extractOption,
-    required List<({String name, bool value})> options,
+    @Default(<String>{}) Set<String> selectedOptions,
+    @Default(<String>[]) List<String> availableOptions,
   }) = _Filter<T>;
 
-  factory Filter.fromObjects({
-    required String name,
-    required String? Function(T) extractOption,
-    required List<T> objects,
-  }) {
-    final names = <String>{};
-    for (final object in objects) {
-      final name = extractOption(object);
-      if (name != null) names.add(name);
-    }
-
-    final options = [
-      for (final name in names.toList().sorted()) (name: name, value: false),
-    ];
-
-    return Filter(name: name, extractOption: extractOption, options: options);
-  }
-
   bool doesObjectPassFilter(T object) {
-    final noOptionsSelected = options.none((option) => option.value);
-    if (noOptionsSelected) return true;
-    final selectedOptions = {
-      for (final option in options)
-        if (option.value) option.name,
-    };
-    return selectedOptions.contains(extractOption(object));
-  }
-
-  Filter<T> copyWithOptionValue(String optionName, bool optionValue) {
-    return copyWith(
-      options: [
-        for (final option in options)
-          if (option.name == optionName)
-            (name: optionName, value: optionValue)
-          else
-            option,
-      ],
-    );
-  }
-
-  Filter<T> copyWithOptionValues(Set<String> values) {
-    return copyWith(
-      options: [
-        for (final option in options)
-          (name: option.name, value: values.contains(option.name)),
-      ],
-    );
+    return selectedOptions.isEmpty ||
+        selectedOptions.contains(extractOption(object));
   }
 }

--- a/frontend/lib/models/filter.dart
+++ b/frontend/lib/models/filter.dart
@@ -10,7 +10,7 @@ class Filter<T> with _$Filter<T> {
     required String name,
     required String? Function(T) extractOption,
     @Default(<String>{}) Set<String> selectedOptions,
-    @Default(<String>[]) List<String> availableOptions,
+    @Default(<String>[]) List<String> detectedOptions,
   }) = _Filter<T>;
 
   bool doesObjectPassFilter(T object) {

--- a/frontend/lib/models/filters.dart
+++ b/frontend/lib/models/filters.dart
@@ -1,6 +1,7 @@
 import 'package:dartx/dartx.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'artefact.dart';
 import 'filter.dart';
 
 part 'filters.freezed.dart';
@@ -31,4 +32,53 @@ class Filters<T> with _$Filters<T> {
 
   bool doesObjectPassFilters(T object) =>
       filters.all((filter) => filter.doesObjectPassFilter(object));
+
+  Filters<T> copyWithQueryParams(Map<String, List<String>> queryParams) {
+    final filterValues = queryParams.map(
+      (filterName, filterValues) => MapEntry(
+        filterName.urlDecode,
+        filterValues.map((value) => value.urlDecode).toSet(),
+      ),
+    );
+
+    final newFilters = filters.map((filter) {
+      final values = filterValues[filter.name];
+      if (values == null) return filter;
+      return filter.copyWithOptionValues(values);
+    });
+
+    return copyWith(filters: newFilters.toList());
+  }
+
+  Map<String, List<String>> toQueryParams() {
+    final queryParams = <String, List<String>>{};
+    for (final filter in filters) {
+      final selectedOptions =
+          filter.options.filter((option) => option.value).toList();
+      if (selectedOptions.isNotEmpty) {
+        queryParams[filter.name.urlEncode] =
+            selectedOptions.map((option) => option.name.urlEncode).toList();
+      }
+    }
+    return queryParams;
+  }
+}
+
+Filters<Artefact> getArtefactFilters(
+  List<Artefact> artefactsToFillOptionsWith,
+) {
+  return Filters<Artefact>(
+    filters: [
+      Filter<Artefact>.fromObjects(
+        name: 'Assignee',
+        extractOption: (artefact) => artefact.assignee?.name,
+        objects: artefactsToFillOptionsWith,
+      ),
+      Filter<Artefact>.fromObjects(
+        name: 'Status',
+        extractOption: (artefact) => artefact.status.name,
+        objects: artefactsToFillOptionsWith,
+      ),
+    ],
+  );
 }

--- a/frontend/lib/models/filters.dart
+++ b/frontend/lib/models/filters.dart
@@ -48,7 +48,7 @@ class Filters<T> with _$Filters<T> {
       if (values == null || values.isEmpty) return filter;
       return filter.copyWith(
         selectedOptions: values.toSet(),
-        availableOptions: filter.availableOptions.toSet().union(values).toList()
+        detectedOptions: filter.detectedOptions.toSet().union(values).toList()
           ..sort(),
       );
     });
@@ -75,7 +75,7 @@ class Filters<T> with _$Filters<T> {
         if (option != null) options.add(option);
       }
       newFilters
-          .add(filter.copyWith(availableOptions: options.toList()..sort()));
+          .add(filter.copyWith(detectedOptions: options.toList()..sort()));
     }
     return copyWith(filters: newFilters);
   }

--- a/frontend/lib/models/filters.dart
+++ b/frontend/lib/models/filters.dart
@@ -43,17 +43,14 @@ class Filters<T> with _$Filters<T> {
       filters.all((filter) => filter.doesObjectPassFilter(object));
 
   Filters<T> copyWithQueryParams(Map<String, List<String>> queryParams) {
-    final filterValues = queryParams.map(
-      (filterName, filterValues) => MapEntry(
-        filterName.urlDecode,
-        filterValues.map((value) => value.urlDecode).toSet(),
-      ),
-    );
-
     final newFilters = filters.map((filter) {
-      final values = filterValues[filter.name];
-      if (values == null) return filter;
-      return filter.copyWith(selectedOptions: values);
+      final values = queryParams[filter.name]?.toSet();
+      if (values == null || values.isEmpty) return filter;
+      return filter.copyWith(
+        selectedOptions: values.toSet(),
+        availableOptions: filter.availableOptions.toSet().union(values).toList()
+          ..sort(),
+      );
     });
 
     return copyWith(filters: newFilters.toList());
@@ -63,8 +60,7 @@ class Filters<T> with _$Filters<T> {
     final queryParams = <String, List<String>>{};
     for (final filter in filters) {
       if (filter.selectedOptions.isNotEmpty) {
-        queryParams[filter.name.urlEncode] =
-            filter.selectedOptions.map((option) => option.urlEncode).toList();
+        queryParams[filter.name] = filter.selectedOptions.toList();
       }
     }
     return queryParams;

--- a/frontend/lib/providers/artefact_filters.dart
+++ b/frontend/lib/providers/artefact_filters.dart
@@ -2,8 +2,8 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../models/artefact.dart';
 import '../models/family_name.dart';
-import '../models/filter.dart';
 import '../models/filters.dart';
+import '../routing.dart';
 import 'family_artefacts.dart';
 
 part 'artefact_filters.g.dart';
@@ -11,24 +11,17 @@ part 'artefact_filters.g.dart';
 @riverpod
 class ArtefactFilters extends _$ArtefactFilters {
   @override
-  Filters<Artefact> build(FamilyName family) {
+  Filters<Artefact> build(Uri pageUri) {
+    final family = pageUri.path.startsWith(AppRoutes.debs)
+        ? FamilyName.deb
+        : FamilyName.snap;
+
     final artefacts =
         ref.watch(familyArtefactsProvider(family)).requireValue.values.toList();
 
-    return Filters<Artefact>(
-      filters: [
-        Filter<Artefact>.fromObjects(
-          name: 'Assignee',
-          extractOption: (artefact) => artefact.assignee?.name,
-          objects: artefacts,
-        ),
-        Filter<Artefact>.fromObjects(
-          name: 'Status',
-          extractOption: (artefact) => artefact.status.name,
-          objects: artefacts,
-        ),
-      ],
-    );
+    final emptyFilters = getArtefactFilters(artefacts);
+
+    return emptyFilters.copyWithQueryParams(pageUri.queryParametersAll);
   }
 
   void handleFilterOptionChange(

--- a/frontend/lib/providers/artefact_filters.dart
+++ b/frontend/lib/providers/artefact_filters.dart
@@ -1,7 +1,6 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../models/artefact.dart';
-import '../models/family_name.dart';
 import '../models/filters.dart';
 import '../routing.dart';
 import 'family_artefacts.dart';
@@ -12,9 +11,7 @@ part 'artefact_filters.g.dart';
 class ArtefactFilters extends _$ArtefactFilters {
   @override
   Filters<Artefact> build(Uri pageUri) {
-    final family = pageUri.path.startsWith(AppRoutes.debs)
-        ? FamilyName.deb
-        : FamilyName.snap;
+    final family = AppRoutes.familyFromUri(pageUri);
 
     final artefacts =
         ref.watch(familyArtefactsProvider(family)).requireValue.values.toList();

--- a/frontend/lib/providers/artefact_filters.dart
+++ b/frontend/lib/providers/artefact_filters.dart
@@ -19,9 +19,9 @@ class ArtefactFilters extends _$ArtefactFilters {
     final artefacts =
         ref.watch(familyArtefactsProvider(family)).requireValue.values.toList();
 
-    final emptyFilters = getArtefactFilters(artefacts);
-
-    return emptyFilters.copyWithQueryParams(pageUri.queryParametersAll);
+    return emptyArtefactFilters
+        .copyWithOptionsExtracted(artefacts)
+        .copyWithQueryParams(pageUri.queryParametersAll);
   }
 
   void handleFilterOptionChange(

--- a/frontend/lib/providers/filtered_family_artefacts.dart
+++ b/frontend/lib/providers/filtered_family_artefacts.dart
@@ -3,20 +3,21 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../models/artefact.dart';
 import '../models/family_name.dart';
+import '../models/filters.dart';
 import 'family_artefacts.dart';
-import 'artefact_filters.dart';
-import 'search_value.dart';
 
 part 'filtered_family_artefacts.g.dart';
 
 @riverpod
 Map<int, Artefact> filteredFamilyArtefacts(
   FilteredFamilyArtefactsRef ref,
-  FamilyName family,
+  Uri pageUri,
 ) {
-  final artefacts = ref.watch(familyArtefactsProvider(family)).requireValue;
-  final filters = ref.watch(artefactFiltersProvider(family));
-  final searchValue = ref.watch(searchValueProvider);
+  final artefacts =
+      ref.watch(familyArtefactsProvider(FamilyName.snap)).requireValue;
+  final filters = getArtefactFilters(artefacts.values.toList())
+      .copyWithQueryParams(pageUri.queryParametersAll);
+  final searchValue = pageUri.queryParameters['q'] ?? '';
 
   return artefacts.filterValues(
     (artefact) =>

--- a/frontend/lib/providers/filtered_family_artefacts.dart
+++ b/frontend/lib/providers/filtered_family_artefacts.dart
@@ -15,8 +15,8 @@ Map<int, Artefact> filteredFamilyArtefacts(
 ) {
   final artefacts =
       ref.watch(familyArtefactsProvider(FamilyName.snap)).requireValue;
-  final filters = getArtefactFilters(artefacts.values.toList())
-      .copyWithQueryParams(pageUri.queryParametersAll);
+  final filters =
+      emptyArtefactFilters.copyWithQueryParams(pageUri.queryParametersAll);
   final searchValue = pageUri.queryParameters['q'] ?? '';
 
   return artefacts.filterValues(

--- a/frontend/lib/providers/filtered_family_artefacts.dart
+++ b/frontend/lib/providers/filtered_family_artefacts.dart
@@ -2,8 +2,8 @@ import 'package:dartx/dartx.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../models/artefact.dart';
-import '../models/family_name.dart';
 import '../models/filters.dart';
+import '../routing.dart';
 import 'family_artefacts.dart';
 
 part 'filtered_family_artefacts.g.dart';
@@ -13,8 +13,8 @@ Map<int, Artefact> filteredFamilyArtefacts(
   FilteredFamilyArtefactsRef ref,
   Uri pageUri,
 ) {
-  final artefacts =
-      ref.watch(familyArtefactsProvider(FamilyName.snap)).requireValue;
+  final family = AppRoutes.familyFromUri(pageUri);
+  final artefacts = ref.watch(familyArtefactsProvider(family)).requireValue;
   final filters =
       emptyArtefactFilters.copyWithQueryParams(pageUri.queryParametersAll);
   final searchValue = pageUri.queryParameters['q'] ?? '';

--- a/frontend/lib/providers/test_execution_filters.dart
+++ b/frontend/lib/providers/test_execution_filters.dart
@@ -1,6 +1,5 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import '../models/filter.dart';
 import '../models/filters.dart';
 import '../models/test_execution.dart';
 import 'artefact_builds.dart';
@@ -17,31 +16,7 @@ class TestExecutionFilters extends _$TestExecutionFilters {
         for (final testExecution in build.testExecutions) testExecution,
     ];
 
-    decisionExtractor(TestExecution te) =>
-        te.reviewDecision.isEmpty ? 'Undecided' : 'Reviewed';
-    statusExtractor(TestExecution te) => te.status.name;
-
-    final decisionOptions = <String>{};
-    final statusOptions = <String>{};
-    for (final te in testExecutions) {
-      decisionOptions.add(decisionExtractor(te));
-      statusOptions.add(statusExtractor(te));
-    }
-
-    return Filters<TestExecution>(
-      filters: [
-        Filter<TestExecution>(
-          name: 'Review status',
-          extractOption: decisionExtractor,
-          availableOptions: decisionOptions.toList()..sort(),
-        ),
-        Filter<TestExecution>(
-          name: 'Execution status',
-          extractOption: statusExtractor,
-          availableOptions: statusOptions.toList()..sort(),
-        ),
-      ],
-    );
+    return emptyTestExecutionFilters.copyWithOptionsExtracted(testExecutions);
   }
 
   void handleFilterOptionChange(

--- a/frontend/lib/providers/test_execution_filters.dart
+++ b/frontend/lib/providers/test_execution_filters.dart
@@ -17,18 +17,28 @@ class TestExecutionFilters extends _$TestExecutionFilters {
         for (final testExecution in build.testExecutions) testExecution,
     ];
 
+    decisionExtractor(TestExecution te) =>
+        te.reviewDecision.isEmpty ? 'Undecided' : 'Reviewed';
+    statusExtractor(TestExecution te) => te.status.name;
+
+    final decisionOptions = <String>{};
+    final statusOptions = <String>{};
+    for (final te in testExecutions) {
+      decisionOptions.add(decisionExtractor(te));
+      statusOptions.add(statusExtractor(te));
+    }
+
     return Filters<TestExecution>(
       filters: [
-        Filter<TestExecution>.fromObjects(
+        Filter<TestExecution>(
           name: 'Review status',
-          extractOption: (te) =>
-              te.reviewDecision.isEmpty ? 'Undecided' : 'Reviewed',
-          objects: testExecutions,
+          extractOption: decisionExtractor,
+          availableOptions: decisionOptions.toList()..sort(),
         ),
-        Filter<TestExecution>.fromObjects(
+        Filter<TestExecution>(
           name: 'Execution status',
-          extractOption: (te) => te.status.name,
-          objects: testExecutions,
+          extractOption: statusExtractor,
+          availableOptions: statusOptions.toList()..sort(),
         ),
       ],
     );

--- a/frontend/lib/routing.dart
+++ b/frontend/lib/routing.dart
@@ -55,14 +55,18 @@ class AppRoutes {
   static const debs = '/debs';
 
   static FamilyName familyFromContext(BuildContext context) {
-    final route = GoRouterState.of(context).fullPath!;
+    return familyFromUri(GoRouterState.of(context).uri);
+  }
 
-    if (route.startsWith(snaps)) {
+  static FamilyName familyFromUri(Uri uri) {
+    final path = uri.path;
+
+    if (path.startsWith(snaps)) {
       return FamilyName.snap;
-    } else if (route.startsWith(debs)) {
+    } else if (path.startsWith(debs)) {
       return FamilyName.deb;
     } else {
-      throw Exception('Unknown route: $route');
+      throw Exception('Unknown route: $path');
     }
   }
 

--- a/frontend/lib/ui/dashboard/artefact_side_filters.dart
+++ b/frontend/lib/ui/dashboard/artefact_side_filters.dart
@@ -32,7 +32,7 @@ class ArtefactSideFilters extends ConsumerWidget {
             width: double.infinity,
             child: ElevatedButton(
               onPressed: () {
-                final searchValue = ref.read(searchValueProvider);
+                final searchValue = ref.read(searchValueProvider).trim();
                 final queryParams = {
                   if (searchValue.isNotEmpty) 'q': searchValue,
                   ...ref.read(artefactFiltersProvider(pageUri)).toQueryParams(),

--- a/frontend/lib/ui/dashboard/artefact_side_filters.dart
+++ b/frontend/lib/ui/dashboard/artefact_side_filters.dart
@@ -32,9 +32,10 @@ class ArtefactSideFilters extends ConsumerWidget {
             width: double.infinity,
             child: ElevatedButton(
               onPressed: () {
+                final searchValue = ref.read(searchValueProvider);
                 final queryParams = {
+                  if (searchValue.isNotEmpty) 'q': searchValue,
                   ...ref.read(artefactFiltersProvider(pageUri)).toQueryParams(),
-                  'q': ref.read(searchValueProvider),
                 };
                 context.go(
                   pageUri.replace(queryParameters: queryParams).toString(),

--- a/frontend/lib/ui/dashboard/artefact_side_filters.dart
+++ b/frontend/lib/ui/dashboard/artefact_side_filters.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../providers/artefact_filters.dart';
-import '../../routing.dart';
+import '../../providers/search_value.dart';
 import '../side_filters.dart';
 import 'artefact_search_bar.dart';
 
@@ -11,8 +12,8 @@ class ArtefactSideFilters extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final family = AppRoutes.familyFromContext(context);
-    final filters = ref.watch(artefactFiltersProvider(family));
+    final pageUri = GoRouterState.of(context).uri;
+    final filters = ref.watch(artefactFiltersProvider(pageUri));
 
     return SizedBox(
       width: SideFilters.width,
@@ -23,8 +24,24 @@ class ArtefactSideFilters extends ConsumerWidget {
           SideFilters(
             filters: filters,
             onOptionChanged: ref
-                .read(artefactFiltersProvider(family).notifier)
+                .read(artefactFiltersProvider(pageUri).notifier)
                 .handleFilterOptionChange,
+          ),
+          const SizedBox(height: SideFilters.spacingBetweenFilters),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              onPressed: () {
+                final queryParams = {
+                  ...ref.read(artefactFiltersProvider(pageUri)).toQueryParams(),
+                  'q': ref.read(searchValueProvider),
+                };
+                context.go(
+                  pageUri.replace(queryParameters: queryParams).toString(),
+                );
+              },
+              child: const Text('Apply'),
+            ),
           ),
         ],
       ),

--- a/frontend/lib/ui/dashboard/stage_column.dart
+++ b/frontend/lib/ui/dashboard/stage_column.dart
@@ -1,10 +1,10 @@
 import 'package:dartx/dartx.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../models/stage_name.dart';
 import '../../providers/filtered_family_artefacts.dart';
-import '../../routing.dart';
 import '../spacing.dart';
 import 'artefact_card.dart';
 
@@ -15,10 +15,10 @@ class StageColumn extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final family = AppRoutes.familyFromContext(context);
+    final pageUri = GoRouterState.of(context).uri;
     final artefacts = [
       for (final artefact
-          in ref.watch(filteredFamilyArtefactsProvider(family)).values)
+          in ref.watch(filteredFamilyArtefactsProvider(pageUri)).values)
         if (artefact.stage == stage) artefact,
     ];
 

--- a/frontend/lib/ui/side_filters.dart
+++ b/frontend/lib/ui/side_filters.dart
@@ -55,18 +55,18 @@ class _SideFilter extends StatelessWidget {
         style: Theme.of(context).textTheme.headlineSmall,
       ),
       children: [
-        for (final option in filter.options)
+        for (final option in filter.availableOptions)
           Row(
             children: [
               YaruCheckbox(
-                value: option.value,
+                value: filter.selectedOptions.contains(option),
                 onChanged: (newValue) {
                   if (newValue != null) {
-                    onOptionChanged(filter.name, option.name, newValue);
+                    onOptionChanged(filter.name, option, newValue);
                   }
                 },
               ),
-              Text(option.name),
+              Text(option),
             ],
           ),
       ],

--- a/frontend/lib/ui/side_filters.dart
+++ b/frontend/lib/ui/side_filters.dart
@@ -55,7 +55,7 @@ class _SideFilter extends StatelessWidget {
         style: Theme.of(context).textTheme.headlineSmall,
       ),
       children: [
-        for (final option in filter.availableOptions)
+        for (final option in filter.detectedOptions)
           Row(
             children: [
               YaruCheckbox(

--- a/frontend/test/providers/artefact_filters_test.dart
+++ b/frontend/test/providers/artefact_filters_test.dart
@@ -26,9 +26,9 @@ void main() {
         .filters;
 
     expect(filters[0].name, 'Assignee');
-    expect(filters[0].availableOptions, {dummyArtefact.assignee?.name});
+    expect(filters[0].detectedOptions, {dummyArtefact.assignee?.name});
     expect(filters[1].name, 'Status');
-    expect(filters[1].availableOptions, {dummyArtefact.status.name});
+    expect(filters[1].detectedOptions, {dummyArtefact.status.name});
   });
 }
 

--- a/frontend/test/providers/artefact_filters_test.dart
+++ b/frontend/test/providers/artefact_filters_test.dart
@@ -6,6 +6,7 @@ import 'package:testcase_dashboard/providers/api.dart';
 import 'package:testcase_dashboard/providers/family_artefacts.dart';
 import 'package:testcase_dashboard/providers/artefact_filters.dart';
 import 'package:testcase_dashboard/repositories/api_repository.dart';
+import 'package:testcase_dashboard/routing.dart';
 
 import '../dummy_data.dart';
 import '../utilities.dart';
@@ -20,7 +21,9 @@ void main() {
     // Wait on artefacts to load cause artefactFiltersProvider uses requireValue
     await container.read(familyArtefactsProvider(family).future);
 
-    final filters = container.read(artefactFiltersProvider(family)).filters;
+    final filters = container
+        .read(artefactFiltersProvider(Uri(path: AppRoutes.snaps)))
+        .filters;
 
     expect(filters[0].name, 'Assignee');
     expect(

--- a/frontend/test/providers/artefact_filters_test.dart
+++ b/frontend/test/providers/artefact_filters_test.dart
@@ -26,15 +26,9 @@ void main() {
         .filters;
 
     expect(filters[0].name, 'Assignee');
-    expect(
-      filters[0].options,
-      [(name: dummyArtefact.assignee?.name, value: false)],
-    );
+    expect(filters[0].availableOptions, {dummyArtefact.assignee?.name});
     expect(filters[1].name, 'Status');
-    expect(
-      filters[1].options,
-      [(name: dummyArtefact.status.name, value: false)],
-    );
+    expect(filters[1].availableOptions, {dummyArtefact.status.name});
   });
 }
 

--- a/frontend/test/providers/filtered_family_artefacts_test.dart
+++ b/frontend/test/providers/filtered_family_artefacts_test.dart
@@ -5,9 +5,8 @@ import 'package:testcase_dashboard/models/family_name.dart';
 import 'package:testcase_dashboard/providers/api.dart';
 import 'package:testcase_dashboard/providers/family_artefacts.dart';
 import 'package:testcase_dashboard/providers/filtered_family_artefacts.dart';
-import 'package:testcase_dashboard/providers/artefact_filters.dart';
-import 'package:testcase_dashboard/providers/search_value.dart';
 import 'package:testcase_dashboard/repositories/api_repository.dart';
+import 'package:testcase_dashboard/routing.dart';
 
 import '../dummy_data.dart';
 import '../utilities.dart';
@@ -24,8 +23,8 @@ void main() {
     await container.read(familyArtefactsProvider(family).future);
 
     final allArtefacts = await apiMock.getFamilyArtefacts(family);
-    final filteredArtefacts =
-        container.read(filteredFamilyArtefactsProvider(family));
+    final filteredArtefacts = container
+        .read(filteredFamilyArtefactsProvider(Uri(path: AppRoutes.snaps)));
 
     expect(filteredArtefacts, allArtefacts);
   });
@@ -43,15 +42,14 @@ void main() {
     final firstArtefact =
         (await apiMock.getFamilyArtefacts(family)).values.first;
 
-    container
-        .read(artefactFiltersProvider(family).notifier)
-        .handleFilterOptionChange(
-          'Assignee',
-          firstArtefact.assignee!.name,
-          true,
-        );
-    final filteredArtefacts =
-        container.read(filteredFamilyArtefactsProvider(family));
+    final filteredArtefacts = container.read(
+      filteredFamilyArtefactsProvider(
+        Uri(
+          path: AppRoutes.snaps,
+          queryParameters: {'Assignee': firstArtefact.assignee!.name},
+        ),
+      ),
+    );
 
     expect(filteredArtefacts, {firstArtefact.id: firstArtefact});
   });
@@ -69,15 +67,14 @@ void main() {
     final firstArtefact =
         (await apiMock.getFamilyArtefacts(family)).values.first;
 
-    container
-        .read(artefactFiltersProvider(family).notifier)
-        .handleFilterOptionChange(
-          'Status',
-          firstArtefact.status.name,
-          true,
-        );
-    final filteredArtefacts =
-        container.read(filteredFamilyArtefactsProvider(family));
+    final filteredArtefacts = container.read(
+      filteredFamilyArtefactsProvider(
+        Uri(
+          path: AppRoutes.snaps,
+          queryParameters: {'Status': firstArtefact.status.name},
+        ),
+      ),
+    );
 
     expect(filteredArtefacts, {firstArtefact.id: firstArtefact});
   });
@@ -95,10 +92,14 @@ void main() {
     final firstArtefact =
         (await apiMock.getFamilyArtefacts(family)).values.first;
 
-    container.read(searchValueProvider.notifier).onChanged(firstArtefact.name);
-
-    final filteredArtefacts =
-        container.read(filteredFamilyArtefactsProvider(family));
+    final filteredArtefacts = container.read(
+      filteredFamilyArtefactsProvider(
+        Uri(
+          path: AppRoutes.snaps,
+          queryParameters: {'q': firstArtefact.name},
+        ),
+      ),
+    );
 
     expect(filteredArtefacts, {firstArtefact.id: firstArtefact});
   });

--- a/frontend/test/providers/test_execution_filters_test.dart
+++ b/frontend/test/providers/test_execution_filters_test.dart
@@ -23,7 +23,7 @@ void main() {
         container.read(testExecutionFiltersProvider(artefactId)).filters;
 
     expect(filters[0].name, 'Review status');
-    expect(filters[0].options, [(name: 'Undecided', value: false)]);
+    expect(filters[0].availableOptions, {'Undecided'});
   });
 }
 

--- a/frontend/test/providers/test_execution_filters_test.dart
+++ b/frontend/test/providers/test_execution_filters_test.dart
@@ -23,7 +23,7 @@ void main() {
         container.read(testExecutionFiltersProvider(artefactId)).filters;
 
     expect(filters[0].name, 'Review status');
-    expect(filters[0].availableOptions, {'Undecided'});
+    expect(filters[0].detectedOptions, {'Undecided'});
   });
 }
 


### PR DESCRIPTION
Resolves [RTW-243](https://warthogs.atlassian.net/browse/RTW-243).

Changes:
- Filters artefacts on dashboard page based on url query parameters
- When you click apply you're filters are added to the url as query parameters.

Video:
[Screencast from 2024-03-15 16-20-54.webm](https://github.com/canonical/test_observer/assets/4087200/094f1fb9-21d3-477a-8d6f-317daa8f3571)


[RTW-243]: https://warthogs.atlassian.net/browse/RTW-243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ