### PR TITLE
Drop last execution status icons

### DIFF
--- a/frontend/lib/ui/artefact_page/artefact_page_body.dart
+++ b/frontend/lib/ui/artefact_page/artefact_page_body.dart
@@ -16,11 +16,8 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intersperse/intersperse.dart';
 import 'package:yaru/yaru.dart';
 import '../../models/artefact.dart';
-import '../../models/artefact_environment.dart';
-import '../../models/test_execution.dart';
 import '../../providers/environments_issues.dart';
 import '../../providers/filtered_artefact_environments.dart';
 import '../../providers/tests_issues.dart';
@@ -57,10 +54,6 @@ class ArtefactPageBody extends ConsumerWidget {
               'Environments',
               style: Theme.of(context).textTheme.headlineSmall,
             ),
-            const SizedBox(width: Spacing.level4),
-            _ArtefactEnvironmentsStatusSummary(
-              artefactEnvironments: environments,
-            ),
           ],
         ),
         NonBlockingProviderPreloader(
@@ -83,48 +76,5 @@ class ArtefactPageBody extends ConsumerWidget {
         ),
       ],
     );
-  }
-}
-
-class _ArtefactEnvironmentsStatusSummary extends StatelessWidget {
-  const _ArtefactEnvironmentsStatusSummary({
-    required this.artefactEnvironments,
-  });
-
-  final Iterable<ArtefactEnvironment> artefactEnvironments;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: _latestExecutionStatusCounts(artefactEnvironments)
-          .entries
-          .map<Widget>(
-            (entry) => Row(
-              children: [
-                entry.key.icon,
-                const SizedBox(width: Spacing.level2),
-                Text(
-                  entry.value.toString(),
-                  style: Theme.of(context).textTheme.titleLarge,
-                ),
-              ],
-            ),
-          )
-          .intersperse(const SizedBox(width: Spacing.level4))
-          .toList(),
-    );
-  }
-
-  Map<TestExecutionStatus, int> _latestExecutionStatusCounts(
-    Iterable<ArtefactEnvironment> artefactEnvironments,
-  ) {
-    final counts = {for (final status in TestExecutionStatus.values) status: 0};
-
-    for (final artefactEnvironment in artefactEnvironments) {
-      final status = artefactEnvironment.runsDescending.first.status;
-      counts[status] = (counts[status] ?? 0) + 1;
-    }
-
-    return counts;
   }
 }

--- a/frontend/lib/ui/artefact_page/environment_expandable.dart
+++ b/frontend/lib/ui/artefact_page/environment_expandable.dart
@@ -68,8 +68,6 @@ class _EnvironmentExpandableTitle extends StatelessWidget {
   Widget build(BuildContext context) {
     return Row(
       children: [
-        artefactEnvironment.runsDescending.first.status.icon,
-        const SizedBox(width: Spacing.level4),
         Text(
           artefactEnvironment.architecture,
           style: Theme.of(context).textTheme.titleLarge,


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

After the switch to test plans filters. We're dropping any mention of last test execution status on environment level.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

Resolves https://warthogs.atlassian.net/browse/RTW-460

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

![image](https://github.com/user-attachments/assets/48f4fe12-85dd-43b0-8c28-108cd6e687d9)
