### PR TITLE
Make the postgres charm channel match what's deployed until we can test further

### DIFF
--- a/terraform/test-observer.tf
+++ b/terraform/test-observer.tf
@@ -66,7 +66,7 @@ resource "juju_application" "pg" {
 
   charm {
     name    = "postgresql-k8s"
-    channel = "14/stable"
+    channel = "14/candidate"
     series  = "jammy"
   }
 }


### PR DESCRIPTION
## Description

TO currently deploys postgres from candidate. I think this is leftover from some of the postgres issues that had to be worked around in the past.  If we deploy this terraform right now, it would cause it to flip to stable and also get a MUCH newer version of the charm. Let's flip it back to candidate for now, until we can adequately test the upgrade in staging.

## Resolved issues

N/A

## Documentation

N/A

## Web service API changes

N/A

## Tests

N/A - but this will avoid unintended changes due to running terraform apply
