### PR TITLE
HOTFIX: Allow more simultaneous connections to the database

### DIFF
--- a/backend/test_observer/data_access/setup.py
+++ b/backend/test_observer/data_access/setup.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import sessionmaker
 DEFAULT_DB_URL = "postgresql+pg8000://postgres:password@test-observer-db:5432/postgres"
 DB_URL = environ.get("DB_URL", DEFAULT_DB_URL)
 
-engine = create_engine(DB_URL, pool_size=10, max_overflow=20)
+engine = create_engine(DB_URL, pool_size=20, max_overflow=30)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

API is struggling right now on production due to not enough connections available. This increases the amount. Postgresql currently can handle 100 connections concurrently. But I've set it to 20+30=50 in api server so that in the future we can add another api replica. I hope this is enough.
