### PR TITLE
Apply search and filters on pressing enter

### DIFF
--- a/frontend/lib/ui/page_filters/page_filters.dart
+++ b/frontend/lib/ui/page_filters/page_filters.dart
@@ -29,23 +29,20 @@ class PageFiltersView extends ConsumerWidget {
       child: ListView.separated(
         shrinkWrap: true,
         itemBuilder: (_, i) {
-          if (i == 0) return PageSearchBar(hintText: searchHint);
+          if (i == 0) {
+            return PageSearchBar(
+              hintText: searchHint,
+              onSubmitted: (searchQuery) =>
+                  submitFilters(ref, searchQuery, pageUri, context),
+            );
+          }
 
           if (i == filters.filters.length + 1) {
             return SizedBox(
               width: double.infinity,
               child: ElevatedButton(
-                onPressed: () {
-                  final searchValue =
-                      ref.read(searchValueProvider(searchQuery)).trim();
-                  final queryParams = {
-                    if (searchValue.isNotEmpty) 'q': searchValue,
-                    ...ref.read(pageFiltersProvider(pageUri)).toQueryParams(),
-                  };
-                  context.go(
-                    pageUri.replace(queryParameters: queryParams).toString(),
-                  );
-                },
+                onPressed: () =>
+                    submitFilters(ref, searchQuery, pageUri, context),
                 child: const Text('Apply'),
               ),
             );
@@ -62,6 +59,22 @@ class PageFiltersView extends ConsumerWidget {
             const SizedBox(height: spacingBetweenFilters),
         itemCount: filters.filters.length + 2,
       ),
+    );
+  }
+
+  void submitFilters(
+    WidgetRef ref,
+    String? searchQuery,
+    Uri pageUri,
+    BuildContext context,
+  ) {
+    final searchValue = ref.read(searchValueProvider(searchQuery)).trim();
+    final queryParams = {
+      if (searchValue.isNotEmpty) 'q': searchValue,
+      ...ref.read(pageFiltersProvider(pageUri)).toQueryParams(),
+    };
+    context.go(
+      pageUri.replace(queryParameters: queryParams).toString(),
     );
   }
 }

--- a/frontend/lib/ui/page_filters/page_filters.dart
+++ b/frontend/lib/ui/page_filters/page_filters.dart
@@ -32,7 +32,7 @@ class PageFiltersView extends ConsumerWidget {
           if (i == 0) {
             return PageSearchBar(
               hintText: searchHint,
-              onSubmitted: (searchQuery) =>
+              onSubmitted: (_) =>
                   submitFilters(ref, searchQuery, pageUri, context),
             );
           }

--- a/frontend/lib/ui/page_filters/page_search_bar.dart
+++ b/frontend/lib/ui/page_filters/page_search_bar.dart
@@ -8,9 +8,11 @@ import '../vanilla/vanilla_search_bar.dart';
 final pageSearchBarKey = GlobalKey<_PageSearchBarState>();
 
 class PageSearchBar extends ConsumerStatefulWidget {
-  PageSearchBar({this.hintText}) : super(key: pageSearchBarKey);
+  PageSearchBar({this.hintText, this.onSubmitted})
+      : super(key: pageSearchBarKey);
 
   final String? hintText;
+  final void Function(String)? onSubmitted;
 
   @override
   ConsumerState<PageSearchBar> createState() => _PageSearchBarState();
@@ -43,6 +45,7 @@ class _PageSearchBarState extends ConsumerState<PageSearchBar> {
             ref.read(searchValueProvider(searchQuery).notifier).onChanged,
         hintText: widget.hintText,
         initialText: searchQuery,
+        onSubmitted: widget.onSubmitted,
       ),
     );
   }

--- a/frontend/lib/ui/vanilla/vanilla_search_bar.dart
+++ b/frontend/lib/ui/vanilla/vanilla_search_bar.dart
@@ -8,12 +8,14 @@ class VanillaSearchBar extends StatefulWidget {
     this.hintText,
     this.focusNode,
     this.initialText,
+    this.onSubmitted,
   });
 
   final String? hintText;
   final FocusNode? focusNode;
   final void Function(String)? onChanged;
   final String? initialText;
+  final void Function(String)? onSubmitted;
 
   @override
   State<VanillaSearchBar> createState() => _VanillaSearchBarState();
@@ -62,6 +64,7 @@ class _VanillaSearchBarState extends State<VanillaSearchBar> {
         shape: MaterialStatePropertyAll(LinearBorder.bottom()),
         side: const MaterialStatePropertyAll(BorderSide()),
         onChanged: widget.onChanged,
+        onSubmitted: widget.onSubmitted,
       ),
     );
   }


### PR DESCRIPTION
Resolves #146 

Basically, when a user is focused on a search bar and clicks enter, then the search query and filters selected are applied immediately.