### PR TITLE
Fix scroll resetting on rerun or review

### DIFF
--- a/frontend/lib/ui/artefact_page/artefact_page_body.dart
+++ b/frontend/lib/ui/artefact_page/artefact_page_body.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intersperse/intersperse.dart';
-import 'package:yaru/widgets.dart';
+import 'package:yaru/yaru.dart';
 import '../../models/artefact.dart';
 import '../../models/test_execution.dart';
 import '../../providers/filtered_test_executions.dart';
@@ -18,45 +18,43 @@ class ArtefactPageBody extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final pageUri = AppRoutes.uriFromContext(context);
-    final filteredTestExecutions =
-        ref.watch(filteredTestExecutionsProvider(pageUri));
+    final testExecutions =
+        ref.watch(filteredTestExecutionsProvider(pageUri)).value;
 
-    return filteredTestExecutions.when(
-      data: (testExecutions) => Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.baseline,
-            textBaseline: TextBaseline.alphabetic,
-            children: [
-              Text(
-                'Environments',
-                style: Theme.of(context).textTheme.headlineSmall,
-              ),
-              const SizedBox(width: Spacing.level4),
-              _TestExecutionsStatusSummary(testExecutions: testExecutions),
-              const Spacer(),
-              const RerunFilteredEnvironmentsButton(),
-            ],
-          ),
-          Expanded(
-            child: ListView.builder(
-              itemCount: testExecutions.length,
-              itemBuilder: (_, i) => Padding(
-                // Padding is to avoid scroll bar covering trailing buttons
-                padding: const EdgeInsets.only(right: Spacing.level3),
-                child: TestExecutionExpandable(
-                  testExecution: testExecutions[i],
-                ),
+    if (testExecutions == null) {
+      return const YaruCircularProgressIndicator();
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.baseline,
+          textBaseline: TextBaseline.alphabetic,
+          children: [
+            Text(
+              'Environments',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(width: Spacing.level4),
+            _TestExecutionsStatusSummary(testExecutions: testExecutions),
+            const Spacer(),
+            const RerunFilteredEnvironmentsButton(),
+          ],
+        ),
+        Expanded(
+          child: ListView.builder(
+            itemCount: testExecutions.length,
+            itemBuilder: (_, i) => Padding(
+              // Padding is to avoid scroll bar covering trailing buttons
+              padding: const EdgeInsets.only(right: Spacing.level3),
+              child: TestExecutionExpandable(
+                testExecution: testExecutions[i],
               ),
             ),
           ),
-        ],
-      ),
-      loading: () => const Center(child: YaruCircularProgressIndicator()),
-      error: (error, stackTrace) {
-        return Center(child: Text('Error: $error'));
-      },
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

On artefact page, when you scroll then rerun or review an environment, the scroll position resets to the top. After lots of debugging turns out that the issues occurs because initially the `ArtefactPageBody` widget builds a `ListView`. When you rerun or approve an artefact the `ArtefactPageBody` builds a `YaruCircularProgressIndicator` for a split second before building a `ListView` again. During this split second the older ListView is destroyed and together with it the scroll position on this page. To resolve the issue we avoid building a `YaruCircularProgressIndicator` during that split second. This can be done by using the filtered test executions provider's [value property](https://pub.dev/documentation/riverpod/latest/riverpod/AsyncValue/value.html). This property will return the previous filtered test executions list while it's loading the changes of the rerun/review. Hence the ListView is always returned even when loading (at least not initially).

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

https://warthogs.atlassian.net/browse/RTW-344

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

None

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

None

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

[Screencast from 2024-08-08 13-36-46.webm](https://github.com/user-attachments/assets/868ec58a-d199-42c1-8c63-c6f3191189a1)
[Screencast from 2024-08-08 13-40-35.webm](https://github.com/user-attachments/assets/bb5956ed-6d5e-4716-806e-eae7cbf6066c)
