### PR TITLE
Add rerun test executions helper script

### DIFF
--- a/backend/scripts/rerun_failing_test_executions.py
+++ b/backend/scripts/rerun_failing_test_executions.py
@@ -1,12 +1,16 @@
 # ruff: noqa: T201
 
 import argparse
+import functools
 import re
 from os import environ
 
-import requests
+from requests import Session
 
 TO_API_URL = environ.get("TO_API_URL", "https://test-observer-api.canonical.com")
+
+requests = Session()
+requests.request = functools.partial(requests.request, timeout=5)  # type: ignore
 
 
 def main(artefact_id: int, test_case_regex: str, reversed: bool):
@@ -56,9 +60,9 @@ def main(artefact_id: int, test_case_regex: str, reversed: bool):
     should_rerun = (
         input(
             f"Will rerun {len(test_execution_ids_to_rerun)}"
-            " test executions is that ok? (yes/no) "
+            " test executions is that ok? (y/N) "
         )
-        == "yes"
+        == "y"
     )
 
     if should_rerun:

--- a/backend/scripts/rerun_failing_test_executions.py
+++ b/backend/scripts/rerun_failing_test_executions.py
@@ -10,7 +10,7 @@ from requests import Session
 TO_API_URL = environ.get("TO_API_URL", "https://test-observer-api.canonical.com")
 
 requests = Session()
-requests.request = functools.partial(requests.request, timeout=5)  # type: ignore
+requests.request = functools.partial(requests.request, timeout=30)  # type: ignore
 
 
 def main(artefact_id: int, test_case_regex: str, reversed: bool):

--- a/backend/scripts/rerun_failing_test_executions.py
+++ b/backend/scripts/rerun_failing_test_executions.py
@@ -65,7 +65,8 @@ def main(artefact_id: int, test_case_regex: str, reversed: bool):
             json={"test_execution_ids": test_execution_ids_to_rerun},
         )
         print("Submitted rerun requests")
-
+    else:
+        print("Aborting the script")
 
 example_usage = """Example:
 

--- a/backend/scripts/rerun_failing_test_executions.py
+++ b/backend/scripts/rerun_failing_test_executions.py
@@ -54,9 +54,9 @@ def main(artefact_id: int, test_case_regex: str, reversed: bool):
     should_rerun = (
         input(
             f"Will rerun {len(test_execution_ids_to_rerun)}"
-            " test executions is that ok? (Y/n) "
+            " test executions is that ok? (yes/no) "
         )
-        == "Y"
+        == "yes"
     )
 
     if should_rerun:

--- a/backend/scripts/rerun_failing_test_executions.py
+++ b/backend/scripts/rerun_failing_test_executions.py
@@ -61,7 +61,7 @@ def main(artefact_id: int, test_case_regex: str, reversed: bool):
         input(
             f"Will rerun {len(test_execution_ids_to_rerun)}"
             " test executions is that ok? (y/N) "
-        )
+        ).lower()
         == "y"
     )
 

--- a/backend/scripts/rerun_failing_test_executions.py
+++ b/backend/scripts/rerun_failing_test_executions.py
@@ -48,7 +48,7 @@ def main(artefact_id: int, test_case_regex: str):
     should_rerun = (
         input(
             f"Will rerun {len(test_execution_ids_to_rerun)}"
-            "test executions is that ok? (Y/n) "
+            " test executions is that ok? (Y/n) "
         )
         == "Y"
     )

--- a/backend/scripts/rerun_failing_test_executions.py
+++ b/backend/scripts/rerun_failing_test_executions.py
@@ -1,0 +1,80 @@
+# ruff: noqa: T201
+
+import argparse
+import re
+
+import requests
+
+TO_API_URL = "https://test-observer-api.canonical.com"
+
+
+def main(artefact_id: int, test_case_regex: str):
+    artefact_builds = requests.get(
+        f"{TO_API_URL}/v1/artefacts/{artefact_id}/builds"
+    ).json()
+
+    test_case_matcher = re.compile(test_case_regex)
+
+    relevant_test_executions = [
+        te
+        for ab in artefact_builds
+        for te in ab["test_executions"]
+        if te["review_decision"] == []
+        and not te["is_rerun_requested"]
+        and te["status"] == "FAILED"
+    ]
+
+    test_execution_ids_to_rerun = []
+    for te in relevant_test_executions:
+        test_results = requests.get(
+            f"{TO_API_URL}/v1/test-executions/{te['id']}/test-results"
+        ).json()
+
+        matching_failed_tests = (
+            tr
+            for tr in test_results
+            if tr["status"] == "FAILED" and test_case_matcher.match(tr["name"])
+        )
+
+        first_failing_test = next(matching_failed_tests, None)
+
+        if first_failing_test:
+            test_execution_ids_to_rerun.append(te["id"])
+            print(
+                f"will rerun {te['environment']['name']}"
+                f" for failing {first_failing_test['name']}"
+            )
+
+    should_rerun = (
+        input(
+            f"Will rerun {len(test_execution_ids_to_rerun)}"
+            "test executions is that ok? (Y/n) "
+        )
+        == "Y"
+    )
+
+    if should_rerun:
+        requests.post(
+            f"{TO_API_URL}/v1/test-executions/reruns",
+            json={"test_execution_ids": test_execution_ids_to_rerun},
+        )
+        print("Submitted rerun requests")
+
+
+example_usage = """Example:
+
+  python %(prog)s 47906 '.*wireless.*'
+  python %(prog)s 47906 '.*suspend.*'"""
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Reruns test executions of an artefact that"
+        " failed particular test cases matched by the passed regex",
+        epilog=example_usage,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("artefact_id", type=int)
+    parser.add_argument("test_case_regex", type=str)
+    args = parser.parse_args()
+
+    main(args.artefact_id, args.test_case_regex)

--- a/backend/scripts/rerun_failing_test_executions.py
+++ b/backend/scripts/rerun_failing_test_executions.py
@@ -70,6 +70,7 @@ def main(artefact_id: int, test_case_regex: str, reversed: bool):
     else:
         print("Aborting the script")
 
+
 example_usage = """Example:
 
   python %(prog)s 47906 '.*wireless.*'

--- a/backend/scripts/rerun_failing_test_executions.py
+++ b/backend/scripts/rerun_failing_test_executions.py
@@ -8,7 +8,7 @@ import requests
 TO_API_URL = "https://test-observer-api.canonical.com"
 
 
-def main(artefact_id: int, test_case_regex: str):
+def main(artefact_id: int, test_case_regex: str, reversed: bool):
     artefact_builds = requests.get(
         f"{TO_API_URL}/v1/artefacts/{artefact_id}/builds"
     ).json()
@@ -38,11 +38,17 @@ def main(artefact_id: int, test_case_regex: str):
 
         first_failing_test = next(matching_failed_tests, None)
 
-        if first_failing_test:
+        if first_failing_test and not reversed:
             test_execution_ids_to_rerun.append(te["id"])
             print(
                 f"will rerun {te['environment']['name']}"
                 f" for failing {first_failing_test['name']}"
+            )
+        elif not first_failing_test and reversed:
+            test_execution_ids_to_rerun.append(te["id"])
+            print(
+                f"will rerun {te['environment']['name']}"
+                f" as no failing matches found and reversed option is set"
             )
 
     should_rerun = (
@@ -75,6 +81,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("artefact_id", type=int)
     parser.add_argument("test_case_regex", type=str)
+    parser.add_argument("--reversed", action="store_true")
     args = parser.parse_args()
 
-    main(args.artefact_id, args.test_case_regex)
+    main(args.artefact_id, args.test_case_regex, args.reversed)

--- a/backend/scripts/show_common_failures.py
+++ b/backend/scripts/show_common_failures.py
@@ -1,14 +1,18 @@
 # ruff: noqa: T201
 
 import argparse
+import functools
 import sys
 from collections import Counter
 from os import environ
 from pprint import pprint
 
-import requests
+from requests import Session
 
 TO_API_URL = environ.get("TO_API_URL", "https://test-observer-api.canonical.com")
+
+requests = Session()
+requests.request = functools.partial(requests.request, timeout=5)  # type: ignore
 
 
 def main(artefact_id: int):

--- a/backend/scripts/show_common_failures.py
+++ b/backend/scripts/show_common_failures.py
@@ -3,11 +3,12 @@
 import argparse
 import sys
 from collections import Counter
+from os import environ
 from pprint import pprint
 
 import requests
 
-TO_API_URL = "https://test-observer-api.canonical.com"
+TO_API_URL = environ.get("TO_API_URL", "https://test-observer-api.canonical.com")
 
 
 def main(artefact_id: int):
@@ -39,13 +40,14 @@ def main(artefact_id: int):
     counter = Counter(failing_test_cases)
 
     print()
-    pprint(counter.most_common())
+    pprint(counter.most_common())  # noqa: T203
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Given an artefact id, prints the most common failing"
-        " test cases under undecided test executions",
+        " test cases under undecided test executions."
+        "\nUses TO_API_URL environment if defined defaulting to production otherwise",
     )
     parser.add_argument("artefact_id", type=int)
     args = parser.parse_args()

--- a/backend/scripts/show_common_failures.py
+++ b/backend/scripts/show_common_failures.py
@@ -1,0 +1,53 @@
+# ruff: noqa: T201
+
+import argparse
+import sys
+from collections import Counter
+from pprint import pprint
+
+import requests
+
+TO_API_URL = "https://test-observer-api.canonical.com"
+
+
+def main(artefact_id: int):
+    artefact_builds = requests.get(
+        f"{TO_API_URL}/v1/artefacts/{artefact_id}/builds"
+    ).json()
+
+    relevant_test_executions = [
+        te
+        for ab in artefact_builds
+        for te in ab["test_executions"]
+        if te["review_decision"] == [] and te["status"] == "FAILED"
+    ]
+
+    failing_test_cases: list[str] = []
+    for i, te in enumerate(relevant_test_executions):
+        test_results = requests.get(
+            f"{TO_API_URL}/v1/test-executions/{te['id']}/test-results"
+        ).json()
+
+        failing_test_cases.extend(
+            tr["name"] for tr in test_results if tr["status"] == "FAILED"
+        )
+
+        sys.stdout.write("\r")
+        sys.stdout.write(f"{i+1}/{len(relevant_test_executions)}")
+        sys.stdout.flush()
+
+    counter = Counter(failing_test_cases)
+
+    print()
+    pprint(counter.most_common())
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Given an artefact id, prints the most common failing"
+        " test cases under undecided test executions",
+    )
+    parser.add_argument("artefact_id", type=int)
+    args = parser.parse_args()
+
+    main(args.artefact_id)

--- a/backend/scripts/show_common_failures.py
+++ b/backend/scripts/show_common_failures.py
@@ -12,7 +12,7 @@ from requests import Session
 TO_API_URL = environ.get("TO_API_URL", "https://test-observer-api.canonical.com")
 
 requests = Session()
-requests.request = functools.partial(requests.request, timeout=5)  # type: ignore
+requests.request = functools.partial(requests.request, timeout=30)  # type: ignore
 
 
 def main(artefact_id: int):


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This is a script helper script for reviewers. Often when reviewing an artefact, we'd want to rerun all test executions that failed a particular test or group of tests. This handy script does just that for us as otherwise we'd have to manually go through all of the test executions in the UI which is time consuming and annoying.

```
$ python scripts/rerun_failing_test_executions.py -h
usage: rerun_failing_test_executions.py [-h] artefact_id test_case_regex

Reruns test executions of an artefact that failed particular test cases matched by the passed regex

positional arguments:
  artefact_id
  test_case_regex

options:
  -h, --help       show this help message and exit

Example:

  python rerun_failing_test_executions.py 47906 '.*wireless.*'
  python rerun_failing_test_executions.py 47906 '.*suspend.*'
```

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

Resolves https://warthogs.atlassian.net/browse/RTW-337

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

None.

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

None.

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

This is a throwaway script (ideally this sort of functionality will be available through the UI eventually). But I've tried it myself a few times.
