### PR TITLE
Allow setting initial status of a test execution

### DIFF
--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -47,6 +47,7 @@ class _StartTestExecutionRequest(BaseModel):
     environment: str
     ci_link: Annotated[str, HttpUrl]
     test_plan: str = Field(max_length=200)
+    initial_status: TestExecutionStatus = TestExecutionStatus.IN_PROGRESS
 
     @field_validator("version")
     @classmethod

--- a/backend/test_observer/controllers/test_executions/start_test.py
+++ b/backend/test_observer/controllers/test_executions/start_test.py
@@ -31,7 +31,6 @@ from test_observer.data_access.models import (
     TestExecution,
     User,
 )
-from test_observer.data_access.models_enums import TestExecutionStatus
 from test_observer.data_access.repository import get_or_create
 from test_observer.data_access.setup import get_db
 

--- a/backend/test_observer/controllers/test_executions/start_test.py
+++ b/backend/test_observer/controllers/test_executions/start_test.py
@@ -108,7 +108,7 @@ def start_test_execution(
                 "ci_link": request.ci_link,
             },
             creation_kwargs={
-                "status": TestExecutionStatus.IN_PROGRESS,
+                "status": request.initial_status,
                 "environment_id": environment.id,
                 "artefact_build_id": artefact_build.id,
                 "test_plan": request.test_plan,

--- a/backend/tests/controllers/test_executions/test_start_test.py
+++ b/backend/tests/controllers/test_executions/test_start_test.py
@@ -348,3 +348,12 @@ def test_keeps_rerun_request_of_different_plan(
 
     db_session.refresh(te)
     assert te.rerun_request
+
+
+def test_sets_initial_test_execution_status(db_session: Session, execute: Execute):
+    response = execute({**deb_test_request, "initial_status": "NOT_STARTED"})
+
+    assert response.status_code == 200
+    te = db_session.get(TestExecution, response.json()["id"])
+    assert te is not None
+    assert te.status == TestExecutionStatus.NOT_STARTED


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

Allow creating test executions with a custom initial status like "NOT_STARTED".

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

Resolves https://warthogs.atlassian.net/browse/RTW-424

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

`PUT /v1/test-executions/start-test` now optionally accepts a new field named `initial_status` with a default value of `IN_PROGRESS`.

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Added a test case.
