### PR TITLE
Rerun artefact test executions

### DIFF
--- a/backend/test_observer/controllers/artefacts/artefacts.py
+++ b/backend/test_observer/controllers/artefacts/artefacts.py
@@ -164,7 +164,7 @@ def rerun_artefact_test_executions(
             test_executions = (te for te in test_executions if te.status == status)
         if (decision := request.test_execution_review_decision) is not None:
             test_executions = (
-                te for te in test_executions if te.review_decision == decision
+                te for te in test_executions if set(te.review_decision) == decision
             )
 
     for te in test_executions:

--- a/backend/test_observer/controllers/artefacts/artefacts.py
+++ b/backend/test_observer/controllers/artefacts/artefacts.py
@@ -21,9 +21,14 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session, joinedload
 
 from test_observer.data_access import queries
-from test_observer.data_access.models import Artefact, ArtefactBuild, TestExecution
+from test_observer.data_access.models import (
+    Artefact,
+    ArtefactBuild,
+    TestExecution,
+    TestExecutionRerunRequest,
+)
 from test_observer.data_access.models_enums import ArtefactStatus, FamilyName
-from test_observer.data_access.repository import get_artefacts_by_family
+from test_observer.data_access.repository import get_artefacts_by_family, get_or_create
 from test_observer.data_access.setup import get_db
 
 from .logic import (
@@ -32,7 +37,15 @@ from .logic import (
 )
 from .models import ArtefactBuildDTO, ArtefactDTO, ArtefactPatch
 
-router = APIRouter()
+router = APIRouter(tags=["artefacts"])
+
+
+def _get_artefact_from_db(artefact_id: int, db: Session = Depends(get_db)) -> Artefact:
+    a = db.get(Artefact, artefact_id)
+    if a is None:
+        msg = f"Artefact with id {artefact_id} not found"
+        raise HTTPException(status_code=404, detail=msg)
+    return a
 
 
 @router.get("", response_model=list[ArtefactDTO])
@@ -61,29 +74,20 @@ def get_artefacts(family: FamilyName | None = None, db: Session = Depends(get_db
 
 
 @router.get("/{artefact_id}", response_model=ArtefactDTO)
-def get_artefact(artefact_id: int, db: Session = Depends(get_db)):
-    """Get an artefact by id"""
-    artefact = db.get(Artefact, artefact_id)
-
-    if artefact is None:
-        raise HTTPException(status_code=404, detail="Artefact not found")
-
+def get_artefact(artefact: Artefact = Depends(_get_artefact_from_db)):
     return artefact
 
 
 @router.patch("/{artefact_id}", response_model=ArtefactDTO)
 def patch_artefact(
-    artefact_id: int, request: ArtefactPatch, db: Session = Depends(get_db)
+    request: ArtefactPatch,
+    db: Session = Depends(get_db),
+    artefact: Artefact = Depends(_get_artefact_from_db),
 ):
-    artefact = db.get(Artefact, artefact_id)
-
-    if not artefact:
-        raise HTTPException(status_code=404, detail="Artefact not found")
-
     latest_builds = list(
         db.scalars(
             queries.latest_artefact_builds.where(
-                ArtefactBuild.artefact_id == artefact_id
+                ArtefactBuild.artefact_id == artefact.id
             ).options(joinedload(ArtefactBuild.test_executions))
         ).unique()
     )
@@ -137,3 +141,16 @@ def get_artefact_builds(artefact_id: int, db: Session = Depends(get_db)):
         )
 
     return latest_builds
+
+
+@router.post("/{artefact_id}/reruns")
+def rerun_artefact_test_executions(
+    artefact: Artefact = Depends(_get_artefact_from_db),
+    db: Session = Depends(get_db),
+):
+    latest_builds = db.scalars(
+        queries.latest_artefact_builds.where(ArtefactBuild.artefact_id == artefact.id)
+    )
+    for ab in latest_builds:
+        for te in ab.test_executions:
+            get_or_create(db, TestExecutionRerunRequest, {"test_execution_id": te.id})

--- a/backend/test_observer/controllers/artefacts/artefacts.py
+++ b/backend/test_observer/controllers/artefacts/artefacts.py
@@ -35,7 +35,12 @@ from .logic import (
     are_all_test_executions_approved,
     is_there_a_rejected_test_execution,
 )
-from .models import ArtefactBuildDTO, ArtefactDTO, ArtefactPatch
+from .models import (
+    ArtefactBuildDTO,
+    ArtefactDTO,
+    ArtefactPatch,
+    RerunArtefactTestExecutionsRequest,
+)
 
 router = APIRouter(tags=["artefacts"])
 
@@ -145,12 +150,22 @@ def get_artefact_builds(artefact_id: int, db: Session = Depends(get_db)):
 
 @router.post("/{artefact_id}/reruns")
 def rerun_artefact_test_executions(
+    request: RerunArtefactTestExecutionsRequest | None = None,
     artefact: Artefact = Depends(_get_artefact_from_db),
     db: Session = Depends(get_db),
 ):
     latest_builds = db.scalars(
         queries.latest_artefact_builds.where(ArtefactBuild.artefact_id == artefact.id)
     )
-    for ab in latest_builds:
-        for te in ab.test_executions:
-            get_or_create(db, TestExecutionRerunRequest, {"test_execution_id": te.id})
+    test_executions = (te for ab in latest_builds for te in ab.test_executions)
+
+    if request:
+        if status := request.test_execution_status:
+            test_executions = (te for te in test_executions if te.status == status)
+        if (decision := request.test_execution_review_decision) is not None:
+            test_executions = (
+                te for te in test_executions if te.review_decision == decision
+            )
+
+    for te in test_executions:
+        get_or_create(db, TestExecutionRerunRequest, {"test_execution_id": te.id})

--- a/backend/test_observer/controllers/artefacts/models.py
+++ b/backend/test_observer/controllers/artefacts/models.py
@@ -93,3 +93,8 @@ class ArtefactBuildDTO(BaseModel):
 
 class ArtefactPatch(BaseModel):
     status: ArtefactStatus
+
+
+class RerunArtefactTestExecutionsRequest(BaseModel):
+    test_execution_status: TestExecutionStatus | None = None
+    test_execution_review_decision: list[TestExecutionReviewDecision] | None = None

--- a/backend/test_observer/controllers/artefacts/models.py
+++ b/backend/test_observer/controllers/artefacts/models.py
@@ -97,4 +97,4 @@ class ArtefactPatch(BaseModel):
 
 class RerunArtefactTestExecutionsRequest(BaseModel):
     test_execution_status: TestExecutionStatus | None = None
-    test_execution_review_decision: list[TestExecutionReviewDecision] | None = None
+    test_execution_review_decision: set[TestExecutionReviewDecision] | None = None

--- a/backend/tests/controllers/artefacts/test_artefacts.py
+++ b/backend/tests/controllers/artefacts/test_artefacts.py
@@ -413,3 +413,25 @@ def test_rerun_undecided_artefact_test_executions(
     assert response.status_code == 200
     assert te1.rerun_request is None
     assert te2.rerun_request
+
+
+def test_rerun_filters_ignore_review_decisions_order(
+    test_client: TestClient, test_execution: TestExecution
+):
+    test_execution.review_decision = [
+        TestExecutionReviewDecision.APPROVED_INCONSISTENT_TEST,
+        TestExecutionReviewDecision.APPROVED_FAULTY_HARDWARE,
+    ]
+
+    response = test_client.post(
+        f"/v1/artefacts/{test_execution.artefact_build.artefact_id}/reruns",
+        json={
+            "test_execution_review_decision": [
+                TestExecutionReviewDecision.APPROVED_FAULTY_HARDWARE,
+                TestExecutionReviewDecision.APPROVED_INCONSISTENT_TEST,
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    assert test_execution.rerun_request


### PR DESCRIPTION
This is the backend side of https://warthogs.atlassian.net/browse/RTW-307

Changes:
- Adds a new endpoint `POST /v1/artefacts/<artefact-id>/reruns` that allows user to rerun all test executions belonging to an artefact
- Adds some useful filters to the above endpoint

Note that CI will fail until we merge and rebase https://github.com/canonical/test_observer/pull/172