### PR TITLE
Support setting a test execution to completed

### DIFF
--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -97,7 +97,7 @@ class TestExecutionsPatchRequest(BaseModel):
 
     c3_link: HttpUrl | None = None
     ci_link: HttpUrl | None = None
-    status: TestExecutionStatus | None = None
+    status: TestExecutionStatus | Literal["COMPLETED"] | None = None
 
 
 class PreviousTestResult(BaseModel):

--- a/backend/test_observer/controllers/test_executions/patch.py
+++ b/backend/test_observer/controllers/test_executions/patch.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import Session
 
 from test_observer.controllers.artefacts.models import TestExecutionDTO
 from test_observer.data_access.models import TestExecution
+from test_observer.data_access.models_enums import TestExecutionStatus, TestResultStatus
 from test_observer.data_access.setup import get_db
 
 from .models import TestExecutionsPatchRequest
@@ -43,8 +44,23 @@ def patch_test_execution(
     if request.ci_link is not None:
         test_execution.ci_link = str(request.ci_link)
 
-    if request.status is not None:
-        test_execution.status = request.status
+    _set_test_execution_status(request, test_execution)
 
     db.commit()
     return test_execution
+
+
+def _set_test_execution_status(
+    request: TestExecutionsPatchRequest, test_execution: TestExecution
+) -> None:
+    match (request.status, test_execution.test_results):
+        case (TestExecutionStatus(), _):
+            test_execution.status = request.status
+        case ("COMPLETED", []):
+            test_execution.status = TestExecutionStatus.ENDED_PREMATURELY
+        case ("COMPLETED", results) if any(
+            r.status == TestResultStatus.FAILED for r in results
+        ):
+            test_execution.status = TestExecutionStatus.FAILED
+        case ("COMPLETED", _):
+            test_execution.status = TestExecutionStatus.PASSED

--- a/backend/tests/controllers/test_executions/test_patch.py
+++ b/backend/tests/controllers/test_executions/test_patch.py
@@ -14,23 +14,77 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from collections.abc import Callable
+from typing import Any, TypeAlias
+
+import pytest
 from fastapi.testclient import TestClient
+from httpx import Response
 
 from test_observer.data_access.models import (
     TestExecution,
 )
-from test_observer.data_access.models_enums import TestExecutionStatus
+from test_observer.data_access.models_enums import TestExecutionStatus, TestResultStatus
+from tests.data_generator import DataGenerator
+
+Execute: TypeAlias = Callable[[int, dict[str, Any]], Response]
 
 
-def test_updates_test_execution(test_client: TestClient, test_execution: TestExecution):
-    test_client.patch(
-        f"/v1/test-executions/{test_execution.id}",
-        json={
+@pytest.fixture
+def execute(test_client: TestClient) -> Execute:
+    def execute_helper(id: int, data: dict[str, Any]) -> Response:
+        return test_client.patch(f"/v1/test-executions/{id}", json=data)
+
+    return execute_helper
+
+
+def test_updates_test_execution(execute: Execute, test_execution: TestExecution):
+    execute(
+        test_execution.id,
+        {
             "ci_link": "http://ci_link/",
             "c3_link": "http://c3_link/",
-            "status": TestExecutionStatus.PASSED.name,
+            "status": "PASSED",
         },
     )
     assert test_execution.ci_link == "http://ci_link/"
     assert test_execution.c3_link == "http://c3_link/"
     assert test_execution.status == TestExecutionStatus.PASSED
+
+
+def test_set_completed_status_with_failures(
+    execute: Execute, test_execution: TestExecution, generator: DataGenerator
+):
+    c1 = generator.gen_test_case(name="case1")
+    c2 = generator.gen_test_case(name="case2")
+    generator.gen_test_result(c1, test_execution, status=TestResultStatus.PASSED)
+    generator.gen_test_result(c2, test_execution, status=TestResultStatus.FAILED)
+
+    response = execute(test_execution.id, {"status": "COMPLETED"})
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "FAILED"
+    assert test_execution.status == TestExecutionStatus.FAILED
+
+
+def test_set_completed_status_all_green(
+    execute: Execute, test_execution: TestExecution, generator: DataGenerator
+):
+    c = generator.gen_test_case()
+    generator.gen_test_result(c, test_execution, TestResultStatus.PASSED)
+
+    response = execute(test_execution.id, {"status": "COMPLETED"})
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "PASSED"
+    assert test_execution.status == TestExecutionStatus.PASSED
+
+
+def test_set_completed_status_no_results(
+    execute: Execute, test_execution: TestExecution
+):
+    response = execute(test_execution.id, {"status": "COMPLETED"})
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ENDED_PREMATURELY"
+    assert test_execution.status == TestExecutionStatus.ENDED_PREMATURELY


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

The new approach to ending a test execution is to set it's status to `COMPLETED`. TO doesn't have such a status but it maps it to the appropriate one depending on the results of the test execution.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

Resolves https://warthogs.atlassian.net/browse/RTW-423

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

`PATCH /v1/test-executions/id` endpoint can now take a new value for status `COMPLETED`.

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Added appropriate tests.
