### PR TITLE
DTO -> Response renaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 
 .idea
+build

--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -261,7 +261,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestExecutionDTO"
+                  "$ref": "#/components/schemas/TestExecutionResponse"
                 }
               }
             }
@@ -458,7 +458,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/TestEventDTO"
+                    "$ref": "#/components/schemas/TestEventResponse"
                   },
                   "title": "Response Get Status Update V1 Test Executions  Id  Status Update Get"
                 }
@@ -505,7 +505,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/ArtefactBuildEnvironmentReviewDTO"
+                    "$ref": "#/components/schemas/ArtefactBuildEnvironmentReviewResponse"
                   },
                   "title": "Response Get Environment Reviews V1 Artefacts  Artefact Id  Environment Reviews Get"
                 }
@@ -569,7 +569,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ArtefactBuildEnvironmentReviewDTO"
+                  "$ref": "#/components/schemas/ArtefactBuildEnvironmentReviewResponse"
                 }
               }
             }
@@ -615,7 +615,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/ArtefactBuildDTO"
+                    "$ref": "#/components/schemas/ArtefactBuildResponse"
                   },
                   "title": "Response Get Artefact Builds V1 Artefacts  Artefact Id  Builds Get"
                 }
@@ -669,7 +669,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/ArtefactDTO"
+                    "$ref": "#/components/schemas/ArtefactResponse"
                   },
                   "title": "Response Get Artefacts V1 Artefacts Get"
                 }
@@ -713,7 +713,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ArtefactDTO"
+                  "$ref": "#/components/schemas/ArtefactResponse"
                 }
               }
             }
@@ -763,7 +763,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ArtefactDTO"
+                  "$ref": "#/components/schemas/ArtefactResponse"
                 }
               }
             }
@@ -807,7 +807,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/ArtefactVersionDTO"
+                    "$ref": "#/components/schemas/ArtefactVersionResponse"
                   },
                   "title": "Response Get Artefact Versions V1 Artefacts  Artefact Id  Versions Get"
                 }
@@ -1352,7 +1352,7 @@
   },
   "components": {
     "schemas": {
-      "ArtefactBuildDTO": {
+      "ArtefactBuildResponse": {
         "properties": {
           "id": {
             "type": "integer",
@@ -1375,7 +1375,7 @@
           },
           "test_executions": {
             "items": {
-              "$ref": "#/components/schemas/TestExecutionDTO"
+              "$ref": "#/components/schemas/TestExecutionResponse"
             },
             "type": "array",
             "title": "Test Executions"
@@ -1388,9 +1388,9 @@
           "revision",
           "test_executions"
         ],
-        "title": "ArtefactBuildDTO"
+        "title": "ArtefactBuildResponse"
       },
-      "ArtefactBuildEnvironmentReviewDTO": {
+      "ArtefactBuildEnvironmentReviewResponse": {
         "properties": {
           "id": {
             "type": "integer",
@@ -1408,10 +1408,10 @@
             "title": "Review Comment"
           },
           "environment": {
-            "$ref": "#/components/schemas/EnvironmentDTO"
+            "$ref": "#/components/schemas/EnvironmentResponse"
           },
           "artefact_build": {
-            "$ref": "#/components/schemas/ArtefactBuildMinimalDTO"
+            "$ref": "#/components/schemas/ArtefactBuildMinimalResponse"
           }
         },
         "type": "object",
@@ -1422,7 +1422,7 @@
           "environment",
           "artefact_build"
         ],
-        "title": "ArtefactBuildEnvironmentReviewDTO"
+        "title": "ArtefactBuildEnvironmentReviewResponse"
       },
       "ArtefactBuildEnvironmentReviewDecision": {
         "type": "string",
@@ -1436,7 +1436,7 @@
         ],
         "title": "ArtefactBuildEnvironmentReviewDecision"
       },
-      "ArtefactBuildMinimalDTO": {
+      "ArtefactBuildMinimalResponse": {
         "properties": {
           "id": {
             "type": "integer",
@@ -1464,9 +1464,9 @@
           "architecture",
           "revision"
         ],
-        "title": "ArtefactBuildMinimalDTO"
+        "title": "ArtefactBuildMinimalResponse"
       },
-      "ArtefactDTO": {
+      "ArtefactResponse": {
         "properties": {
           "id": {
             "type": "integer",
@@ -1526,7 +1526,7 @@
           "assignee": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/UserDTO"
+                "$ref": "#/components/schemas/UserResponse"
               },
               {
                 "type": "null"
@@ -1580,7 +1580,7 @@
           "all_environment_reviews_count",
           "completed_environment_reviews_count"
         ],
-        "title": "ArtefactDTO"
+        "title": "ArtefactResponse"
       },
       "ArtefactPatch": {
         "properties": {
@@ -1603,7 +1603,7 @@
         ],
         "title": "ArtefactStatus"
       },
-      "ArtefactVersionDTO": {
+      "ArtefactVersionResponse": {
         "properties": {
           "version": {
             "type": "string",
@@ -1619,7 +1619,7 @@
           "version",
           "artefact_id"
         ],
-        "title": "ArtefactVersionDTO"
+        "title": "ArtefactVersionResponse"
       },
       "C3TestResult": {
         "properties": {
@@ -1733,7 +1733,7 @@
         ],
         "title": "EndTestExecutionRequest"
       },
-      "EnvironmentDTO": {
+      "EnvironmentResponse": {
         "properties": {
           "id": {
             "type": "integer",
@@ -1754,7 +1754,7 @@
           "name",
           "architecture"
         ],
-        "title": "EnvironmentDTO"
+        "title": "EnvironmentResponse"
       },
       "EnvironmentReportedIssueRequest": {
         "properties": {
@@ -1923,13 +1923,13 @@
             "$ref": "#/components/schemas/FamilyName"
           },
           "test_execution": {
-            "$ref": "#/components/schemas/TestExecutionDTO"
+            "$ref": "#/components/schemas/TestExecutionResponse"
           },
           "artefact": {
-            "$ref": "#/components/schemas/ArtefactDTO"
+            "$ref": "#/components/schemas/ArtefactResponse"
           },
           "artefact_build": {
-            "$ref": "#/components/schemas/ArtefactBuildMinimalDTO"
+            "$ref": "#/components/schemas/ArtefactBuildMinimalResponse"
           }
         },
         "type": "object",
@@ -2337,7 +2337,7 @@
         "properties": {
           "events": {
             "items": {
-              "$ref": "#/components/schemas/TestEventDTO"
+              "$ref": "#/components/schemas/TestEventResponse"
             },
             "type": "array",
             "title": "Events"
@@ -2349,7 +2349,7 @@
         ],
         "title": "StatusUpdateRequest"
       },
-      "TestEventDTO": {
+      "TestEventResponse": {
         "properties": {
           "event_name": {
             "type": "string",
@@ -2371,9 +2371,9 @@
           "timestamp",
           "detail"
         ],
-        "title": "TestEventDTO"
+        "title": "TestEventResponse"
       },
-      "TestExecutionDTO": {
+      "TestExecutionResponse": {
         "properties": {
           "id": {
             "type": "integer",
@@ -2402,7 +2402,7 @@
             "title": "C3 Link"
           },
           "environment": {
-            "$ref": "#/components/schemas/EnvironmentDTO"
+            "$ref": "#/components/schemas/EnvironmentResponse"
           },
           "status": {
             "$ref": "#/components/schemas/TestExecutionStatus"
@@ -2427,7 +2427,7 @@
           "test_plan",
           "is_rerun_requested"
         ],
-        "title": "TestExecutionDTO"
+        "title": "TestExecutionResponse"
       },
       "TestExecutionStatus": {
         "type": "string",
@@ -2669,7 +2669,7 @@
         ],
         "title": "TestResultStatus"
       },
-      "UserDTO": {
+      "UserResponse": {
         "properties": {
           "id": {
             "type": "integer",
@@ -2695,7 +2695,7 @@
           "launchpad_email",
           "name"
         ],
-        "title": "UserDTO"
+        "title": "UserResponse"
       },
       "ValidationError": {
         "properties": {

--- a/backend/test_observer/controllers/artefacts/artefacts.py
+++ b/backend/test_observer/controllers/artefacts/artefacts.py
@@ -34,9 +34,9 @@ from .logic import (
     is_there_a_rejected_environment,
 )
 from .models import (
-    ArtefactDTO,
+    ArtefactResponse,
     ArtefactPatch,
-    ArtefactVersionDTO,
+    ArtefactVersionResponse,
 )
 
 router = APIRouter(tags=["artefacts"])
@@ -44,7 +44,7 @@ router.include_router(environment_reviews.router)
 router.include_router(builds.router)
 
 
-@router.get("", response_model=list[ArtefactDTO])
+@router.get("", response_model=list[ArtefactResponse])
 def get_artefacts(family: FamilyName | None = None, db: Session = Depends(get_db)):
     """Get latest artefacts optionally by family"""
     artefacts = []
@@ -69,7 +69,7 @@ def get_artefacts(family: FamilyName | None = None, db: Session = Depends(get_db
     return artefacts
 
 
-@router.get("/{artefact_id}", response_model=ArtefactDTO)
+@router.get("/{artefact_id}", response_model=ArtefactResponse)
 def get_artefact(
     artefact: Artefact = Depends(
         ArtefactRetriever(
@@ -82,7 +82,7 @@ def get_artefact(
     return artefact
 
 
-@router.patch("/{artefact_id}", response_model=ArtefactDTO)
+@router.patch("/{artefact_id}", response_model=ArtefactResponse)
 def patch_artefact(
     request: ArtefactPatch,
     db: Session = Depends(get_db),
@@ -121,7 +121,7 @@ def _validate_artefact_status(
         )
 
 
-@router.get("/{artefact_id}/versions", response_model=list[ArtefactVersionDTO])
+@router.get("/{artefact_id}/versions", response_model=list[ArtefactVersionResponse])
 def get_artefact_versions(
     artefact: Artefact = Depends(ArtefactRetriever()), db: Session = Depends(get_db)
 ):

--- a/backend/test_observer/controllers/artefacts/builds.py
+++ b/backend/test_observer/controllers/artefacts/builds.py
@@ -26,13 +26,13 @@ from test_observer.data_access.models import (
 )
 
 from .models import (
-    ArtefactBuildDTO,
+    ArtefactBuildResponse,
 )
 
 router = APIRouter(tags=["artefact-builds"])
 
 
-@router.get("/{artefact_id}/builds", response_model=list[ArtefactBuildDTO])
+@router.get("/{artefact_id}/builds", response_model=list[ArtefactBuildResponse])
 def get_artefact_builds(
     artefact: Artefact = Depends(
         ArtefactRetriever(

--- a/backend/test_observer/controllers/artefacts/environment_reviews.py
+++ b/backend/test_observer/controllers/artefacts/environment_reviews.py
@@ -28,7 +28,7 @@ from test_observer.data_access.models import (
 from test_observer.data_access.setup import get_db
 
 from .models import (
-    ArtefactBuildEnvironmentReviewDTO,
+    ArtefactBuildEnvironmentReviewResponse,
     EnvironmentReviewPatch,
 )
 
@@ -37,7 +37,7 @@ router = APIRouter(tags=["environment-reviews"])
 
 @router.get(
     "/{artefact_id}/environment-reviews",
-    response_model=list[ArtefactBuildEnvironmentReviewDTO],
+    response_model=list[ArtefactBuildEnvironmentReviewResponse],
 )
 def get_environment_reviews(
     artefact: Artefact = Depends(
@@ -57,7 +57,7 @@ def get_environment_reviews(
 
 @router.patch(
     "/{artefact_id}/environment-reviews/{review_id}",
-    response_model=ArtefactBuildEnvironmentReviewDTO,
+    response_model=ArtefactBuildEnvironmentReviewResponse,
 )
 def update_environment_review(
     artefact_id: int,

--- a/backend/test_observer/controllers/artefacts/models.py
+++ b/backend/test_observer/controllers/artefacts/models.py
@@ -34,7 +34,7 @@ from test_observer.data_access.models_enums import (
 )
 
 
-class UserDTO(BaseModel):
+class UserResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
@@ -43,7 +43,7 @@ class UserDTO(BaseModel):
     name: str
 
 
-class ArtefactDTO(BaseModel):
+class ArtefactResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
@@ -60,14 +60,14 @@ class ArtefactDTO(BaseModel):
     image_url: str
     stage: str
     status: ArtefactStatus
-    assignee: UserDTO | None
+    assignee: UserResponse | None
     due_date: date | None
     bug_link: str
     all_environment_reviews_count: int
     completed_environment_reviews_count: int
 
 
-class EnvironmentDTO(BaseModel):
+class EnvironmentResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
@@ -75,7 +75,7 @@ class EnvironmentDTO(BaseModel):
     architecture: str
 
 
-class TestExecutionDTO(BaseModel):
+class TestExecutionResponse(BaseModel):
     __test__ = False
 
     model_config = ConfigDict(from_attributes=True)
@@ -83,7 +83,7 @@ class TestExecutionDTO(BaseModel):
     id: int
     ci_link: str | None
     c3_link: str | None
-    environment: EnvironmentDTO
+    environment: EnvironmentResponse
     status: TestExecutionStatus
     rerun_request: Any = Field(exclude=True)
     test_plan: str
@@ -93,25 +93,25 @@ class TestExecutionDTO(BaseModel):
         return bool(self.rerun_request)
 
 
-class ArtefactBuildDTO(BaseModel):
+class ArtefactBuildResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
     architecture: str
     revision: int | None
-    test_executions: list[TestExecutionDTO]
+    test_executions: list[TestExecutionResponse]
 
 
 class ArtefactPatch(BaseModel):
     status: ArtefactStatus
 
 
-class ArtefactVersionDTO(BaseModel):
+class ArtefactVersionResponse(BaseModel):
     version: str
     artefact_id: int = Field(validation_alias=AliasPath("id"))
 
 
-class ArtefactBuildMinimalDTO(BaseModel):
+class ArtefactBuildMinimalResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
@@ -119,12 +119,12 @@ class ArtefactBuildMinimalDTO(BaseModel):
     revision: int | None
 
 
-class ArtefactBuildEnvironmentReviewDTO(BaseModel):
+class ArtefactBuildEnvironmentReviewResponse(BaseModel):
     id: int
     review_decision: list[ArtefactBuildEnvironmentReviewDecision]
     review_comment: str
-    environment: EnvironmentDTO
-    artefact_build: ArtefactBuildMinimalDTO
+    environment: EnvironmentResponse
+    artefact_build: ArtefactBuildMinimalResponse
 
 
 class EnvironmentReviewPatch(BaseModel):

--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -30,9 +30,9 @@ from pydantic import (
 
 from test_observer.common.constants import PREVIOUS_TEST_RESULT_COUNT
 from test_observer.controllers.artefacts.models import (
-    ArtefactBuildMinimalDTO,
-    ArtefactDTO,
-    TestExecutionDTO,
+    ArtefactBuildMinimalResponse,
+    ArtefactResponse,
+    TestExecutionResponse,
 )
 from test_observer.data_access.models_enums import (
     FamilyName,
@@ -175,13 +175,13 @@ class PendingRerun(BaseModel):
             "test_execution", "artefact_build", "artefact", "family"
         )
     )
-    test_execution: TestExecutionDTO = Field(
+    test_execution: TestExecutionResponse = Field(
         validation_alias=AliasPath("test_execution")
     )
-    artefact: ArtefactDTO = Field(
+    artefact: ArtefactResponse = Field(
         validation_alias=AliasPath("test_execution", "artefact_build", "artefact")
     )
-    artefact_build: ArtefactBuildMinimalDTO = Field(
+    artefact_build: ArtefactBuildMinimalResponse = Field(
         validation_alias=AliasPath("test_execution", "artefact_build")
     )
 
@@ -190,11 +190,11 @@ class DeleteReruns(BaseModel):
     test_execution_ids: set[int]
 
 
-class TestEventDTO(BaseModel):
+class TestEventResponse(BaseModel):
     event_name: str
     timestamp: datetime
     detail: str
 
 
 class StatusUpdateRequest(BaseModel):
-    events: list[TestEventDTO]
+    events: list[TestEventResponse]

--- a/backend/test_observer/controllers/test_executions/patch.py
+++ b/backend/test_observer/controllers/test_executions/patch.py
@@ -18,7 +18,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from test_observer.controllers.artefacts.models import TestExecutionDTO
+from test_observer.controllers.artefacts.models import TestExecutionResponse
 from test_observer.data_access.models import TestExecution
 from test_observer.data_access.models_enums import TestExecutionStatus, TestResultStatus
 from test_observer.data_access.setup import get_db
@@ -28,7 +28,7 @@ from .models import TestExecutionsPatchRequest
 router = APIRouter()
 
 
-@router.patch("/{id}", response_model=TestExecutionDTO)
+@router.patch("/{id}", response_model=TestExecutionResponse)
 def patch_test_execution(
     id: int,
     request: TestExecutionsPatchRequest,

--- a/backend/test_observer/controllers/test_executions/status_update.py
+++ b/backend/test_observer/controllers/test_executions/status_update.py
@@ -26,7 +26,7 @@ from test_observer.data_access.models_enums import TestExecutionStatus
 from test_observer.data_access.setup import get_db
 
 from .logic import delete_previous_test_events
-from .models import StatusUpdateRequest, TestEventDTO
+from .models import StatusUpdateRequest, TestEventResponse
 from .testflinger_event_parser import TestflingerEventParser
 
 router = APIRouter()
@@ -67,7 +67,7 @@ def put_status_update(
     db.commit()
 
 
-@router.get("/{id}/status_update", response_model=list[TestEventDTO])
+@router.get("/{id}/status_update", response_model=list[TestEventResponse])
 def get_status_update(id: int, db: Session = Depends(get_db)):
     test_execution = db.get(
         TestExecution,


### PR DESCRIPTION
## Description

The "DTO" terminology trickles down into the OpenAPI schema generated for the API, and as such it trickles down to also automatically generated clients etc. Feels unnecessary to use an acronym and feels unnecessary to reflect the broad architectural role this entity serves when we can talk about a more specific one (it's specifically a response object).

## Resolved issues

No response

## Documentation

API schema updated.

## Web service API changes

OpenAPI schema adjusted.

## Tests

Doesn't look to have impacted tests (interesting observation itself, but doesn't IMO require further actions in this PR).