### PR TITLE
Remove package building, it's only used for dynamic versioning which isn't working

### DIFF
--- a/backend/Dockerfile.production
+++ b/backend/Dockerfile.production
@@ -8,13 +8,10 @@ COPY backend/poetry.lock .
 
 COPY backend/pyproject.toml .
 
-RUN --mount=source=.git,target=.git,type=bind pip3 install poetry && \
+RUN pip3 install poetry && \
     poetry config virtualenvs.create false && \
-    poetry install --no-interaction --no-ansi --without dev && \
-    pip3 install --user poetry-dynamic-versioning[plugin]
+    poetry install --no-interaction --no-ansi --without dev
 
 COPY ./backend .
-
-RUN --mount=source=.git,target=.git,type=bind poetry build && pip3 install dist/*.whl
 
 CMD [ "uvicorn",  "test_observer.main:app", "--host", "0.0.0.0", "--port", "30000" ]


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

Due to a poetry update, building images stopped working as it's trying to install test observer as a package which it isn't. When specifying through pyproject.toml that the project isn't a package the development image got built successfully. But turns out the production [one didn't](https://github.com/canonical/test_observer/actions/runs/12653246130/job/35258021016#step:7:542). Because the production image is trying to install test observer as a package again (it used to work because it installed it in the parent directory context and not the backend context). I don't think there is much use of treating test observer api as a package frankly. The production image tried to do that to use poetry dynamic versioning. But it didn't work anyways and you can check that by visiting https://test-observer-api.canonical.com/v1/version.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Built the production image locally and it succeeded.
