### PR TITLE
Add charm family to test observer

### DIFF
--- a/backend/migrations/versions/2024_12_13_1702-0e09759a33c3_add_charm_family.py
+++ b/backend/migrations/versions/2024_12_13_1702-0e09759a33c3_add_charm_family.py
@@ -27,19 +27,19 @@ def upgrade() -> None:
     conn = op.get_bind()
     session = sa.orm.Session(bind=conn)
 
-    for family, stages in new_families.items():
+    for family_name, stage_names in new_families.items():
         # Create family
-        new_family = Family(name=family)
+        family = Family(name=family_name)
 
         # Add stages
         stage_position = 10
-        new_family.stages = []
-        for stage in stages:
-            new_family.stages.append(Stage(name=stage, position=stage_position))
+        family.stages = []
+        for stage_name in stage_names:
+            family.stages.append(Stage(name=stage_name, position=stage_position))
             stage_position += 10
 
         # Add family
-        session.add(new_family)
+        session.add(family)
 
     session.commit()
 
@@ -49,8 +49,8 @@ def downgrade() -> None:
     session = sa.orm.Session(bind=conn)
 
     # Delete each family, stage deletes on cascade
-    for family in new_families:
-        family = session.query(Family).filter_by(name=family).first()
+    for family_name in new_families:
+        family = session.query(Family).filter_by(name=family_name).first()
         session.delete(family)
 
     session.commit()

--- a/backend/migrations/versions/2024_12_13_1702-0e09759a33c3_add_charm_family.py
+++ b/backend/migrations/versions/2024_12_13_1702-0e09759a33c3_add_charm_family.py
@@ -1,0 +1,56 @@
+"""Add charm family
+
+Revision ID: 0e09759a33c3
+Revises: 4c2e5946358c
+Create Date: 2024-12-13 17:02:14.136283+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from test_observer.data_access.models_enums import FamilyName
+from test_observer.data_access.models import Family, Stage
+
+new_families = {
+    FamilyName.CHARM: ["edge", "beta", "candidate", "stable"],
+}
+
+
+# revision identifiers, used by Alembic.
+revision = "0e09759a33c3"
+down_revision = "4c2e5946358c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    session = sa.orm.Session(bind=conn)
+
+    for family, stages in new_families.items():
+        # Create family
+        new_family = Family(name=family)
+
+        # Add stages
+        stage_position = 10
+        new_family.stages = []
+        for stage in stages:
+            new_family.stages.append(Stage(name=stage, position=stage_position))
+            stage_position += 10
+
+        # Add family
+        session.add(new_family)
+
+    session.commit()
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    session = sa.orm.Session(bind=conn)
+
+    # Delete each family, stage deletes on cascade
+    for family in new_families:
+        family = session.query(Family).filter_by(name=family).first()
+        session.delete(family)
+
+    session.commit()

--- a/backend/scripts/seed_data.py
+++ b/backend/scripts/seed_data.py
@@ -21,6 +21,7 @@ from test_observer.controllers.test_executions.models import (
     EndTestExecutionRequest,
     StartDebTestExecutionRequest,
     StartSnapTestExecutionRequest,
+    StartCharmTestExecutionRequest,
 )
 from test_observer.data_access.models import Artefact
 from test_observer.data_access.models_enums import FamilyName
@@ -250,6 +251,18 @@ START_TEST_EXECUTION_REQUESTS = [
         environment="rpi400",
         ci_link="http://example17",
         test_plan="com.canonical.certification::sru-server",
+    ),
+    StartCharmTestExecutionRequest(
+        family=FamilyName.CHARM,
+        name="postgresql-k8s",
+        version="123",
+        revision=123,
+        track="14",
+        arch="arm64",
+        execution_stage="candidate",
+        environment="juju=3.5 ubuntu=22.04 cloud=k8s",
+        ci_link="http://example13",
+        test_plan="com.canonical.solutions-qa::tbd",
     ),
 ]
 

--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -70,6 +70,12 @@ class StartDebTestExecutionRequest(_StartTestExecutionRequest):
     repo: str
 
 
+class StartCharmTestExecutionRequest(_StartTestExecutionRequest):
+    family: Literal[FamilyName.CHARM]
+    revision: int
+    track: str
+
+
 class C3TestResultStatus(str, Enum):
     PASS = "pass"
     FAIL = "fail"

--- a/backend/test_observer/data_access/models_enums.py
+++ b/backend/test_observer/data_access/models_enums.py
@@ -25,6 +25,7 @@ from enum import Enum
 class FamilyName(str, Enum):
     SNAP = "snap"
     DEB = "deb"
+    CHARM = "charm"
 
 
 class TestExecutionStatus(str, Enum):

--- a/backend/tests/controllers/artefacts/test_artefacts.py
+++ b/backend/tests/controllers/artefacts/test_artefacts.py
@@ -42,7 +42,7 @@ def test_get_latest_artefacts_by_family(
 
     old_timestamp = relevant_artefact.created_at - timedelta(days=1)
     generator.gen_artefact("edge", created_at=old_timestamp, version="1")
-    generator.gen_artefact("proposed")
+    generator.gen_artefact("proposed", family_name="deb")
 
     response = test_client.get("/v1/artefacts", params={"family": "snap"})
 

--- a/backend/tests/data_access/test_repository.py
+++ b/backend/tests/data_access/test_repository.py
@@ -123,7 +123,7 @@ def test_get_artefacts_by_family_name_latest(
 def test_get_artefacts_by_family_charm_unique(
     db_session: Session, generator: DataGenerator
 ):
-    """For latest charms, latest artefacts should be unique on name, track, and version"""
+    """For latest charms, artefacts should be unique on name, track, and version"""
     # Arrange
     specs = [
         ("name-1", "track-1", "version-1"),
@@ -155,7 +155,7 @@ def test_get_artefacts_by_family_charm_unique(
 def test_get_artefacts_by_family_charm_all_architectures(
     db_session: Session, generator: DataGenerator
 ):
-    """For latest charms, latest artefacts should return all known architectures"""
+    """For latest charms, artefacts should return all known architectures"""
     # Arrange
     specs = [
         ("version-3", "arch-1", 0),

--- a/backend/tests/data_access/test_repository.py
+++ b/backend/tests/data_access/test_repository.py
@@ -20,7 +20,8 @@
 """Test services functions"""
 
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 
 from sqlalchemy.orm import Session
 
@@ -87,16 +88,17 @@ def test_get_artefacts_by_family_name_latest(
     """We should get a only latest artefacts in each stage for the specified family"""
     # Arrange
     artefact_tuple = [
-        ("core20", "edge", datetime.utcnow(), "1"),
-        ("oem-jammy", "proposed", datetime.utcnow(), "1"),
-        ("core20", "edge", datetime.utcnow() - timedelta(days=10), "2"),
-        ("core20", "beta", datetime.utcnow() - timedelta(days=20), "3"),
+        ("core20", "snap", "edge", datetime.utcnow(), "1"),
+        ("oem-jammy", "deb", "proposed", datetime.utcnow(), "1"),
+        ("core20", "snap", "edge", datetime.utcnow() - timedelta(days=10), "2"),
+        ("core20", "snap", "beta", datetime.utcnow() - timedelta(days=20), "3"),
     ]
     expected_artefacts = {artefact_tuple[0], artefact_tuple[-1]}
 
-    for name, stage, created_at, version in artefact_tuple:
+    for name, family, stage, created_at, version in artefact_tuple:
         generator.gen_artefact(
             stage,
+            family_name=family,
             name=name,
             created_at=created_at,
             version=version,
@@ -108,6 +110,75 @@ def test_get_artefacts_by_family_name_latest(
     # Assert
     assert len(artefacts) == len(expected_artefacts)
     assert {
-        (artefact.name, artefact.stage.name, artefact.created_at, artefact.version)
+        (
+            artefact.name,
+            artefact.stage.family.name,
+            artefact.stage.name,
+            artefact.created_at,
+            artefact.version,
+        )
         for artefact in artefacts
     } == expected_artefacts
+
+
+def test_get_artefacts_by_family_charm_latest_architectures(
+    db_session: Session, generator: DataGenerator
+):
+    """For latest charms, latest artefacts should include all unique architectures"""
+    # Arrange
+    base = SimpleNamespace(
+        expect=True,
+        name="name-1",
+        version="1",
+        family="charm",
+        track="track-1",
+        stage="edge",
+        day=0,
+        arches=["arch-1"],
+    )
+    specs = [
+        # Base case
+        SimpleNamespace(),
+        # Family is not Charm
+        SimpleNamespace(version="2", family="snap", expect=False),
+        # Name different from base (same version)
+        SimpleNamespace(name="name-2"),
+        # Track different from base (same version)
+        SimpleNamespace(track="track-2"),
+        # Version different from base (same date, return both)
+        SimpleNamespace(version="3"),
+        # Stage different from base
+        SimpleNamespace(version="4", stage="beta"),
+        # Older release than base
+        SimpleNamespace(version="5", day=-1, expect=False),
+        # Older release than base with unique arch
+        SimpleNamespace(version="6", day=-1, arches=["arch-1", "arch-2"]),
+    ]
+
+    expected_artefacts = []
+    for spec in specs:
+        spec = SimpleNamespace(**{**vars(base), **vars(spec)})
+        artefact = generator.gen_artefact(
+            spec.stage,
+            family_name=spec.family,
+            name=spec.name,
+            version=spec.version,
+            track=spec.track,
+            created_at=datetime(2024, 1, 1, tzinfo=timezone.utc)
+            + timedelta(days=spec.day),
+        )
+        for arch in spec.arches:
+            generator.gen_artefact_build(
+                artefact,
+                arch,
+            )
+        if spec.expect:
+            expected_artefacts.append(artefact)
+
+    # Act
+    artefacts = get_artefacts_by_family(db_session, FamilyName.CHARM)
+
+    # Assert
+    assert sorted([a.id for a in artefacts]) == sorted(
+        [a.id for a in expected_artefacts]
+    )

--- a/backend/tests/kernel_swm_integration/test_swm_integrator.py
+++ b/backend/tests/kernel_swm_integration/test_swm_integrator.py
@@ -21,7 +21,7 @@ def test_update_artefacts_with_tracker_info(
         "due_date": date(2024, 2, 20),
     }
     artefact1 = generator.gen_artefact("beta")
-    artefact2 = generator.gen_artefact("proposed")
+    artefact2 = generator.gen_artefact("proposed", family_name="deb")
     artefacts_swm_info = {artefact2.id: tracker_info_2, artefact1.id: tracker_info_1}
 
     update_artefacts_with_tracker_info(db_session, artefacts_swm_info)

--- a/backend/tests/promotion/test_promoter.py
+++ b/backend/tests/promotion/test_promoter.py
@@ -111,6 +111,7 @@ def test_run_to_move_artefact_deb(
     # Arrange
     artefact1 = generator.gen_artefact(
         "proposed",
+        family_name="deb",
         name="linux-generic",
         version="5.19.0.43.39",
         series="kinetic",
@@ -119,6 +120,7 @@ def test_run_to_move_artefact_deb(
     )
     artefact2 = generator.gen_artefact(
         "proposed",
+        family_name="deb",
         name="linux-oem-22_04a",
         version="6.1.0.1028.29",
         series="kinetic",
@@ -127,6 +129,7 @@ def test_run_to_move_artefact_deb(
     )
     artefact3 = generator.gen_artefact(
         "proposed",
+        family_name="deb",
         name="linux-cloud-tools-5_15.0-86",
         version="5.15.0-86.96",
         series="kinetic",

--- a/frontend/lib/models/family_name.dart
+++ b/frontend/lib/models/family_name.dart
@@ -1,1 +1,1 @@
-enum FamilyName { snap, deb }
+enum FamilyName { snap, deb, charm }

--- a/frontend/lib/models/stage_name.dart
+++ b/frontend/lib/models/stage_name.dart
@@ -16,5 +16,12 @@ List<StageName> familyStages(FamilyName family) {
         StageName.proposed,
         StageName.updates,
       ];
+    case FamilyName.charm:
+      return [
+        StageName.edge,
+        StageName.beta,
+        StageName.candidate,
+        StageName.stable,
+      ];
   }
 }

--- a/frontend/lib/routing.dart
+++ b/frontend/lib/routing.dart
@@ -46,6 +46,20 @@ final appRouter = GoRouter(
             ),
           ),
         ),
+        GoRoute(
+          path: AppRoutes.charms,
+          pageBuilder: (_, __) => const NoTransitionPage(
+            child: Dashboard(),
+          ),
+        ),
+        GoRoute(
+          path: '${AppRoutes.charms}/:artefactId',
+          pageBuilder: (context, state) => NoTransitionPage(
+            child: ArtefactPage(
+              artefactId: int.parse(state.pathParameters['artefactId']!),
+            ),
+          ),
+        ),
       ],
     ),
   ],
@@ -65,6 +79,7 @@ class CommonQueryParameters {
 class AppRoutes {
   static const snaps = '/snaps';
   static const debs = '/debs';
+  static const charms = '/charms';
 
   static Uri uriFromContext(BuildContext context) =>
       GoRouterState.of(context).uri;
@@ -74,6 +89,7 @@ class AppRoutes {
 
     if (path.startsWith(snaps)) return FamilyName.snap;
     if (path.startsWith(debs)) return FamilyName.deb;
+    if (path.startsWith(charms)) return FamilyName.charm;
 
     throw Exception('Unknown route: $path');
   }
@@ -84,11 +100,13 @@ class AppRoutes {
     throw Exception('$uri isn\'t an artefact page');
   }
 
-  static bool isDashboardPage(Uri uri) => {snaps, debs}.contains(uri.path);
+  static bool isDashboardPage(Uri uri) =>
+      {snaps, debs, charms}.contains(uri.path);
 
   static bool isArtefactPage(Uri uri) =>
       (uri.path.contains(AppRoutes.snaps) ||
-          uri.path.contains(AppRoutes.debs)) &&
+          uri.path.contains(AppRoutes.debs) ||
+          uri.path.contains(AppRoutes.charms)) &&
       uri.pathSegments.length == 2;
 }
 
@@ -103,6 +121,9 @@ void navigateToArtefactPage(BuildContext context, int artefactId) {
       break;
     case FamilyName.snap:
       path = AppRoutes.snaps + path;
+      break;
+    case FamilyName.charm:
+      path = AppRoutes.charms + path;
       break;
   }
 

--- a/frontend/lib/ui/dashboard/dashboard_body/artefacts_list_view/artefacts_list_view.dart
+++ b/frontend/lib/ui/dashboard/dashboard_body/artefacts_list_view/artefacts_list_view.dart
@@ -37,6 +37,14 @@ class ArtefactsListView extends ConsumerWidget {
     return _Row.deb(key: PageStorageKey(artefact.id), artefact: artefact);
   }
 
+  const ArtefactsListView.charms({super.key})
+      : listHeader = const _Headers.charms(key: PageStorageKey('Header')),
+        listItemBuilder = _charmsListItemBuilder;
+
+  static Widget _charmsListItemBuilder(Artefact artefact) {
+    return _Row.charm(key: PageStorageKey(artefact.id), artefact: artefact);
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final pageUri = AppRoutes.uriFromContext(context);

--- a/frontend/lib/ui/dashboard/dashboard_body/artefacts_list_view/column_metadata.dart
+++ b/frontend/lib/ui/dashboard/dashboard_body/artefacts_list_view/column_metadata.dart
@@ -115,6 +115,57 @@ const _debColumnsMetadata = <ColumnMetadata>[
   ),
 ];
 
+const _charmColumnsMetadata = <ColumnMetadata>[
+  (
+    name: 'Name',
+    queryParam: ArtefactSortingQuery.name,
+    flex: 2,
+    cellBuilder: _buildNameCell,
+  ),
+  (
+    name: 'Version',
+    queryParam: ArtefactSortingQuery.version,
+    flex: 2,
+    cellBuilder: _buildVersionCell,
+  ),
+  (
+    name: 'Track',
+    queryParam: ArtefactSortingQuery.track,
+    flex: 1,
+    cellBuilder: _buildTrackCell,
+  ),
+  (
+    name: 'Risk',
+    queryParam: ArtefactSortingQuery.risk,
+    flex: 1,
+    cellBuilder: _buildStageCell,
+  ),
+  (
+    name: 'Due date',
+    queryParam: ArtefactSortingQuery.dueDate,
+    flex: 1,
+    cellBuilder: _buildDueDateCell,
+  ),
+  (
+    name: 'Reviews remaining',
+    queryParam: ArtefactSortingQuery.reviewsRemaining,
+    flex: 1,
+    cellBuilder: _buildReviewsRemainingCell,
+  ),
+  (
+    name: 'Status',
+    queryParam: ArtefactSortingQuery.status,
+    flex: 1,
+    cellBuilder: _buildStatusCell,
+  ),
+  (
+    name: 'Assignee',
+    queryParam: ArtefactSortingQuery.assignee,
+    flex: 1,
+    cellBuilder: _buildAssigneeCell,
+  ),
+];
+
 Widget _buildNameCell(BuildContext context, Artefact artefact) =>
     Text(artefact.name);
 

--- a/frontend/lib/ui/dashboard/dashboard_body/artefacts_list_view/headers.dart
+++ b/frontend/lib/ui/dashboard/dashboard_body/artefacts_list_view/headers.dart
@@ -9,6 +9,8 @@ class _Headers extends StatelessWidget {
 
   const _Headers.snaps({super.key}) : columnsMetaData = _snapColumnsMetadata;
 
+  const _Headers.charms({super.key}) : columnsMetaData = _charmColumnsMetadata;
+
   @override
   Widget build(BuildContext context) {
     final uri = AppRoutes.uriFromContext(context);

--- a/frontend/lib/ui/dashboard/dashboard_body/artefacts_list_view/row.dart
+++ b/frontend/lib/ui/dashboard/dashboard_body/artefacts_list_view/row.dart
@@ -15,6 +15,9 @@ class _Row extends StatelessWidget {
   const _Row.snap({super.key, required this.artefact})
       : columnsMetaData = _snapColumnsMetadata;
 
+  const _Row.charm({super.key, required this.artefact})
+      : columnsMetaData = _charmColumnsMetadata;
+
   @override
   Widget build(BuildContext context) {
     return InkWell(

--- a/frontend/lib/ui/dashboard/dashboard_body/dashboard_body.dart
+++ b/frontend/lib/ui/dashboard/dashboard_body/dashboard_body.dart
@@ -22,6 +22,7 @@ class DashboardBody extends StatelessWidget {
         (_, ViewModes.dashboard) => const ArtefactsColumnsView(),
         (FamilyName.snap, ViewModes.list) => const ArtefactsListView.snaps(),
         (FamilyName.deb, ViewModes.list) => const ArtefactsListView.debs(),
+        (FamilyName.charm, ViewModes.list) => const ArtefactsListView.charms(),
       },
     );
   }

--- a/frontend/lib/ui/navbar.dart
+++ b/frontend/lib/ui/navbar.dart
@@ -25,6 +25,7 @@ class Navbar extends StatelessWidget {
               children: [
                 _NavbarEntry(title: 'Snap Testing', route: AppRoutes.snaps),
                 _NavbarEntry(title: 'Deb Testing', route: AppRoutes.debs),
+                _NavbarEntry(title: 'Charm Testing', route: AppRoutes.charms),
               ],
             ),
           ),


### PR DESCRIPTION
## Description

Adds charm family and stages to the database, and updates the scattered backend and frontend logic to also support Charms. 

I think it'd be worth making an improvement ticket to centralize all this logic in a file/module just so it's manageable. I don't know when or if there will ever be time to get this done, but having loads of ifs and matches throughout the code is a bit of a headache.

## Resolved issues

[SQT-392](https://warthogs.atlassian.net/browse/SQT-392)

## Documentation

I don't believe any documentation needs to be updated. These changes following the existing pattern used by Snaps and Debs.

## Web service API changes

Not really applicable, can now specify `CHARM` has a family.

## Tests

* Existing unit tests pass
* Charm added to `seed_data.py`
* Test added to the unique artefacts query for Charms that includes all instances of architectures.
* Front end tested by poking around the UI with the seed_data

![Screenshot from 2024-12-13 11-46-20](https://github.com/user-attachments/assets/2ad50cfa-5e7d-42c8-976a-5f858361dde2)
![Screenshot from 2024-12-13 11-46-39](https://github.com/user-attachments/assets/a02b209b-a7f8-4207-83bb-3ffea0b6e68b)



[SQT-392]: https://warthogs.atlassian.net/browse/SQT-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ