### PR TITLE
If needs_assignment is set to false an artefact shouldn't get a due date

### DIFF
--- a/backend/test_observer/controllers/test_executions/start_test.py
+++ b/backend/test_observer/controllers/test_executions/start_test.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from datetime import date, timedelta
 import random
 
 from fastapi import APIRouter, Body, Depends
@@ -76,6 +77,7 @@ class StartTestExecutionController:
             and (users := self.db.query(User).all())
         ):
             self.artefact.assignee = random.choice(users)
+            self.artefact.due_date = self.determine_due_date()
             self.db.commit()
 
     def create_test_execution(self):
@@ -174,6 +176,14 @@ class StartTestExecutionController:
                 self.db.delete(rerun_request)
 
         self.db.commit()
+
+    def determine_due_date(self):
+        name = self.artefact.name
+        is_kernel = name.startswith("linux-") or name.endswith("-kernel")
+        if not is_kernel:
+            # If not a kernel, return a date 10 days from now
+            return date.today() + timedelta(days=10)
+        return None
 
 
 @router.put("/start-test")

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -16,7 +16,7 @@
 
 
 from collections import defaultdict
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 from typing import TypeVar
 
 from sqlalchemy import (
@@ -30,7 +30,6 @@ from sqlalchemy import (
     Boolean,
 )
 from sqlalchemy.dialects.postgresql import ARRAY
-from sqlalchemy.engine.default import DefaultExecutionContext
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import (
     DeclarativeBase,
@@ -80,15 +79,6 @@ def data_model_repr(obj: DataModel, *keys: str) -> str:
     return f"{type(obj).__name__}({', '.join(kwargs)})"
 
 
-def determine_due_date(context: DefaultExecutionContext):
-    name = context.get_current_parameters()["name"]
-    is_kernel = name.startswith("linux-") or name.endswith("-kernel")
-    if not is_kernel:
-        # If not a kernel, return a date 10 days from now
-        return date.today() + timedelta(days=10)
-    return None
-
-
 class User(Base):
     """
     ORM representing users that can be assigned to review artefacts
@@ -117,7 +107,7 @@ class Artefact(Base):
     version: Mapped[str]
     stage: Mapped[str] = mapped_column(String(100))
     family: Mapped[FamilyName]
-    due_date: Mapped[date | None] = mapped_column(default=determine_due_date)
+    due_date: Mapped[date | None] = mapped_column(default=None)
     bug_link: Mapped[str] = mapped_column(default="")
     status: Mapped[ArtefactStatus] = mapped_column(default=ArtefactStatus.UNDECIDED)
     archived: Mapped[bool] = mapped_column(Boolean, default=False, index=True)

--- a/backend/tests/controllers/test_executions/test_start_test.py
+++ b/backend/tests/controllers/test_executions/test_start_test.py
@@ -151,7 +151,7 @@ class TestFamilyIndependentTests:
         assert test_execution_2.environment_id == test_execution_1.environment_id
         assert test_execution_2.artefact_build_id == test_execution_1.artefact_build_id
 
-    def test_new_artefact_no_assignment_by_default(
+    def test_new_artefact_no_assignment_and_no_date_by_default(
         self, execute: Execute, generator: DataGenerator, start_request: dict[str, Any]
     ):
         generator.gen_user()
@@ -160,8 +160,8 @@ class TestFamilyIndependentTests:
 
         test_execution = self._db_session.get(TestExecution, response.json()["id"])
         assert test_execution
-        assignee = test_execution.artefact_build.artefact.assignee
-        assert assignee is None
+        assert test_execution.artefact_build.artefact.assignee is None
+        assert test_execution.artefact_build.artefact.due_date is None
 
     def test_new_artefacts_get_assigned_a_reviewer(
         self, execute: Execute, generator: DataGenerator, start_request: dict[str, Any]
@@ -348,11 +348,15 @@ def test_image_required_fields(execute: Execute, field: str):
     assert_fails_validation(response, field, "missing")
 
 
-def test_non_kernel_artefact_due_date(db_session: Session, execute: Execute):
+def test_non_kernel_artefact_due_date(
+    db_session: Session, execute: Execute, generator: DataGenerator
+):
     """
     For non-kernel snaps, the default due date should be set to now + 10 days
     """
-    execute(snap_test_request)
+    generator.gen_user()
+
+    execute({**snap_test_request, "needs_assignment": True})
 
     artefact = (
         db_session.query(Artefact)

--- a/frontend/lib/ui/artefact_page/artefact_page_info_section.dart
+++ b/frontend/lib/ui/artefact_page/artefact_page_info_section.dart
@@ -56,7 +56,7 @@ class ArtefactPageInfoSection extends ConsumerWidget {
         if (artefact.repo.isNotEmpty)
           Text('repo: ${artefact.repo}', style: fontStyle),
         if (artefact.source.isNotEmpty)
-          Text('repo: ${artefact.source}', style: fontStyle),
+          Text('source: ${artefact.source}', style: fontStyle),
         if (artefact.os.isNotEmpty)
           Text('os: ${artefact.os}', style: fontStyle),
         if (artefact.release.isNotEmpty)


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

As pointed out by @boukeas, TO was incorrectly setting a due date for artefacts that need no assignment. Additionally there was a small copy mistake on the front-end.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Added automated tests.
