### PR TITLE
Return more information from GET reruns endpoint.

### DIFF
--- a/backend/test_observer/controllers/artefacts/models.py
+++ b/backend/test_observer/controllers/artefacts/models.py
@@ -108,7 +108,9 @@ class ArtefactVersionDTO(BaseModel):
     artefact_id: int = Field(validation_alias=AliasPath("id"))
 
 
-class _EnvironmentReviewArtefactBuild(BaseModel):
+class ArtefactBuildMinimalDTO(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     architecture: str
     revision: int | None
@@ -119,7 +121,7 @@ class ArtefactBuildEnvironmentReviewDTO(BaseModel):
     review_decision: list[ArtefactBuildEnvironmentReviewDecision]
     review_comment: str
     environment: EnvironmentDTO
-    artefact_build: _EnvironmentReviewArtefactBuild
+    artefact_build: ArtefactBuildMinimalDTO
 
 
 class EnvironmentReviewPatch(BaseModel):

--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -38,6 +38,7 @@ from test_observer.data_access.models_enums import (
     TestExecutionStatus,
     TestResultStatus,
 )
+from test_observer.controllers.artefacts.models import TestExecutionDTO, ArtefactDTO
 
 
 class _StartTestExecutionRequest(BaseModel):
@@ -157,39 +158,12 @@ class PendingRerun(BaseModel):
             "test_execution", "artefact_build", "artefact", "family"
         )
     )
-    test_execution_status: TestExecutionStatus = Field(
-        validation_alias=AliasPath("test_execution", "status")
+    test_execution: TestExecutionDTO = Field(
+        validation_alias=AliasPath("test_execution")
     )
-    artefact_name: str = Field(
-        validation_alias=AliasPath(
-            "test_execution", "artefact_build", "artefact", "name"
-        )
+    artefact: ArtefactDTO = Field(
+        validation_alias=AliasPath("test_execution", "artefact_build", "artefact")
     )
-    version: str = Field(
-        validation_alias=AliasPath(
-            "test_execution", "artefact_build", "artefact", "version"
-        )
-    )
-    revision: int | None = Field(
-        validation_alias=AliasPath("test_execution", "artefact_build", "revision")
-    )
-    stage: StageName = Field(
-        validation_alias=AliasPath(
-            "test_execution", "artefact_build", "artefact", "stage"
-        )
-    )
-    track: str = Field(
-        validation_alias=AliasPath(
-            "test_execution", "artefact_build", "artefact", "track"
-        )
-    )
-    architecture: str = Field(
-        validation_alias=AliasPath("test_execution", "environment", "architecture")
-    )
-    environment: str = Field(
-        validation_alias=AliasPath("test_execution", "environment", "name")
-    )
-    test_plan: str = Field(validation_alias=AliasPath("test_execution", "test_plan"))
 
 
 class DeleteReruns(BaseModel):

--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -38,7 +38,11 @@ from test_observer.data_access.models_enums import (
     TestExecutionStatus,
     TestResultStatus,
 )
-from test_observer.controllers.artefacts.models import TestExecutionDTO, ArtefactDTO
+from test_observer.controllers.artefacts.models import (
+    TestExecutionDTO,
+    ArtefactDTO,
+    ArtefactBuildMinimalDTO,
+)
 
 
 class _StartTestExecutionRequest(BaseModel):
@@ -163,6 +167,9 @@ class PendingRerun(BaseModel):
     )
     artefact: ArtefactDTO = Field(
         validation_alias=AliasPath("test_execution", "artefact_build", "artefact")
+    )
+    artefact_build: ArtefactBuildMinimalDTO = Field(
+        validation_alias=AliasPath("test_execution", "artefact_build")
     )
 
 

--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -151,12 +151,35 @@ class RerunRequest(BaseModel):
 
 class PendingRerun(BaseModel):
     test_execution_id: int
-    ci_link: str = Field(validation_alias=AliasPath("test_execution", "ci_link"))
+    ci_link: str | None = Field(validation_alias=AliasPath("test_execution", "ci_link"))
     family: FamilyName = Field(
         validation_alias=AliasPath(
             "test_execution", "artefact_build", "artefact", "family"
         )
     )
+    test_execution_status: TestExecutionStatus = Field(
+        validation_alias=AliasPath("test_execution", "status")
+    )
+    artefact_name: str = Field(
+        validation_alias=AliasPath(
+            "test_execution", "artefact_build", "artefact", "name"
+        )
+    )
+    version: str = Field(
+        validation_alias=AliasPath(
+            "test_execution", "artefact_build", "artefact", "version"
+        )
+    )
+    revision: int | None = Field(
+        validation_alias=AliasPath("test_execution", "artefact_build", "revision")
+    )
+    architecture: str = Field(
+        validation_alias=AliasPath("test_execution", "environment", "architecture")
+    )
+    environment: str = Field(
+        validation_alias=AliasPath("test_execution", "environment", "name")
+    )
+    test_plan: str = Field(validation_alias=AliasPath("test_execution", "test_plan"))
 
 
 class DeleteReruns(BaseModel):

--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -173,6 +173,16 @@ class PendingRerun(BaseModel):
     revision: int | None = Field(
         validation_alias=AliasPath("test_execution", "artefact_build", "revision")
     )
+    stage: StageName = Field(
+        validation_alias=AliasPath(
+            "test_execution", "artefact_build", "artefact", "stage"
+        )
+    )
+    track: str = Field(
+        validation_alias=AliasPath(
+            "test_execution", "artefact_build", "artefact", "track"
+        )
+    )
     architecture: str = Field(
         validation_alias=AliasPath("test_execution", "environment", "architecture")
     )

--- a/backend/test_observer/controllers/test_executions/reruns.py
+++ b/backend/test_observer/controllers/test_executions/reruns.py
@@ -8,6 +8,7 @@ from test_observer.data_access.models import (
     ArtefactBuild,
     TestExecution,
     TestExecutionRerunRequest,
+    Artefact,
 )
 from test_observer.data_access.repository import get_or_create
 from test_observer.data_access.setup import get_db
@@ -54,7 +55,8 @@ def get_rerun_requests(db: Session = Depends(get_db)):
         select(TestExecutionRerunRequest).options(
             joinedload(TestExecutionRerunRequest.test_execution)
             .joinedload(TestExecution.artefact_build)
-            .joinedload(ArtefactBuild.artefact),
+            .joinedload(ArtefactBuild.artefact)
+            .joinedload(Artefact.assignee),
             joinedload(TestExecutionRerunRequest.test_execution).joinedload(
                 TestExecution.environment
             ),

--- a/backend/test_observer/controllers/test_executions/reruns.py
+++ b/backend/test_observer/controllers/test_executions/reruns.py
@@ -54,7 +54,10 @@ def get_rerun_requests(db: Session = Depends(get_db)):
         select(TestExecutionRerunRequest).options(
             joinedload(TestExecutionRerunRequest.test_execution)
             .joinedload(TestExecution.artefact_build)
-            .joinedload(ArtefactBuild.artefact)
+            .joinedload(ArtefactBuild.artefact),
+            joinedload(TestExecutionRerunRequest.test_execution).joinedload(
+                TestExecution.environment
+            ),
         )
     )
 

--- a/backend/test_observer/controllers/test_executions/start_test.py
+++ b/backend/test_observer/controllers/test_executions/start_test.py
@@ -86,7 +86,10 @@ def start_test_execution(
             filter_kwargs={
                 "architecture": request.arch,
                 "revision": request.revision
-                if isinstance(request, StartSnapTestExecutionRequest)
+                if isinstance(
+                    request,
+                    StartSnapTestExecutionRequest | StartCharmTestExecutionRequest,
+                )
                 else None,
                 "artefact_id": artefact.id,
             },

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -51,6 +51,8 @@ def test_execution_to_pending_rerun(test_execution: TestExecution) -> dict:
         "artefact_name": test_execution.artefact_build.artefact.name,
         "version": test_execution.artefact_build.artefact.version,
         "revision": test_execution.artefact_build.revision,
+        "stage": test_execution.artefact_build.artefact.stage,
+        "track": test_execution.artefact_build.artefact.track,
         "architecture": test_execution.environment.architecture,
         "environment": test_execution.environment.name,
         "test_plan": test_execution.test_plan,

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -10,11 +10,6 @@ from httpx import Response
 from test_observer.data_access.models import TestExecution
 from test_observer.data_access.models_enums import StageName
 from tests.data_generator import DataGenerator
-from test_observer.controllers.artefacts.models import (
-    TestExecutionDTO,
-    ArtefactDTO,
-    ArtefactBuildMinimalDTO,
-)
 
 reruns_url = "/v1/test-executions/reruns"
 
@@ -54,11 +49,44 @@ def test_execution_to_pending_rerun(test_execution: TestExecution) -> dict:
             "test_execution_id": test_execution.id,
             "ci_link": test_execution.ci_link,
             "family": test_execution.artefact_build.artefact.family,
-            "test_execution": TestExecutionDTO.from_orm(test_execution),
-            "artefact": ArtefactDTO.from_orm(test_execution.artefact_build.artefact),
-            "artefact_build": ArtefactBuildMinimalDTO.from_orm(
-                test_execution.artefact_build
-            ),
+            "test_execution": {
+                "id": test_execution.id,
+                "ci_link": test_execution.ci_link,
+                "c3_link": test_execution.c3_link,
+                "environment": {
+                    "id": test_execution.environment.id,
+                    "name": test_execution.environment.name,
+                    "architecture": test_execution.environment.architecture,
+                },
+                "status": test_execution.status,
+                "test_plan": test_execution.test_plan,
+                "is_rerun_requested": bool(test_execution.rerun_request),
+            },
+            "artefact": {
+                "id": test_execution.artefact_build.artefact.id,
+                "name": test_execution.artefact_build.artefact.name,
+                "version": test_execution.artefact_build.artefact.version,
+                "track": test_execution.artefact_build.artefact.track,
+                "store": test_execution.artefact_build.artefact.store,
+                "series": test_execution.artefact_build.artefact.series,
+                "repo": test_execution.artefact_build.artefact.repo,
+                "stage": test_execution.artefact_build.artefact.stage,
+                "status": test_execution.artefact_build.artefact.status,
+                "assignee": test_execution.artefact_build.artefact.assignee,
+                "due_date": test_execution.artefact_build.artefact.due_date,
+                "bug_link": test_execution.artefact_build.artefact.bug_link,
+                "all_environment_reviews_count": (
+                    test_execution.artefact_build.artefact.all_environment_reviews_count
+                ),
+                "completed_environment_reviews_count": (
+                    test_execution.artefact_build.artefact.completed_environment_reviews_count
+                ),
+            },
+            "artefact_build": {
+                "id": test_execution.artefact_build.id,
+                "architecture": test_execution.artefact_build.architecture,
+                "revision": test_execution.artefact_build.revision,
+            },
         }
     )
 

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -10,7 +10,11 @@ from httpx import Response
 from test_observer.data_access.models import TestExecution
 from test_observer.data_access.models_enums import StageName
 from tests.data_generator import DataGenerator
-from test_observer.controllers.artefacts.models import TestExecutionDTO, ArtefactDTO
+from test_observer.controllers.artefacts.models import (
+    TestExecutionDTO,
+    ArtefactDTO,
+    ArtefactBuildMinimalDTO,
+)
 
 reruns_url = "/v1/test-executions/reruns"
 
@@ -52,6 +56,9 @@ def test_execution_to_pending_rerun(test_execution: TestExecution) -> dict:
             "family": test_execution.artefact_build.artefact.family,
             "test_execution": TestExecutionDTO.from_orm(test_execution),
             "artefact": ArtefactDTO.from_orm(test_execution.artefact_build.artefact),
+            "artefact_build": ArtefactBuildMinimalDTO.from_orm(
+                test_execution.artefact_build
+            ),
         }
     )
 


### PR DESCRIPTION
## Description

Modifies the rerun endpoint to return all the information to trigger a new test from parameters.

The changes are backwards compatible.

Also adds revision to artefact build for Charms, missed that when adding the Charm family.

## Resolved issues

[SQT-428](https://warthogs.atlassian.net/browse/SQT-428)

## Documentation

Is there any?

## Web service API changes

`GET /reruns` now returns artefact, artefact_build, and test_execution DTOs.

## Tests

rerun tests have been updated to check all of the added fields.


[SQT-428]: https://warthogs.atlassian.net/browse/SQT-428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ