### PR TITLE
Make artefact comment tick green

### DIFF
--- a/frontend/lib/ui/submittable_text_field.dart
+++ b/frontend/lib/ui/submittable_text_field.dart
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'package:flutter/material.dart';
+import 'package:yaru/theme.dart';
 import 'spacing.dart';
 import 'vanilla/vanilla_text_input.dart';
 
@@ -112,7 +113,7 @@ class _SubmittableTextFieldState extends State<SubmittableTextField> {
             widget.onSubmit(commentController.text);
           });
         },
-        icon: Icon(Icons.done),
+        icon: Icon(Icons.done, color: YaruColors.light.success),
       ),
     ];
   }


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

In attempt to make it clearer that to save an artefact comment you need to press the tick.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

![Screenshot from 2025-07-09 09-15-18](https://github.com/user-attachments/assets/5080816c-b105-448a-9528-464ec096c0ef)
