### PR TITLE
Fix delete rerun doesn't actually work

### DIFF
--- a/backend/test_observer/controllers/test_executions/reruns.py
+++ b/backend/test_observer/controllers/test_executions/reruns.py
@@ -65,11 +65,12 @@ def get_rerun_requests(db: Session = Depends(get_db)):
 
 @router.delete("/reruns")
 def delete_rerun_requests(request: DeleteReruns, db: Session = Depends(get_db)):
-    return db.execute(
+    db.execute(
         delete(TestExecutionRerunRequest).where(
             TestExecutionRerunRequest.test_execution_id.in_(request.test_execution_ids)
         )
     )
+    db.commit()
 
 
 class _TestExecutionNotFound(ValueError):


### PR DESCRIPTION
Our testing infrastructure sadly can't detect whether a sqlalchemy session has been committed or not. This led before to bugs leaking to production. And it has done so now too. Turns out this endpoint doesn't work. Which is why [reruns can still keep rerunning multiple times](https://chat.canonical.com/canonical/pl/rfrxxqpg43dttqox957cwtscmw).