### PR TITLE
Charm integration tests

### DIFF
--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -128,11 +128,11 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:
-          name: charmcraft-logs
+          name: charmcraft-logs-${{ matrix.suite }}
           path: /home/ubuntu/.local/state/charmcraft/log/*
       
       - name: Upload spread artifacts
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:
-          name: spread-artifacts
+          name: spread-artifacts-${{ matrix.suite }}
           path: ./artifacts

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -85,7 +85,6 @@ jobs:
           list="$(charmcraft test --list github-ci | sed "s|github-ci:ubuntu-24.04:spread/||g" | jq -r -ncR '[inputs | select(length>0)]')"
           echo "suites=$list"
           echo "suites=$list" >> $GITHUB_OUTPUT
-        working-directory: charm
 
   integration-test:
     name: Spread (${{ matrix.suite }})
@@ -118,7 +117,6 @@ jobs:
       - name: Run integration tests
         run: |
           charmcraft test -v "github-ci:ubuntu-24.04:tests/spread/${{ matrix.suite }}"
-        working-directory: charm
       
       - name: Upload charmcraft logs
         if: failure()

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -122,9 +122,15 @@ jobs:
         with:
           channel: 5.21/stable
 
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+  
       - name: Install spread
-        run: sudo snap install spread --devmode # --devmode to allow spread tests to call other snaps
-
+        run: |
+          go install github.com/snapcore/spread/cmd/spread@latest
+  
       - name: Run integration tests
         run: |
           spread -v "github-ci:ubuntu-24.04:spread/${{ matrix.suite }}"

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -124,14 +124,23 @@ jobs:
         run: |
           charmcraft test -v "github-ci:ubuntu-24.04:tests/spread/${{ matrix.suite }}"
       
+      - name: Sanitize suite name
+        if: failure()
+        id: sanitize
+        run: |
+          SANITIZED_SUITE=$(echo "${{ matrix.suite }}" | tr ':/' '-')
+          echo "sanitized_suite=$SANITIZED_SUITE" >> $GITHUB_OUTPUT
+
       - name: Upload charmcraft logs
+        if: failure()
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:
-          name: charmcraft-logs-${{ matrix.suite }}
+          name: charmcraft-logs-${{ steps.sanitize.outputs.sanitized_suite }}
           path: /home/ubuntu/.local/state/charmcraft/log/*
       
       - name: Upload spread artifacts
+        if: failure()
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:
-          name: spread-artifacts-${{ matrix.suite }}
+          name: spread-artifacts-${{ steps.sanitize.outputs.sanitized_suite }}
           path: ./artifacts

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        charm-dir: [backend/charm, frontend/charm]
+        charm: [backend/charm, frontend/charm]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -59,13 +59,13 @@ jobs:
 
       - name: Pack charm
         run: charmcraft pack -v
-        working-directory: ${{ matrix.charm-dir }}
+        working-directory: ${{ matrix.charm }}
       
       - name: Upload charm artifact
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:
-          name: charm
-          path: ${{ matrix.charm-dir }}/*.charm
+          name: ${{ matrix.charm }}
+          path: ${{ matrix.charm }}/*.charm
 
   define-matrix:
     name: Define spread matrix
@@ -105,13 +105,13 @@ jobs:
       - name: Download backend charm artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
-          name: charm
+          name: backend/charm
           path: ${{ github.workspace }}/backend/charm
       
       - name: Download frontend charm artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
-          name: charm
+          name: frontend/charm
           path: ${{ github.workspace }}/frontend/charm
   
       - name: Setup LXD

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Run integration tests
         run: |
-          charmcraft test -v "github-ci:ubuntu-24.04:tests/spread/${{ matrix.suite }}"
+          charmcraft test -v "github-ci:ubuntu-24.04:spread/${{ matrix.suite }}"
       
       - name: Sanitize suite name
         if: failure()

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -15,7 +15,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.job }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -124,8 +124,6 @@ jobs:
 
       - name: Setup Go
         uses: actions/setup-go@v5.3.0
-        with:
-          go-version-file: "go.mod"
   
       - name: Install spread
         run: |

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -13,12 +13,6 @@ on:
       - v*
  
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches:
-      - main
-
-  pull_request_review:
-    types: [submitted]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -77,7 +71,6 @@ jobs:
           path: "${{ matrix.charm }}/charm/*.charm"
 
   define-matrix:
-    if: github.event_name == 'push' || github.event.review.state == 'approved'
     name: Define spread matrix
     runs-on: ubuntu-24.04
     outputs:
@@ -97,7 +90,6 @@ jobs:
           echo "suites=$list" >> $GITHUB_OUTPUT
 
   integration-test:
-    if: github.event_name == 'push' || github.event.review.state == 'approved'
     name: Spread (${{ matrix.suite }})
     
     runs-on: [self-hosted, linux, large, noble, x64]

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -50,10 +50,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Setup LXD
-        uses: canonical/setup-lxd@main
+        uses: canonical/setup-lxd@v0.1.2
+        with:
+          channel: 5.21/stable
 
       - name: Install charmcraft
-        run: sudo snap install charmcraft --classic
+        run: sudo snap install charmcraft --channel=3.x/stable --classic
 
       - name: Cache wheels
         id: cache-wheels
@@ -85,7 +87,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install charmcraft
-        run: sudo snap install charmcraft --classic
+        run: sudo snap install charmcraft --channel=3.x/stable --classic
 
       - name: Generate matrix list
         id: suites
@@ -124,10 +126,12 @@ jobs:
           path: ${{ github.workspace }}/frontend/charm
   
       - name: Setup LXD
-        uses: canonical/setup-lxd@main
+        uses: canonical/setup-lxd@v0.1.2
+        with:
+          channel: 5.21/stable
 
       - name: Install charmcraft
-        run: sudo snap install charmcraft --classic
+        run: sudo snap install charmcraft --channel=3.x/stable --classic
 
       - name: Run integration tests
         run: |

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Generate matrix list
         id: suites
         run: |
-          list="$(charmcraft test --list github-ci | sed "s|github-ci:ubuntu-24.04:spread/||g" | jq -r -ncR '[inputs | select(length>0)]')"
+          list="$(spread --list github-ci | sed "s|github-ci:ubuntu-24.04:spread/||g" | jq -r -ncR '[inputs | select(length>0)]')"
           echo "suites=$list"
           echo "suites=$list" >> $GITHUB_OUTPUT
 
@@ -125,9 +125,12 @@ jobs:
       - name: Install charmcraft
         run: sudo snap install charmcraft --channel=3.x/stable --classic
 
+      - name: Install spread
+        run: sudo snap install spread --devmode
+
       - name: Run integration tests
         run: |
-          charmcraft test -v "github-ci:ubuntu-24.04:spread/${{ matrix.suite }}"
+          spread -v "github-ci:ubuntu-24.04:spread/${{ matrix.suite }}"
       
       - name: Sanitize suite name
         if: failure()

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -102,11 +102,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - name: Download charm artifact
+      - name: Download backend charm artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
           name: charm
-          path: ${{ github.workspace }}/charm
+          path: ${{ github.workspace }}/backend/charm
+      
+      - name: Download frontend charm artifact
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: charm
+          path: ${{ github.workspace }}/frontend/charm
   
       - name: Setup LXD
         uses: canonical/setup-lxd@main

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -123,7 +123,7 @@ jobs:
           channel: 5.21/stable
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v5.3.0
         with:
           go-version-file: "go.mod"
   

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -125,7 +125,6 @@ jobs:
           charmcraft test -v "github-ci:ubuntu-24.04:tests/spread/${{ matrix.suite }}"
       
       - name: Upload charmcraft logs
-        if: failure()
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:
           name: charmcraft-logs-${{ matrix.suite }}

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Generate matrix list
         id: suites
         run: |
-          list="$(charmcraft test --list github-ci | sed "s|github-ci:ubuntu-24.04:tests/spread/||g" | jq -r -ncR '[inputs | select(length>0)]')"
+          list="$(charmcraft test --list github-ci | sed "s|github-ci:ubuntu-24.04:spread/||g" | jq -r -ncR '[inputs | select(length>0)]')"
           echo "suites=$list"
           echo "suites=$list" >> $GITHUB_OUTPUT
         working-directory: charm

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -1,4 +1,4 @@
-name: Integration Test
+name: Charm integration tests
 
 on:
   workflow_call:

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        charm: [backend/charm, frontend/charm]
+        charm: [backend, frontend]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -59,13 +59,13 @@ jobs:
 
       - name: Pack charm
         run: charmcraft pack -v
-        working-directory: ${{ matrix.charm }}
+        working-directory: "${{ matrix.charm }}/charm"
       
       - name: Upload charm artifact
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:
-          name: ${{ matrix.charm }}
-          path: ${{ matrix.charm }}/*.charm
+          name: ${{ matrix.charm }}-charm
+          path: "${{ matrix.charm }}/charm/*.charm"
 
   define-matrix:
     name: Define spread matrix
@@ -105,13 +105,13 @@ jobs:
       - name: Download backend charm artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
-          name: backend/charm
+          name: backend-charm
           path: ${{ github.workspace }}/backend/charm
       
       - name: Download frontend charm artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
-          name: frontend/charm
+          name: frontend-charm
           path: ${{ github.workspace }}/frontend/charm
   
       - name: Setup LXD

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -122,9 +122,6 @@ jobs:
         with:
           channel: 5.21/stable
 
-      - name: Install charmcraft
-        run: sudo snap install charmcraft --channel=3.x/stable --classic
-
       - name: Install spread
         run: sudo snap install spread --devmode
 

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -129,4 +129,10 @@ jobs:
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:
           name: charmcraft-logs
-          path: /home/runner/.local/state/charmcraft/log/*
+          path: /home/ubuntu/.local/state/charmcraft/log/*
+      
+      - name: Upload spread artifacts
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: spread-artifacts
+          path: ./artifacts

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -15,7 +15,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.job }}
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.job }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -79,8 +79,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - name: Install charmcraft
-        run: sudo snap install charmcraft --channel=3.x/stable --classic
+      - name: Install spread
+        run: sudo snap install spread
 
       - name: Generate matrix list
         id: suites
@@ -123,7 +123,7 @@ jobs:
           channel: 5.21/stable
 
       - name: Install spread
-        run: sudo snap install spread --devmode
+        run: sudo snap install spread --devmode # --devmode to allow spread tests to call other snaps
 
       - name: Run integration tests
         run: |

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -1,0 +1,128 @@
+name: Integration Test
+
+on:
+  workflow_call:
+    secrets:
+      CHARMHUB_TOKEN:
+        required: true
+  
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+ 
+  pull_request:
+    branches:
+      - main
+
+
+jobs:
+  lib-check:
+    name: Check libraries
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+      - name: Check libs
+        uses: canonical/charming-actions/check-libraries@934193396735701141a1decc3613818e412da606 # 2.6.3
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+  pack-charm:
+    name: Build charm
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        charm-dir: [backend/charm, frontend/charm]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@main
+
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+
+      - name: Cache wheels
+        id: cache-wheels
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+        with:
+          path: /home/runner/snap/charmcraft/common/cache/charmcraft
+          key: ${{ runner.os }}-wheel-cache-${{ hashFiles('./uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-wheel-cache-
+
+      - name: Pack charm
+        run: charmcraft pack -v
+        working-directory: ${{ matrix.charm-dir }}
+      
+      - name: Upload charm artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: charm
+          path: ${{ matrix.charm-dir }}/*.charm
+
+  define-matrix:
+    name: Define spread matrix
+    runs-on: ubuntu-24.04
+    outputs:
+      suites: ${{ steps.suites.outputs.suites }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+
+      - name: Generate matrix list
+        id: suites
+        run: |
+          list="$(charmcraft test --list github-ci | sed "s|github-ci:ubuntu-24.04:tests/spread/||g" | jq -r -ncR '[inputs | select(length>0)]')"
+          echo "suites=$list"
+          echo "suites=$list" >> $GITHUB_OUTPUT
+        working-directory: charm
+
+  integration-test:
+    name: Spread (${{ matrix.suite }})
+    
+    runs-on: ubuntu-24.04
+    needs:
+      - define-matrix
+      - lib-check
+      - pack-charm
+    strategy:
+      fail-fast: true
+      matrix:
+        suite: ${{ fromJSON(needs.define-matrix.outputs.suites) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Download charm artifact
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: charm
+          path: ${{ github.workspace }}/charm
+  
+      - name: Setup LXD
+        uses: canonical/setup-lxd@main
+
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+
+      - name: Run integration tests
+        run: |
+          charmcraft test -v "github-ci:ubuntu-24.04:tests/spread/${{ matrix.suite }}"
+        working-directory: charm
+      
+      - name: Upload charmcraft logs
+        if: failure()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: charmcraft-logs
+          path: /home/runner/.local/state/charmcraft/log/*

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -13,9 +13,16 @@ on:
       - v*
  
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
 
+  pull_request_review:
+    types: [submitted]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lib-check:
@@ -68,6 +75,7 @@ jobs:
           path: "${{ matrix.charm }}/charm/*.charm"
 
   define-matrix:
+    if: github.event_name == 'push' || github.event.review.state == 'approved'
     name: Define spread matrix
     runs-on: ubuntu-24.04
     outputs:
@@ -87,6 +95,7 @@ jobs:
           echo "suites=$list" >> $GITHUB_OUTPUT
 
   integration-test:
+    if: github.event_name == 'push' || github.event.review.state == 'approved'
     name: Spread (${{ matrix.suite }})
     
     runs-on: [self-hosted, linux, large, noble, x64]

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -124,6 +124,8 @@ jobs:
 
       - name: Setup Go
         uses: actions/setup-go@v5.3.0
+        with:
+          go-version: 1.24.0
   
       - name: Install spread
         run: |

--- a/.github/workflows/charm_integration_test.yml
+++ b/.github/workflows/charm_integration_test.yml
@@ -90,7 +90,7 @@ jobs:
   integration-test:
     name: Spread (${{ matrix.suite }})
     
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, linux, large, noble, x64]
     needs:
       - define-matrix
       - lib-check

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ charmcraft.spread -v lxd
 
 ### Jump into a `spread` provided shell environment
 
-You can jump into a `spread` provided environment for the test execution either before, instead of the test task, or after a test task has been executed (you could also combine this choosing to run only a specific test scenario).
+To debug the charm integration tests, you can jump into a `spread` provided environment for the test execution either before, instead of the test task, or after a test task has been executed (you could also combine this choosing to run only a specific test scenario).
 
 ```bash
 # open a shell to the execution environment _before_ executing each test task 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,38 @@ Test Observer (TO) is a dashboard for viewing the results of tests run on differ
 
 Certification currently deploys an instance of TO that they used for reviewing Stable Release Updates (SRUs). Other teams also use this instance for their tests. You can visit the [frontend](https://test-observer.canonical.com/) and view the [API docs](https://test-observer-api.canonical.com/docs), although this currently requires Canonical VPN access. There's also a staging deployment of [frontend](https://test-observer-staging.canonical.com/) and [API](https://test-observer-api-staging.canonical.com/docs) that teams can use to test their integration.
 
-## Run Locally
+## Run locally
 
 For development look at the [backend](/backend/README.md) and [frontend](/frontend/README.md).
 
 To run the whole system (backend + frontend + pg at the time of writing) via Terraform, juju and charms simulating production and staging environments, use [terraform](/terraform/README.md)
+
+
+## Charm integration tests
+
+A charmed Test Observer deployment can be integration tested using `charmcraft test` (which itself internally uses a classically confined copy of [spread](https://github.com/canonical/spread) bundled with `charmcraft`).
+
+The integration tests are runnable either locally (using [lxd](https://documentation.ubuntu.com/lxd/en/latest/installing/) at the time of writing) or using GitHub. Alternative test execution backends are configurable by adding new `adhoc` backends next to `lxd` and `github` in the [spread.yaml](./spread.yaml).
+
+### Run integration tests locally
+
+Tests can be run locally with either `charmcraft test lxd` or `charmcraft.spread lxd` (the latter gives a bit more verbose log output).
+
+```bash
+charmcraft.spread -v lxd
+```
+
+### Jump into a `spread` provided shell environment
+
+You can jump into a `spread` provided environment for the test execution either before, instead of the test task, or after a test task has been executed (you could also combine this choosing to run only a specific test scenario).
+
+```bash
+# open a shell to the execution environment _before_ executing each test task 
+charmcraft.spread -v -shell lxd 
+
+# open a shell to the execution environment _instead of_ executing each test task 
+charmcraft.spread -v -shell lxd
+
+# open a shell to the execution environment _after_ of executing each test task 
+charmcraft.spread -v -shell-after lxd
+```

--- a/spread.yaml
+++ b/spread.yaml
@@ -100,7 +100,7 @@ prepare: |
 
   snap install --classic concierge
 
-  concierge prepare --trace -p microk8s --extra-snaps astral-uv
+  concierge prepare --trace -p microk8s --extra-snaps astral-uv --extra-snaps juju-crashdump
 
   pushd "$SPREAD_PATH"
   chown $(id -u):$(id -g) $PWD/backend/charm/test-observer-api_ubuntu-22.04-amd64.charm

--- a/spread.yaml
+++ b/spread.yaml
@@ -98,6 +98,9 @@ prepare: |
     systemctl mask unattended-upgrades.service
   fi
 
+  apt update
+  apt install -y pipx
+
   snap install --classic concierge
 
   concierge prepare --trace -p microk8s --extra-snaps astral-uv --extra-snaps juju-crashdump

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,0 +1,116 @@
+project: test-observer-charm-tests
+kill-timeout: 90m
+workers: 1
+
+environment:
+  CI: "$(HOST: echo $CI)"
+  CONCIERGE_JUJU_CHANNEL/juju_3_5: 3.5/stable
+  CONCIERGE_JUJU_CHANNEL/juju_3_6: 3.6/stable
+
+backends:
+  lxd:
+    type: adhoc
+    allocate: |
+      BASE="${BASE:-noble}"
+      VM_NAME="${VM_NAME:-ubuntu-${BASE}-${RANDOM}}"
+      DISK="${DISK:-20}"
+      CPU="${CPU:-4}"
+      MEM="${MEM:-8}"
+
+      cloud_config="$(mktemp)"
+      sed "s|SPREAD_PASSWORD|$SPREAD_PASSWORD|g" spread/cloud-config.yaml > "$cloud_config"
+
+      if lxc list --format csv -c n |  grep -q "${VM_NAME}"; then
+        echo "\"${VM_NAME}\" already exists -> skipping rest of allocation."
+      else
+        echo "No \"${VM_NAME}\" present -> launching"
+        lxc launch --vm \
+          "ubuntu:${BASE}" \
+          "${VM_NAME}" \
+          -c user.user-data="$(cat "$cloud_config")" \
+          -c limits.cpu="${CPU}" \
+          -c limits.memory="${MEM}GiB" \
+          -d root,size="${DISK}GiB"
+      fi
+
+      # Wait for the spread user
+      while ! lxc exec "${VM_NAME}" -- id -u spread &>/dev/null; do sleep 0.5; done
+
+      rm "$cloud_config"
+
+      # Set the instance address for spread
+      ADDRESS "$(lxc ls -f csv | grep "${VM_NAME}" | cut -d"," -f3 | cut -d" " -f1)"
+    discard: |
+      instance_name="$(lxc ls -f csv | grep $SPREAD_SYSTEM_ADDRESS | cut -f1 -d",")"
+      lxc delete -f $instance_name
+
+    systems:
+      - ubuntu-24.04:
+          username: spread
+          workers: 1
+
+  github-ci:
+    type: adhoc
+    manual: true
+    allocate: |
+      sudo sed -i "s|#PasswordAuthentication yes|PasswordAuthentication yes|g" /etc/ssh/sshd_config
+      sudo sed -i "s|KbdInteractiveAuthentication no|KbdInteractiveAuthentication yes|g" /etc/ssh/sshd_config
+      sudo rm -f /etc/ssh/sshd_config.d/60-cloudimg-settings.conf
+      sudo systemctl daemon-reload
+      sudo systemctl restart ssh
+
+      sudo useradd spread -s /bin/bash -m || true
+      echo "spread:$SPREAD_PASSWORD" | sudo chpasswd || true
+      echo 'spread ALL=(ALL) NOPASSWD:ALL ' | sudo tee /etc/sudoers.d/99-spread-user || true
+
+      ADDRESS "127.0.0.1"
+    discard: |
+      sudo userdel -f -r spread || true
+      sudo rm -f /etc/sudoers.d/99-spread-user
+
+    systems:
+      - ubuntu-24.04:
+          username: spread
+          workers: 1
+
+suites:
+  spread/:
+    summary: Spread tests
+
+exclude:
+  - .coverage
+  - .git
+  - .github
+  - .pytest_cache
+  - .ruff_cache
+  - .tox
+  - .venv
+
+# this needs to be under /root because spread executes the test scripts
+# as root, which means that juju can only see files in root's
+# home directory due to snap confinement.
+path: /root/proj
+
+prepare: |
+  snap refresh --hold
+  if systemctl is-enabled unattended-upgrades.service; then
+    systemctl stop unattended-upgrades.service
+    systemctl mask unattended-upgrades.service
+  fi
+
+  snap install --classic concierge
+
+  concierge prepare --trace -p microk8s --extra-snaps astral-uv
+
+  pushd "$SPREAD_PATH"
+  chown $(id -u):$(id -g) $PWD/test-observer-api_amd64.charm
+  chown $(id -u):$(id -g) $PWD/test-observer-frontend_amd64.charm
+
+restore: |
+  if [[ -z "${CI:-}" ]]; then
+    concierge restore --trace
+    
+    apt autoremove -y --purge
+    rm -Rf "$SPREAD_PATH"
+    mkdir -p "$SPREAD_PATH"
+  fi

--- a/spread.yaml
+++ b/spread.yaml
@@ -103,8 +103,8 @@ prepare: |
   concierge prepare --trace -p microk8s --extra-snaps astral-uv
 
   pushd "$SPREAD_PATH"
-  chown $(id -u):$(id -g) $PWD/test-observer-api_amd64.charm
-  chown $(id -u):$(id -g) $PWD/test-observer-frontend_amd64.charm
+  chown $(id -u):$(id -g) $PWD/backend/charm/test-observer-api_ubuntu-22.04-amd64.charm
+  chown $(id -u):$(id -g) $PWD/frontend/charm/test-observer-frontend_ubuntu-22.04-amd64.charm
 
 restore: |
   if [[ -z "${CI:-}" ]]; then

--- a/spread.yaml
+++ b/spread.yaml
@@ -93,7 +93,7 @@ path: /root/proj
 
 prepare: |
   snap refresh --hold
-  if systemctl is-enabled unattended-upgrades.service; then
+  if systemctl is-active unattended-upgrades.service; then
     systemctl stop unattended-upgrades.service
     systemctl mask unattended-upgrades.service
   fi

--- a/spread/cloud-config.yaml
+++ b/spread/cloud-config.yaml
@@ -1,0 +1,10 @@
+#cloud-config
+
+ssh_pwauth: true
+
+users:
+  - default
+  - name: spread
+    plain_text_passwd: SPREAD_PASSWORD
+    lock_passwd: false
+    sudo: ALL=(ALL) NOPASSWD:ALL

--- a/spread/integration/task.yaml
+++ b/spread/integration/task.yaml
@@ -1,6 +1,8 @@
 summary: Run the charm integration test
 
 execute: |
+  pipx install git+https://github.com/canonical/juju-k8s-crashdump.git
+
   backend_oci_image="$(cat ../../backend/charm/metadata.yaml | yq '.resources.api-image.upstream-source')"
   frontend_oci_image="$(cat ../../frontend/charm/metadata.yaml | yq '.resources.frontend-image.upstream-source')"
   juju deploy "$PWD/../../backend/charm/test-observer-api_ubuntu-22.04-amd64.charm" api --resource api-image="${backend_oci_image}" --config hostname=test-observer-api.test
@@ -21,6 +23,12 @@ execute: |
 
   juju wait-for application frontend --timeout=30m
   juju wait-for application api --timeout=30m
+
+  microk8s config > kube-config
+  pipx run --spec git+https://github.com/canonical/juju-k8s-crashdump.git juju-k8s-crashdump ./kube-config concierge-microk8s
+
+artifacts:
+  - juju-k8s-crashdump
 
 restore: |
   if [[ -z "${CI:-}" ]]; then

--- a/spread/integration/task.yaml
+++ b/spread/integration/task.yaml
@@ -3,8 +3,8 @@ summary: Run the charm integration test
 execute: |
   backend_oci_image="$(cat ./backend/charm/metadata.yaml | yq '.resources.proxy-image.upstream-source')"
   frontend_oci_image="$(cat ./frontend/charm/metadata.yaml | yq '.resources.proxy-image.upstream-source')"
-  juju deploy "$PWD/../../../test-observer-api_amd64.charm" proxy --resource proxy-image="${backend_oci_image}"
-  juju deploy "$PWD/../../../test-observer-frontend_amd64.charm" proxy --resource proxy-image="${frontend_oci_image}"
+  juju deploy "$PWD/../../../test-observer-api_ubuntu-22.04-amd64.charm" proxy --resource proxy-image="${backend_oci_image}"
+  juju deploy "$PWD/../../../test-observer-frontend_ubuntu-22.04-amd64.charm" proxy --resource proxy-image="${frontend_oci_image}"
 
   # juju config proxy log-level=info
   # juju config proxy endpoint-allow-list='GET:/api/v3/pets'

--- a/spread/integration/task.yaml
+++ b/spread/integration/task.yaml
@@ -21,8 +21,13 @@ execute: |
   juju relate api redis
   juju relate api frontend
 
-  juju wait-for application frontend --timeout=30m
+  juju wait-for application frontend --timeout=30m | juju-crashdump
+  juju show-status-log frontend/0
+
   juju wait-for application api --timeout=30m
+  juju show-status-log api/0
+
+  juju debug-log --level=DEBUG
 
   microk8s config > kube-config
   pipx run --spec git+https://github.com/canonical/juju-k8s-crashdump.git juju-k8s-crashdump ./kube-config concierge-microk8s

--- a/spread/integration/task.yaml
+++ b/spread/integration/task.yaml
@@ -1,0 +1,25 @@
+summary: Run the charm integration test
+
+execute: |
+  backend_oci_image="$(cat ./backend/charm/metadata.yaml | yq '.resources.proxy-image.upstream-source')"
+  frontend_oci_image="$(cat ./frontend/charm/metadata.yaml | yq '.resources.proxy-image.upstream-source')"
+  juju deploy "$PWD/../../../test-observer-api_amd64.charm" proxy --resource proxy-image="${backend_oci_image}"
+  juju deploy "$PWD/../../../test-observer-frontend_amd64.charm" proxy --resource proxy-image="${frontend_oci_image}"
+
+  # juju config proxy log-level=info
+  # juju config proxy endpoint-allow-list='GET:/api/v3/pets'
+  # juju config proxy openapi-schema-url='https://api.example.com/api/v2/openapi'
+  # juju config proxy origin-base-url='https://api.example.com'
+  # juju config proxy fixed-request-headers='Authorization|X-Custom-Header'
+  # juju config proxy auth-endpoint-url='https://auth.example.com/o/token/'
+  # juju config proxy client-id='your-client-id'
+  # juju config proxy client-secret='your-client-secret'
+  # juju config proxy auth-scope='your-auth-scope'
+
+  # juju wait-for application proxy
+
+restore: |
+  if [[ -z "${CI:-}" ]]; then
+    juju destroy-model --no-prompt --destroy-storage testing
+    juju add-model testing
+  fi

--- a/spread/integration/task.yaml
+++ b/spread/integration/task.yaml
@@ -3,10 +3,12 @@ summary: Run the charm integration test
 execute: |
   pipx install git+https://github.com/canonical/juju-k8s-crashdump.git
 
-  backend_oci_image="$(cat ../../backend/charm/metadata.yaml | yq '.resources.api-image.upstream-source')"
-  frontend_oci_image="$(cat ../../frontend/charm/metadata.yaml | yq '.resources.frontend-image.upstream-source')"
-  juju deploy "$PWD/../../backend/charm/test-observer-api_ubuntu-22.04-amd64.charm" api --resource api-image="${backend_oci_image}" --config hostname=test-observer-api.test
-  juju deploy "$PWD/../../frontend/charm/test-observer-frontend_ubuntu-22.04-amd64.charm" frontend --resource frontend-image="${frontend_oci_image}" --config hostname=test-observer-frontend.test --config test-observer-api-scheme='http://'
+  juju deploy "$PWD/../../backend/charm/test-observer-api_ubuntu-22.04-amd64.charm" api \
+  --config hostname=test-observer-api.test
+
+  juju deploy "$PWD/../../frontend/charm/test-observer-frontend_ubuntu-22.04-amd64.charm" frontend \
+  --config hostname=test-observer-frontend.test \
+  --config test-observer-api-scheme='http://'
 
   juju deploy nginx-ingress-integrator --channel=latest/stable --revision=59 ingress
   juju trust ingress --scope=cluster

--- a/spread/integration/task.yaml
+++ b/spread/integration/task.yaml
@@ -3,12 +3,17 @@ summary: Run the charm integration test
 execute: |
   pipx install git+https://github.com/canonical/juju-k8s-crashdump.git
 
+  backend_oci_image="$(cat ../../backend/charm/metadata.yaml | yq '.resources.api-image.upstream-source')"
+  frontend_oci_image="$(cat ../../frontend/charm/metadata.yaml | yq '.resources.frontend-image.upstream-source')"
+
   juju deploy "$PWD/../../backend/charm/test-observer-api_ubuntu-22.04-amd64.charm" api \
-  --config hostname=test-observer-api.test
+  --config hostname=test-observer-api.test \
+  --resource frontend-image="${frontend_oci_image}"
 
   juju deploy "$PWD/../../frontend/charm/test-observer-frontend_ubuntu-22.04-amd64.charm" frontend \
   --config hostname=test-observer-frontend.test \
-  --config test-observer-api-scheme='http://'
+  --config test-observer-api-scheme='http://' \
+  --resource api-image="${backend_oci_image}"
 
   juju deploy nginx-ingress-integrator --channel=latest/stable --revision=59 ingress
   juju trust ingress --scope=cluster

--- a/spread/integration/task.yaml
+++ b/spread/integration/task.yaml
@@ -8,12 +8,12 @@ execute: |
 
   juju deploy "$PWD/../../backend/charm/test-observer-api_ubuntu-22.04-amd64.charm" api \
   --config hostname=test-observer-api.test \
-  --resource frontend-image="${backend_oci_image}"
+  --resource api-image="${backend_oci_image}"
 
   juju deploy "$PWD/../../frontend/charm/test-observer-frontend_ubuntu-22.04-amd64.charm" frontend \
   --config hostname=test-observer-frontend.test \
   --config test-observer-api-scheme='http://' \
-  --resource api-image="${frontend_oci_image}"
+  --resource frontend-image="${frontend_oci_image}"
 
   juju deploy nginx-ingress-integrator --channel=latest/stable --revision=59 ingress
   juju trust ingress --scope=cluster

--- a/spread/integration/task.yaml
+++ b/spread/integration/task.yaml
@@ -8,12 +8,12 @@ execute: |
 
   juju deploy "$PWD/../../backend/charm/test-observer-api_ubuntu-22.04-amd64.charm" api \
   --config hostname=test-observer-api.test \
-  --resource frontend-image="${frontend_oci_image}"
+  --resource frontend-image="${backend_oci_image}"
 
   juju deploy "$PWD/../../frontend/charm/test-observer-frontend_ubuntu-22.04-amd64.charm" frontend \
   --config hostname=test-observer-frontend.test \
   --config test-observer-api-scheme='http://' \
-  --resource api-image="${backend_oci_image}"
+  --resource api-image="${frontend_oci_image}"
 
   juju deploy nginx-ingress-integrator --channel=latest/stable --revision=59 ingress
   juju trust ingress --scope=cluster

--- a/spread/integration/task.yaml
+++ b/spread/integration/task.yaml
@@ -1,22 +1,26 @@
 summary: Run the charm integration test
 
 execute: |
-  backend_oci_image="$(cat ./backend/charm/metadata.yaml | yq '.resources.proxy-image.upstream-source')"
-  frontend_oci_image="$(cat ./frontend/charm/metadata.yaml | yq '.resources.proxy-image.upstream-source')"
-  juju deploy "$PWD/../../../test-observer-api_ubuntu-22.04-amd64.charm" proxy --resource proxy-image="${backend_oci_image}"
-  juju deploy "$PWD/../../../test-observer-frontend_ubuntu-22.04-amd64.charm" proxy --resource proxy-image="${frontend_oci_image}"
+  backend_oci_image="$(cat ../../backend/charm/metadata.yaml | yq '.resources.api-image.upstream-source')"
+  frontend_oci_image="$(cat ../../frontend/charm/metadata.yaml | yq '.resources.frontend-image.upstream-source')"
+  juju deploy "$PWD/../../backend/charm/test-observer-api_ubuntu-22.04-amd64.charm" api --resource api-image="${backend_oci_image}" --config hostname=test-observer-api.test
+  juju deploy "$PWD/../../frontend/charm/test-observer-frontend_ubuntu-22.04-amd64.charm" frontend --resource frontend-image="${frontend_oci_image}" --config hostname=test-observer-frontend.test --config test-observer-api-scheme='http://'
 
-  # juju config proxy log-level=info
-  # juju config proxy endpoint-allow-list='GET:/api/v3/pets'
-  # juju config proxy openapi-schema-url='https://api.example.com/api/v2/openapi'
-  # juju config proxy origin-base-url='https://api.example.com'
-  # juju config proxy fixed-request-headers='Authorization|X-Custom-Header'
-  # juju config proxy auth-endpoint-url='https://auth.example.com/o/token/'
-  # juju config proxy client-id='your-client-id'
-  # juju config proxy client-secret='your-client-secret'
-  # juju config proxy auth-scope='your-auth-scope'
+  juju deploy nginx-ingress-integrator --channel=latest/stable --revision=59 ingress
+  juju trust ingress --scope=cluster
 
-  # juju wait-for application proxy
+  juju deploy postgresql-k8s --channel=14/stable --revision=281 db
+  juju trust db --scope=cluster
+
+  juju deploy redis-k8s --channel=latest/edge --revision=27 redis
+
+  juju relate api ingress
+  juju relate api db
+  juju relate api redis
+  juju relate api frontend
+
+  juju wait-for application frontend --timeout=30m
+  juju wait-for application api --timeout=30m
 
 restore: |
   if [[ -z "${CI:-}" ]]; then

--- a/spread/lib/cloud-config.yaml
+++ b/spread/lib/cloud-config.yaml
@@ -1,0 +1,10 @@
+#cloud-config
+
+ssh_pwauth: true
+
+users:
+  - default
+  - name: spread
+    plain_text_passwd: spread
+    lock_passwd: false
+    sudo: ALL=(ALL) NOPASSWD:ALL


### PR DESCRIPTION
## Description

Adds spread based charm integration tests that cover the backend and frontend charms getting integrated with each others, postgres, redis and ingress.

Spread is extensible with multiple backends, and the ones supported for test execution with this PR are `github` and `lxd`. LXD is used for local execution, since:

1, LXD is what I know how to set up (this being closely modelled after the equivalent pipeline in [openapi-rest-proxy](https://github.com/canonical/openapi-rest-proxy/blob/main/charm/spread.yaml) and [certification-errbot](https://github.com/canonical/certification-errbot/blob/main/charm/spread.yaml) which are themselves closely modeled after the same sort of pipeline for [zinc-operator-k8s](https://github.com/jnsgruk/zinc-k8s-operator/blob/main/spread.yaml)).
2. It works reliably (I've repeatedly run tests for all these three locally without problems).

## Resolved issues

Resolves RTW-146

## Documentation

Top level README updated with instructions.

## Web service API changes

None.

## Tests

GitHub CI executed integration tests added.