### PR TITLE
Update README.md with the correct link to the terraform README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Certification currently deploys an instance of TO that they used for reviewing S
 
 For development look at the [backend](/backend/README.md) and [frontend](/frontend/README.md).
 
-To run via Terraform, juju and charms simulating production and staging environments, look at [terraform](README.md)
+To run the whole system (backend + frontend + pg at the time of writing) via Terraform, juju and charms simulating production and staging environments, use [terraform](/terraform/README.md)


### PR DESCRIPTION
## Description

I happened to notice the terraform README link was in fact linking back to the root level README that contained the link.