### PR TITLE
Fix: small typo in approve label

### DIFF
--- a/frontend/lib/models/test_execution.dart
+++ b/frontend/lib/models/test_execution.dart
@@ -119,7 +119,7 @@ enum TestExecutionReviewDecision {
       case approvedUnstablePhysicalInfra:
         return 'Approve (unstable physical infrastructure)';
       case approvedCustomerPrerequisiteFail:
-        return 'Approve (customer provided prerequsite failing)';
+        return 'Approve (customer provided prerequisite failing)';
       case approvedFaultyHardware:
         return 'Approve (faulty hardware)';
       case approvedAllTestsPass:


### PR DESCRIPTION
## Description

This PR fixes a small typo in one of the available _Approve_ options.

## Resolved issues

N/A

## Documentation

N/A

## Web service API changes

N/A

## Tests

N/A
