### PR TITLE
Add limit and family parameters to reruns

### DIFF
--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -280,29 +280,6 @@
       }
     },
     "/v1/test-executions/reruns": {
-      "get": {
-        "tags": [
-          "test-executions"
-        ],
-        "summary": "Get Rerun Requests",
-        "operationId": "get_rerun_requests_v1_test_executions_reruns_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/PendingRerun"
-                  },
-                  "type": "array",
-                  "title": "Response Get Rerun Requests V1 Test Executions Reruns Get"
-                }
-              }
-            }
-          }
-        }
-      },
       "post": {
         "tags": [
           "test-executions"
@@ -310,14 +287,14 @@
         "summary": "Create Rerun Requests",
         "operationId": "create_rerun_requests_v1_test_executions_reruns_post",
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/RerunRequest"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -325,11 +302,78 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/PendingRerun"
                   },
-                  "type": "array",
                   "title": "Response Create Rerun Requests V1 Test Executions Reruns Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "test-executions"
+        ],
+        "summary": "Get Rerun Requests",
+        "operationId": "get_rerun_requests_v1_test_executions_reruns_get",
+        "parameters": [
+          {
+            "name": "family",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/FamilyName"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Family"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PendingRerun"
+                  },
+                  "title": "Response Get Rerun Requests V1 Test Executions Reruns Get"
                 }
               }
             }
@@ -353,14 +397,14 @@
         "summary": "Delete Rerun Requests",
         "operationId": "delete_rerun_requests_v1_test_executions_reruns_delete",
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DeleteReruns"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {

--- a/backend/test_observer/controllers/test_executions/reruns.py
+++ b/backend/test_observer/controllers/test_executions/reruns.py
@@ -26,6 +26,7 @@ from test_observer.data_access.models import (
     TestExecution,
     TestExecutionRerunRequest,
     Artefact,
+    FamilyName,
 )
 from test_observer.data_access.repository import get_or_create
 from test_observer.data_access.setup import get_db
@@ -67,18 +68,33 @@ def _create_rerun_request(
 
 
 @router.get("/reruns", response_model=list[PendingRerun])
-def get_rerun_requests(db: Session = Depends(get_db)):
-    return db.scalars(
-        select(TestExecutionRerunRequest).options(
+def get_rerun_requests(
+    family: FamilyName | None = None,
+    limit: int | None = None,
+    db: Session = Depends(get_db),
+):
+    stmt = (
+        select(TestExecutionRerunRequest)
+        .join(TestExecutionRerunRequest.test_execution)
+        .join(TestExecution.artefact_build)
+        .join(ArtefactBuild.artefact)
+        .options(
             joinedload(TestExecutionRerunRequest.test_execution)
             .joinedload(TestExecution.artefact_build)
             .joinedload(ArtefactBuild.artefact)
             .joinedload(Artefact.assignee),
-            joinedload(TestExecutionRerunRequest.test_execution).joinedload(
-                TestExecution.environment
-            ),
+            joinedload(TestExecutionRerunRequest.test_execution)
+            .joinedload(TestExecution.environment),
         )
     )
+
+    if family is not None:
+        stmt = stmt.filter(Artefact.family == family)
+
+    if limit is not None:
+        stmt = stmt.limit(limit)
+
+    return db.scalars(stmt)
 
 
 @router.delete("/reruns")

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -25,7 +25,7 @@ from fastapi.testclient import TestClient
 from httpx import Response
 
 from test_observer.data_access.models import TestExecution
-from test_observer.data_access.models_enums import StageName
+from test_observer.data_access.models_enums import StageName, FamilyName
 from tests.data_generator import DataGenerator
 
 reruns_url = "/v1/test-executions/reruns"
@@ -41,8 +41,16 @@ def post(test_client: TestClient):
 
 @pytest.fixture
 def get(test_client: TestClient):
-    def get_helper() -> Response:
-        return test_client.get(reruns_url)
+    def get_helper(
+            family: FamilyName | None = None,
+            limit: int | None = None,
+        ) -> Response:
+        params: dict[str, str | int] = {}
+        if family is not None:
+            params["family"] = family.value
+        if limit is not None:
+            params["limit"] = limit
+        return test_client.get(reruns_url, params=params)
 
     return get_helper
 
@@ -56,7 +64,7 @@ def delete(test_client: TestClient):
 
 
 Post: TypeAlias = Callable[[Any], Response]
-Get: TypeAlias = Callable[[], Response]
+Get: TypeAlias = Callable[..., Response]
 Delete: TypeAlias = Callable[[Any], Response]
 
 
@@ -201,6 +209,38 @@ def test_get_after_post_with_two_test_execution_ids(
 
     assert sorted(get().json(), key=itemgetter("test_execution_id")) == [
         test_execution_to_pending_rerun(te1),
+        test_execution_to_pending_rerun(te2),
+    ]
+
+
+def test_get_with_limit(
+    get: Get, post: Post, test_execution: TestExecution, generator: DataGenerator
+):
+    te1 = test_execution
+    te2 = generator.gen_test_execution(te1.artefact_build, te1.environment)
+
+    post({"test_execution_ids": [te1.id]})
+    post({"test_execution_ids": [te2.id]})
+
+    assert get(limit=1).json() in [
+        [test_execution_to_pending_rerun(te1)],
+        [test_execution_to_pending_rerun(te2)],
+    ]
+
+
+def test_get_with_family(
+    get: Get, post: Post, test_execution: TestExecution, generator: DataGenerator
+):
+    te1 = test_execution
+    a = generator.gen_artefact(StageName.beta, family=FamilyName.charm)
+    ab = generator.gen_artefact_build(a)
+    e2 = generator.gen_environment("e2")
+    te2 = generator.gen_test_execution(ab, e2)
+
+    post({"test_execution_ids": [te1.id]})
+    post({"test_execution_ids": [te2.id]})
+
+    assert get(family=FamilyName.charm).json() == [
         test_execution_to_pending_rerun(te2),
     ]
 


### PR DESCRIPTION
## Description

Filtering by `family` and limiting the number to `limit` in `GET /reruns` helps us avoid a minute long response from Test Observer when there are many many reruns.

## Resolved issues

Reruns API can be limited to not return 7000+ reruns and 6MB+ of data, as seen in staging.

## Documentation

Yes (openapi spec)

## Web service API changes

`GET /reruns?limit=`: Limits number of rerun requests returned.
`GET /reruns?family=`: Filters reruns by artefact family.

Both parameters are optional and therefore backwards compatible.

## Tests

Unit tests added.
