### PR TITLE
Make show_common_failures script group by template id if present

### DIFF
--- a/backend/scripts/show_common_failures.py
+++ b/backend/scripts/show_common_failures.py
@@ -34,7 +34,9 @@ def main(artefact_id: int):
         ).json()
 
         failing_test_cases.extend(
-            tr["name"] for tr in test_results if tr["status"] == "FAILED"
+            tr["template_id"] or tr["name"]
+            for tr in test_results
+            if tr["status"] == "FAILED"
         )
 
         sys.stdout.write("\r")
@@ -50,7 +52,8 @@ def main(artefact_id: int):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Given an artefact id, prints the most common failing"
-        " test cases under undecided test executions."
+        " test cases under undecided test executions. Groups tests by template_id"
+        " if present and case name otherwise"
         "\nUses TO_API_URL environment if defined defaulting to production otherwise",
     )
     parser.add_argument("artefact_id", type=int)


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This shows a more useful grouping of failures instead of having template cases separated.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->
