### PR TITLE
RTW-321: Deprecate two enum choices

### DIFF
--- a/frontend/lib/models/test_execution.dart
+++ b/frontend/lib/models/test_execution.dart
@@ -127,6 +127,19 @@ enum TestExecutionReviewDecision {
     }
   }
 
+  bool get isDeprecated {
+    switch (this) {
+      case approvedFaultyHardware:
+      case approvedUnstablePhysicalInfra:
+        return true;
+      case rejected:
+      case approvedInconsistentTest:
+      case approvedCustomerPrerequisiteFail:
+      case approvedAllTestsPass:
+        return false;
+    }
+  }
+
   String toJson() {
     switch (this) {
       case rejected:

--- a/frontend/lib/models/test_execution.dart
+++ b/frontend/lib/models/test_execution.dart
@@ -132,10 +132,7 @@ enum TestExecutionReviewDecision {
       case approvedFaultyHardware:
       case approvedUnstablePhysicalInfra:
         return true;
-      case rejected:
-      case approvedInconsistentTest:
-      case approvedCustomerPrerequisiteFail:
-      case approvedAllTestsPass:
+      default:
         return false;
     }
   }

--- a/frontend/lib/ui/artefact_page/test_execution_pop_over.dart
+++ b/frontend/lib/ui/artefact_page/test_execution_pop_over.dart
@@ -36,10 +36,12 @@ class TestExecutionPopOverState extends ConsumerState<TestExecutionPopOver> {
   Function(bool?)? getOnChangedCheckboxListTileFunction(
     TestExecutionReviewDecision testExecutionReviewDecision,
   ) {
-    if ((testExecutionReviewDecision == TestExecutionReviewDecision.rejected &&
-            (_canReject)) ||
-        (testExecutionReviewDecision != TestExecutionReviewDecision.rejected &&
-            _canApprove)) {
+    if (!testExecutionReviewDecision.isDeprecated &&
+        ((testExecutionReviewDecision == TestExecutionReviewDecision.rejected &&
+                _canReject) ||
+            (testExecutionReviewDecision !=
+                    TestExecutionReviewDecision.rejected &&
+                _canApprove))) {
       return (bool? value) {
         setState(() {
           if (reviewDecisions.contains(testExecutionReviewDecision)) {
@@ -51,6 +53,11 @@ class TestExecutionPopOverState extends ConsumerState<TestExecutionPopOver> {
       };
     }
     return null;
+  }
+
+  bool shouldDisplayDecision(TestExecutionReviewDecision decision) {
+    return !decision.isDeprecated ||
+        (decision.isDeprecated && reviewDecisions.contains(decision));
   }
 
   @override
@@ -79,12 +86,15 @@ class TestExecutionPopOverState extends ConsumerState<TestExecutionPopOver> {
         Column(
           children: TestExecutionReviewDecision.values
               .map(
-                (e) => YaruCheckboxListTile(
-                  value: reviewDecisions.contains(e),
-                  onChanged: getOnChangedCheckboxListTileFunction(e),
-                  title: Text(e.name),
-                ),
+                (e) => shouldDisplayDecision(e)
+                    ? YaruCheckboxListTile(
+                        value: reviewDecisions.contains(e),
+                        onChanged: getOnChangedCheckboxListTileFunction(e),
+                        title: Text(e.name),
+                      )
+                    : null,
               )
+              .whereType<YaruCheckboxListTile>()
               .toList(),
         ),
         const SizedBox(height: Spacing.level4),

--- a/frontend/lib/ui/artefact_page/test_execution_pop_over.dart
+++ b/frontend/lib/ui/artefact_page/test_execution_pop_over.dart
@@ -36,12 +36,14 @@ class TestExecutionPopOverState extends ConsumerState<TestExecutionPopOver> {
   Function(bool?)? getOnChangedCheckboxListTileFunction(
     TestExecutionReviewDecision testExecutionReviewDecision,
   ) {
+    // Ensure the test execution cannot be rejected and approved in the same time
+    final bool enableCheckboxConsistencyCheck = (testExecutionReviewDecision ==
+                TestExecutionReviewDecision.rejected &&
+            _canReject) ||
+        (testExecutionReviewDecision != TestExecutionReviewDecision.rejected &&
+            _canApprove);
     if (!testExecutionReviewDecision.isDeprecated &&
-        ((testExecutionReviewDecision == TestExecutionReviewDecision.rejected &&
-                _canReject) ||
-            (testExecutionReviewDecision !=
-                    TestExecutionReviewDecision.rejected &&
-                _canApprove))) {
+        enableCheckboxConsistencyCheck) {
       return (bool? value) {
         setState(() {
           if (reviewDecisions.contains(testExecutionReviewDecision)) {

--- a/frontend/lib/ui/artefact_page/test_execution_pop_over.dart
+++ b/frontend/lib/ui/artefact_page/test_execution_pop_over.dart
@@ -56,8 +56,7 @@ class TestExecutionPopOverState extends ConsumerState<TestExecutionPopOver> {
   }
 
   bool shouldDisplayDecision(TestExecutionReviewDecision decision) {
-    return !decision.isDeprecated ||
-        (decision.isDeprecated && reviewDecisions.contains(decision));
+    return !decision.isDeprecated || reviewDecisions.contains(decision);
   }
 
   @override

--- a/frontend/lib/ui/artefact_page/test_execution_review.dart
+++ b/frontend/lib/ui/artefact_page/test_execution_review.dart
@@ -49,7 +49,7 @@ class TestExecutionReviewButton extends StatelessWidget {
           ),
           direction: PopoverDirection.bottom,
           width: 500,
-          height: 500,
+          height: 400,
           arrowHeight: 15,
           arrowWidth: 30,
         );


### PR DESCRIPTION
## Description

This change deprecates the two following options from the Test Execution Review Decision:
* Unstable Physical Infrastructure
* Faulty Hardware

The deprecation is only done on the frontend. To make sure everything is backwards compatible, we will still show the cases where these are selected, but they will be disabled and their selection wont be modifiable.

## Resolved issues

RTW-321

## Documentation

No documentation changes involved.

## Web service API changes

No API changes involved.

## Tests

The testing was performed manually. Firstly, we observe the case where one of the options was already selected:

![Screenshot from 2024-07-08 10-42-21](https://github.com/canonical/test_observer/assets/33193463/5863c0d6-9be2-429a-a93c-da30ba323a81)


We then observe that the choices are not rendered for new test executions

![Screenshot from 2024-07-08 10-42-37](https://github.com/canonical/test_observer/assets/33193463/0dcfbb68-41a7-4242-9dcb-d8446509e63d)