### PR TITLE
Change rerun button order

### DIFF
--- a/frontend/lib/ui/artefact_page/test_execution_expandable.dart
+++ b/frontend/lib/ui/artefact_page/test_execution_expandable.dart
@@ -58,13 +58,14 @@ class _TestExecutionTileTitle extends StatelessWidget {
         if (!testExecution.status.isCompleted) const SizedBox(width: 36.0),
         testExecution.status.icon,
         const SizedBox(width: Spacing.level2),
-        _RerunButton(testExecution: testExecution),
         const SizedBox(width: Spacing.level2),
         Text(
           testExecution.environment.name,
           style: Theme.of(context).textTheme.titleLarge,
         ),
         const Spacer(),
+        _RerunButton(testExecution: testExecution),
+        const SizedBox(width: Spacing.level4),
         TestExecutionReviewButton(testExecution: testExecution),
         const SizedBox(width: Spacing.level4),
         if (ciLink != null)


### PR DESCRIPTION
This small change moves the rerun button from the left of the environment name to the right handside, just before the test execution review button.

This was suggested as a user experience improvement.

## Screenshot

![Screenshot from 2024-05-08 12-35-58](https://github.com/canonical/test_observer/assets/33193463/bdb42682-47f2-4a2c-a55d-dc0c65ab0e14)
