### PR TITLE
Fix bug with promote script

### DIFF
--- a/backend/test_observer/controllers/promoter/promoter.py
+++ b/backend/test_observer/controllers/promoter/promoter.py
@@ -187,9 +187,7 @@ def run_deb_promoter(session: Session, artefact: Artefact) -> None:
     assert series is not None, f"Series is not set for the artefact {artefact.id}"
     assert repo is not None, f"Repo is not set for the artefact {artefact.id}"
 
-    architectures = session.scalars(queries.artefact_architectures(artefact.id))
-
-    for arch in architectures:
+    for arch in artefact.architectures:
         for pocket in POCKET_PROMOTION_MAP:
             with ArchiveManager(
                 arch=arch,

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -164,6 +164,10 @@ class Artefact(Base):
     status: Mapped[ArtefactStatus] = mapped_column(default=ArtefactStatus.UNDECIDED)
     bug_link: Mapped[str] = mapped_column(default="")
 
+    @property
+    def architectures(self) -> set[str]:
+        return {ab.architecture for ab in self.builds}
+
     __table_args__ = (
         Index(
             "unique_snap",

--- a/backend/test_observer/data_access/queries.py
+++ b/backend/test_observer/data_access/queries.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Select, select
+from sqlalchemy import select
 
 from test_observer.data_access.models import ArtefactBuild
 
@@ -11,11 +11,3 @@ latest_artefact_builds = (
         ArtefactBuild.revision.desc(),
     )
 )
-
-
-def artefact_architectures(artefact_id: int) -> Select[tuple[str]]:
-    return (
-        select(ArtefactBuild.architecture)
-        .distinct()
-        .where(ArtefactBuild.id == artefact_id)
-    )


### PR DESCRIPTION
Found a bug with promote script. The helper method `queries.artefact_architectures` filters by `ArtefactBuild.id == artefact_id` where it should've filtered by `ArtefactBuild.artefact_id == artefact_id`. This meant that in some cases promote script couldn't promote debs.

This is a particularly nasty bug because the tests pass. But if you ran pytest on just `promote.py` file then the test would fail. Which begs the question, why? The answer turns out to be because database transaction rollback doesn't reset the auto increment value of a primary key. Hence in some cases it could just happen that `ArtefactBuild.id == artefact_id`. In other cases it would not be. That all depends on what tests ran before this particular failing test. (Learning point, database transaction rollback doesn't rollback the incrementation of primary keys)