### PR TITLE
Fix rerun filtered environments doesn't take into consideration review filters

### DIFF
--- a/frontend/lib/models/filters.dart
+++ b/frontend/lib/models/filters.dart
@@ -122,8 +122,13 @@ final emptyEnvironmentReviewFilters = FiltersGroup<EnvironmentReview>(
   filters: [
     Filter<EnvironmentReview>(
       name: 'Review status',
-      extractOption: (te) =>
-          te.reviewDecision.isEmpty ? 'Undecided' : 'Reviewed',
+      // extractOption: (te) =>
+      //     te.reviewDecision.isEmpty ? 'Undecided' : 'Reviewed',
+      extractOption: (er) => switch (er.reviewDecision) {
+        [] => 'Undecided',
+        [EnvironmentReviewDecision.rejected] => 'Rejected',
+        [...] => 'Approved',
+      },
     ),
   ],
 );

--- a/frontend/lib/models/filters.dart
+++ b/frontend/lib/models/filters.dart
@@ -122,8 +122,6 @@ final emptyEnvironmentReviewFilters = FiltersGroup<EnvironmentReview>(
   filters: [
     Filter<EnvironmentReview>(
       name: 'Review status',
-      // extractOption: (te) =>
-      //     te.reviewDecision.isEmpty ? 'Undecided' : 'Reviewed',
       extractOption: (er) => switch (er.reviewDecision) {
         [] => 'Undecided',
         [EnvironmentReviewDecision.rejected] => 'Rejected',

--- a/frontend/lib/ui/artefact_page/artefact_page_body.dart
+++ b/frontend/lib/ui/artefact_page/artefact_page_body.dart
@@ -58,7 +58,10 @@ class ArtefactPageBody extends ConsumerWidget {
               testExecutions: filteredCombination.map((comb) => comb.$2),
             ),
             const Spacer(),
-            const RerunFilteredEnvironmentsButton(),
+            RerunFilteredEnvironmentsButton(
+              filteredTestExecutions:
+                  filteredCombination.map((comb) => comb.$2),
+            ),
           ],
         ),
         NonBlockingProviderPreloader(

--- a/frontend/lib/ui/artefact_page/rerun_filtered_environments_button.dart
+++ b/frontend/lib/ui/artefact_page/rerun_filtered_environments_button.dart
@@ -5,22 +5,21 @@ import 'package:intersperse/intersperse.dart';
 
 import '../../models/test_execution.dart';
 import '../../providers/artefact_builds.dart';
-import '../../providers/filtered_test_executions.dart';
 import '../../routing.dart';
 import '../spacing.dart';
 
 class RerunFilteredEnvironmentsButton extends ConsumerWidget {
-  const RerunFilteredEnvironmentsButton({super.key});
+  const RerunFilteredEnvironmentsButton({
+    super.key,
+    required this.filteredTestExecutions,
+  });
+
+  final Iterable<TestExecution> filteredTestExecutions;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final pageUri = GoRouterState.of(context).uri;
     final artefactId = AppRoutes.artefactIdFromUri(pageUri);
-
-    final filteredTestExecutions = ref
-        .watch(filteredTestExecutionsProvider(pageUri))
-        .requireValue
-        .toList();
 
     handlePress() => showDialog(
           context: context,
@@ -46,7 +45,7 @@ class _ConfirmationDialog extends ConsumerWidget {
     required this.artefactId,
   });
 
-  final List<TestExecution> filteredTestExecutions;
+  final Iterable<TestExecution> filteredTestExecutions;
   final int artefactId;
 
   @override


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

Since we have two separate filter groups filtering different lists. We need to only use the inclusive combination.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

Fixes https://warthogs.atlassian.net/browse/RTW-390

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Tested manually.

[Screencast from 2024-10-17 15-08-10.webm](https://github.com/user-attachments/assets/00d408c8-0cfb-43cd-9ab3-b6aa21e6afdb)

