### PR TITLE
Add delete reruns endpoint

### DIFF
--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -168,3 +168,7 @@ class PendingRerun(BaseModel):
             "test_execution", "artefact_build", "artefact", "stage", "family", "name"
         )
     )
+
+
+class DeleteReruns(BaseModel):
+    test_execution_ids: set[int]

--- a/backend/test_observer/controllers/test_executions/reruns.py
+++ b/backend/test_observer/controllers/test_executions/reruns.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.orm import Session, joinedload
 
 from test_observer.data_access.models import (
@@ -12,7 +12,7 @@ from test_observer.data_access.models import (
 from test_observer.data_access.repository import get_or_create
 from test_observer.data_access.setup import get_db
 
-from .models import PendingRerun, RerunRequest
+from .models import DeleteReruns, PendingRerun, RerunRequest
 
 router = APIRouter()
 
@@ -36,5 +36,14 @@ def get_rerun_requests(db: Session = Depends(get_db)):
             .joinedload(ArtefactBuild.artefact)
             .joinedload(Artefact.stage)
             .joinedload(Stage.family)
+        )
+    )
+
+
+@router.delete("/reruns")
+def delete_rerun_requests(request: DeleteReruns, db: Session = Depends(get_db)):
+    return db.execute(
+        delete(TestExecutionRerunRequest).where(
+            TestExecutionRerunRequest.test_execution_id.in_(request.test_execution_ids)
         )
     )


### PR DESCRIPTION
Resolves https://warthogs.atlassian.net/browse/RTW-308 together with https://github.com/canonical/hwcert-jenkins-tools/pull/25

Changes:
- Adds an endpoint to delete rerun requests