### PR TITLE
Allow null ci link in start-test endpoint

### DIFF
--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -46,7 +46,7 @@ class _StartTestExecutionRequest(BaseModel):
     arch: str
     execution_stage: StageName
     environment: str
-    ci_link: Annotated[str, HttpUrl]
+    ci_link: Annotated[str, HttpUrl] | None
     test_plan: str = Field(max_length=200)
     initial_status: TestExecutionStatus = TestExecutionStatus.IN_PROGRESS
 

--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -46,7 +46,7 @@ class _StartTestExecutionRequest(BaseModel):
     arch: str
     execution_stage: StageName
     environment: str
-    ci_link: Annotated[str, HttpUrl] | None
+    ci_link: Annotated[str, HttpUrl] | None = None
     test_plan: str = Field(max_length=200)
     initial_status: TestExecutionStatus = TestExecutionStatus.IN_PROGRESS
 

--- a/backend/tests/controllers/test_executions/test_start_test.py
+++ b/backend/tests/controllers/test_executions/test_start_test.py
@@ -97,7 +97,6 @@ def test_requires_family_field(execute: Execute):
         "arch",
         "execution_stage",
         "environment",
-        "ci_link",
         "test_plan",
         "store",
         "track",
@@ -121,7 +120,6 @@ def test_snap_required_fields(execute: Execute, field: str):
         "arch",
         "execution_stage",
         "environment",
-        "ci_link",
         "test_plan",
     ],
 )
@@ -364,9 +362,35 @@ def test_sets_initial_test_execution_status(db_session: Session, execute: Execut
 
 
 def test_allows_null_ci_link(db_session: Session, execute: Execute):
-    response = execute({**deb_test_request, "ci_link": None})
+    request = {**deb_test_request, "ci_link": None}
+
+    response = execute(request)
 
     assert response.status_code == 200
     te = db_session.get(TestExecution, response.json()["id"])
     assert te is not None
     assert te.ci_link is None
+
+
+def test_allows_omitting_ci_link(db_session: Session, execute: Execute):
+    request = {**deb_test_request}
+    del request["ci_link"]
+
+    response = execute(request)
+
+    assert response.status_code == 200
+    te = db_session.get(TestExecution, response.json()["id"])
+    assert te is not None
+    assert te.ci_link is None
+
+
+def test_create_two_executions_for_null_ci_link(execute: Execute):
+    request = {**deb_test_request}
+    del request["ci_link"]
+
+    response_1 = execute(request)
+    response_2 = execute(request)
+
+    assert response_1.status_code == 200
+    assert response_2.status_code == 200
+    assert response_1.json()["id"] != response_2.json()["id"]

--- a/backend/tests/controllers/test_executions/test_start_test.py
+++ b/backend/tests/controllers/test_executions/test_start_test.py
@@ -361,3 +361,12 @@ def test_sets_initial_test_execution_status(db_session: Session, execute: Execut
     te = db_session.get(TestExecution, response.json()["id"])
     assert te is not None
     assert te.status == TestExecutionStatus.NOT_STARTED
+
+
+def test_allows_null_ci_link(db_session: Session, execute: Execute):
+    response = execute({**deb_test_request, "ci_link": None})
+
+    assert response.status_code == 200
+    te = db_session.get(TestExecution, response.json()["id"])
+    assert te is not None
+    assert te.ci_link is None


### PR DESCRIPTION
## Description

Allows the submission to the `/start-test` endpoint of a test execution with a null CI link.

null was already a valid value for a the CI link in the test execution model, but the endpoint would not accept it.

## Resolved issues

[SQT-429][https://warthogs.atlassian.net/browse/SQT-429)

## Documentation

N/A

## Web service API changes

Fully backwards compatible.

## Tests

Unit test added that calls `/start-test` with a null CI link.


[SQT-429]: https://warthogs.atlassian.net/browse/SQT-429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ