### PR TITLE
Move rerun button back next to environment name

### DIFF
--- a/frontend/lib/ui/artefact_page/environment_expandable.dart
+++ b/frontend/lib/ui/artefact_page/environment_expandable.dart
@@ -7,6 +7,7 @@ import '../spacing.dart';
 import 'environment_issues/environment_issues_expandable.dart';
 import 'environment_review_button.dart';
 import 'test_execution_expandable/test_execution_expandable.dart';
+import 'test_execution_expandable/test_execution_rerun_button.dart';
 
 class EnvironmentExpandable extends StatelessWidget {
   const EnvironmentExpandable({super.key, required this.artefactEnvironment});
@@ -56,6 +57,8 @@ class _EnvironmentExpandableTitle extends StatelessWidget {
           style: Theme.of(context).textTheme.titleLarge,
         ),
         const Spacer(),
+        RerunButton(testExecution: artefactEnvironment.runsDescending.first),
+        const SizedBox(width: Spacing.level3),
         EnvironmentReviewButton(environmentReview: artefactEnvironment.review),
       ],
     );

--- a/frontend/lib/ui/artefact_page/test_execution_expandable/test_execution_expandable.dart
+++ b/frontend/lib/ui/artefact_page/test_execution_expandable/test_execution_expandable.dart
@@ -8,7 +8,6 @@ import '../../inline_url_text.dart';
 import '../../spacing.dart';
 import '../test_result_filter_expandable.dart';
 import '../test_event_log_expandable.dart';
-import 'test_execution_rerun_button.dart';
 
 class TestExecutionExpandable extends ConsumerWidget {
   const TestExecutionExpandable({
@@ -76,8 +75,6 @@ class _TestExecutionTileTitle extends StatelessWidget {
           style: Theme.of(context).textTheme.titleMedium,
         ),
         const Spacer(),
-        RerunButton(testExecution: testExecution),
-        const SizedBox(width: Spacing.level3),
         if (ciLink != null)
           InlineUrlText(
             url: ciLink,


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

Mixed with the changes to allow multiple reruns on TO, the rerun button was accidentally moved to be next to reruns rather than the environment itself. This PR moves it back.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->
