### PR TITLE
Adds confirmation dialog before accepting a rerun

### DIFF
--- a/frontend/lib/ui/artefact_page/test_execution_expandable.dart
+++ b/frontend/lib/ui/artefact_page/test_execution_expandable.dart
@@ -103,6 +103,7 @@ class _RerunButton extends ConsumerWidget {
                 ),
                 actions: [
                   TextButton(
+                    autofocus: true,
                     onPressed: () {
                       ref
                           .read(artefactBuildsProvider(artefactId).notifier)

--- a/frontend/lib/ui/artefact_page/test_execution_expandable.dart
+++ b/frontend/lib/ui/artefact_page/test_execution_expandable.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../models/test_execution.dart';
 import '../../models/test_result.dart';
@@ -9,6 +10,38 @@ import '../inline_url_text.dart';
 import '../spacing.dart';
 import 'test_execution_review.dart';
 import 'test_result_filter_expandable.dart';
+
+class TestExecutionExpandable extends ConsumerWidget {
+  const TestExecutionExpandable({super.key, required this.testExecution});
+
+  final TestExecution testExecution;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!testExecution.status.isCompleted) {
+      return ListTile(
+        onTap: () {},
+        shape: const Border(),
+        title: _TestExecutionTileTitle(testExecution: testExecution),
+      );
+    }
+
+    return ExpansionTile(
+      controlAffinity: ListTileControlAffinity.leading,
+      childrenPadding: const EdgeInsets.only(left: Spacing.level4),
+      shape: const Border(),
+      title: _TestExecutionTileTitle(testExecution: testExecution),
+      children: TestResultStatus.values
+          .map(
+            (status) => TestResultsFilterExpandable(
+              statusToFilterBy: status,
+              testExecutionId: testExecution.id,
+            ),
+          )
+          .toList(),
+    );
+  }
+}
 
 class _TestExecutionTileTitle extends StatelessWidget {
   const _TestExecutionTileTitle({required this.testExecution});
@@ -62,9 +95,29 @@ class _RerunButton extends ConsumerWidget {
 
     final handlePress = testExecution.isRerunRequested
         ? null
-        : () => ref
-            .read(artefactBuildsProvider(artefactId).notifier)
-            .rerunTestExecution(testExecution.id);
+        : () => showDialog(
+              context: context,
+              builder: (_) => AlertDialog(
+                title: const Text(
+                  'Are you sure you want to rerun this test execution?',
+                ),
+                actions: [
+                  TextButton(
+                    onPressed: () {
+                      ref
+                          .read(artefactBuildsProvider(artefactId).notifier)
+                          .rerunTestExecution(testExecution.id);
+                      context.pop();
+                    },
+                    child: const Text('yes'),
+                  ),
+                  TextButton(
+                    onPressed: () => context.pop(),
+                    child: const Text('no'),
+                  ),
+                ],
+              ),
+            );
 
     return Tooltip(
       message: testExecution.isRerunRequested ? 'Already requested' : '',
@@ -72,38 +125,6 @@ class _RerunButton extends ConsumerWidget {
         onPressed: handlePress,
         child: const Text('rerun'),
       ),
-    );
-  }
-}
-
-class TestExecutionExpandable extends ConsumerWidget {
-  const TestExecutionExpandable({super.key, required this.testExecution});
-
-  final TestExecution testExecution;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    if (!testExecution.status.isCompleted) {
-      return ListTile(
-        onTap: () {},
-        shape: const Border(),
-        title: _TestExecutionTileTitle(testExecution: testExecution),
-      );
-    }
-
-    return ExpansionTile(
-      controlAffinity: ListTileControlAffinity.leading,
-      childrenPadding: const EdgeInsets.only(left: Spacing.level4),
-      shape: const Border(),
-      title: _TestExecutionTileTitle(testExecution: testExecution),
-      children: TestResultStatus.values
-          .map(
-            (status) => TestResultsFilterExpandable(
-              statusToFilterBy: status,
-              testExecutionId: testExecution.id,
-            ),
-          )
-          .toList(),
     );
   }
 }


### PR DESCRIPTION
Resolves https://warthogs.atlassian.net/browse/RTW-306

Adds confirmation dialog before submitting a rerun request. This confirmation dialog can be accepted immediately by pressing enter.

[Screencast from 2024-05-06 12-58-59.webm](https://github.com/canonical/test_observer/assets/4087200/7e732a11-1823-4354-bac3-6d8ed4c324e7)
