### PR TITLE
Allow end test by test execution id

### DIFF
--- a/backend/test_observer/controllers/test_executions/end_test.py
+++ b/backend/test_observer/controllers/test_executions/end_test.py
@@ -15,7 +15,7 @@
 #
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
+from sqlalchemy import select, or_
 from sqlalchemy.orm import Session, joinedload
 
 from test_observer.data_access.models import (
@@ -67,7 +67,12 @@ def _find_related_test_execution(
     return (
         db.execute(
             select(TestExecution)
-            .where(TestExecution.ci_link == request.ci_link)
+            .where(
+                or_(
+                    TestExecution.ci_link == request.ci_link,
+                    TestExecution.id == request.test_execution_id,
+                )
+            )
             .options(
                 joinedload(TestExecution.artefact_build).joinedload(
                     ArtefactBuild.artefact

--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -29,6 +29,7 @@ from pydantic import (
     Field,
     HttpUrl,
     field_validator,
+    model_validator,
 )
 
 from test_observer.common.constants import PREVIOUS_TEST_RESULT_COUNT
@@ -102,10 +103,17 @@ class TestResultRequest(BaseModel):
 
 
 class EndTestExecutionRequest(BaseModel):
-    ci_link: Annotated[str, HttpUrl]
+    ci_link: Annotated[str, HttpUrl] | None = None
+    test_execution_id: int | None = None
     c3_link: Annotated[str, HttpUrl] | None = None
     checkbox_version: str | None = None
     test_results: list[C3TestResult]
+
+    @model_validator(mode="after")
+    def ensure_test_execution_identifier(self) -> "EndTestExecutionRequest":
+        if sum([self.ci_link is None, self.test_execution_id is None]) != 1:
+            raise ValueError("Provide exactly one of 'ci_link' or 'test_execution_id'")
+        return self
 
 
 class TestExecutionsPatchRequest(BaseModel):


### PR DESCRIPTION
## Description

Updates the `/end-test` endpoint to accept a test execution id. I figure this is worth while now that test executions are not unique on their ci_link.

Changes are backwards compatible.

## Resolved issues

[SQT-430](https://warthogs.atlassian.net/browse/SQT-430)

## Documentation

N/A?

## Web service API changes

`/end-test` must have one of (and only one of) test execution id or ci link.

## Tests

Unit tests added to test the additional argument.


[SQT-430]: https://warthogs.atlassian.net/browse/SQT-430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ