### PR TITLE
Add family to artefact response

### DIFF
--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -1532,6 +1532,10 @@
             "type": "string",
             "title": "Stage"
           },
+          "family": {
+            "type": "string",
+            "title": "Family"
+          },
           "status": {
             "$ref": "#/components/schemas/ArtefactStatus"
           },
@@ -1585,6 +1589,7 @@
           "sha256",
           "image_url",
           "stage",
+          "family",
           "status",
           "assignee",
           "due_date",

--- a/backend/test_observer/controllers/artefacts/models.py
+++ b/backend/test_observer/controllers/artefacts/models.py
@@ -59,6 +59,7 @@ class ArtefactResponse(BaseModel):
     sha256: str
     image_url: str
     stage: str
+    family: str
     status: ArtefactStatus
     assignee: UserResponse | None
     due_date: date | None

--- a/backend/tests/controllers/artefacts/test_artefacts.py
+++ b/backend/tests/controllers/artefacts/test_artefacts.py
@@ -279,6 +279,7 @@ def _assert_get_artefact_response(response: dict[str, Any], artefact: Artefact) 
         "sha256": artefact.sha256,
         "image_url": artefact.image_url,
         "status": artefact.status,
+        "family": artefact.family,
         "assignee": None,
         "due_date": (
             artefact.due_date.strftime("%Y-%m-%d") if artefact.due_date else None

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -103,6 +103,7 @@ def test_execution_to_pending_rerun(test_execution: TestExecution) -> dict:
                 "completed_environment_reviews_count": (
                     test_execution.artefact_build.artefact.completed_environment_reviews_count
                 ),
+                "family": test_execution.artefact_build.artefact.family,
             },
             "artefact_build": {
                 "id": test_execution.artefact_build.id,

--- a/frontend/benchmarks/common.dart
+++ b/frontend/benchmarks/common.dart
@@ -61,6 +61,7 @@ class ApiRepositoryMock extends Mock implements ApiRepository {
       name: 'artefact',
       version: '1',
       track: 'latest',
+      family: 'snap',
       store: 'ubuntu',
       series: '',
       repo: '',

--- a/frontend/lib/models/artefact.dart
+++ b/frontend/lib/models/artefact.dart
@@ -32,6 +32,7 @@ class Artefact with _$Artefact {
     required int id,
     required String name,
     required String version,
+    required String family,
     @Default('') String track,
     @Default('') String store,
     @Default('') String series,

--- a/frontend/test/dummy_data.dart
+++ b/frontend/test/dummy_data.dart
@@ -33,6 +33,7 @@ const dummyArtefact = Artefact(
   id: 1,
   name: 'core',
   version: '16-2.61',
+  family: 'snap',
   track: 'latest',
   store: 'ubuntu',
   series: '',


### PR DESCRIPTION
## Description

Adds `family` into artefact responses (the most immediate need is for an API consumer to be able to build logic dependent on the family, concretely to construct Test Observer frontend URLs to the relevant artefact, without doing API calls by the family).

## Resolved issues

None, this is related to making https://github.com/canonical/hwcert-errbot be useful.

## Documentation

OpenAPI schema updated.

## Web service API changes

An additional property (`family`) has been added to responses that involve the `ArtefactResponse` response type in the schema.

## Tests

Pre-existing test assertions adjusted to account for the additional property.