### PR TITLE
Require artefact comment on rejection

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -153,4 +153,5 @@ def test_execution(generator: DataGenerator) -> TestExecution:
     ab = generator.gen_artefact_build(a)
     e = generator.gen_environment()
     te = generator.gen_test_execution(ab, e)
+    generator.gen_artefact_build_environment_review(ab, e)
     return te

--- a/backend/tests/controllers/artefacts/test_artefacts.py
+++ b/backend/tests/controllers/artefacts/test_artefacts.py
@@ -250,6 +250,34 @@ def test_artefact_signoff_ignore_old_build_on_reject(
     assert response.status_code == 400
 
 
+def test_artefact_rejection_requires_comment(
+    test_client: TestClient, test_execution: TestExecution
+):
+    # Reject an environment as that's required to reject an artefact
+    test_execution.artefact_build.environment_reviews[0].review_decision = [
+        ArtefactBuildEnvironmentReviewDecision.REJECTED
+    ]
+
+    response = test_client.patch(
+        f"/v1/artefacts/{test_execution.artefact_build.artefact_id}",
+        json={"status": ArtefactStatus.MARKED_AS_FAILED},
+    )
+
+    assert response.status_code == 400
+
+    test_execution.artefact_build.artefact.comment = "some comment"
+
+    response = test_client.patch(
+        f"/v1/artefacts/{test_execution.artefact_build.artefact_id}",
+        json={"status": ArtefactStatus.MARKED_AS_FAILED},
+    )
+
+    assert response.status_code == 200
+    assert (
+        test_execution.artefact_build.artefact.status == ArtefactStatus.MARKED_AS_FAILED
+    )
+
+
 def test_artefact_archive(test_client: TestClient, generator: DataGenerator):
     artefact = generator.gen_artefact(StageName.candidate, archived=False)
 


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

Users should not be able to reject an artefact without adding some kind of comment on the artefact level.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

Resolves https://warthogs.atlassian.net/browse/TO-128

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Added automated tests. Also see below front-end behavior.
[Screencast from 2025-07-08 15-10-05.webm](https://github.com/user-attachments/assets/583bdb3e-6b48-41e4-82bf-3754ae4579a2)

