### PR TITLE
Fix template id db migration

### DIFF
--- a/backend/charm/src/charm.py
+++ b/backend/charm/src/charm.py
@@ -113,6 +113,7 @@ class TestObserverBackendCharm(CharmBase):
             logger.error(e.stdout)
             logger.error(e.stderr)
             self.unit.status = BlockedStatus("Database migration failed")
+            raise SystemExit(0)
 
     def _on_database_changed(self, event):
         self._migrate_database()

--- a/backend/migrations/versions/2024_04_17_1118-624a270a03dc_add_template_id_to_test_case.py
+++ b/backend/migrations/versions/2024_04_17_1118-624a270a03dc_add_template_id_to_test_case.py
@@ -17,7 +17,10 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column("test_case", sa.Column("template_id", sa.String(), nullable=False))
+    op.add_column(
+        "test_case",
+        sa.Column("template_id", sa.String(), nullable=False, server_default=""),
+    )
 
 
 def downgrade() -> None:


### PR DESCRIPTION
Changes:
- Fix database migration bug introduced in previous [template id PR](https://github.com/canonical/test_observer/pull/158)
- Force charm code to exit if migrations fail to apply. Otherwise the charm `BlockedStatus("Database migration failed")` status gets overwritten by `ActiveStatus()` somewhere else in the code. If it's overwritten then we wouldn't know that migrations failed from juju status, we'd have to manually examine the logs.