### PR TITLE
Sort test results by execution order

### DIFF
--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -342,9 +342,7 @@ class TestExecution(Base):
     )
     environment: Mapped["Environment"] = relationship(back_populates="test_executions")
     test_results: Mapped[list["TestResult"]] = relationship(
-        back_populates="test_execution", 
-        cascade="all, delete",
-        order_by="TestResult.id",
+        back_populates="test_execution", cascade="all, delete"
     )
     test_events: Mapped[list["TestEvent"]] = relationship(
         back_populates="test_execution",

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -342,7 +342,9 @@ class TestExecution(Base):
     )
     environment: Mapped["Environment"] = relationship(back_populates="test_executions")
     test_results: Mapped[list["TestResult"]] = relationship(
-        back_populates="test_execution", cascade="all, delete"
+        back_populates="test_execution", 
+        cascade="all, delete",
+        order_by="TestResult.id",
     )
     test_events: Mapped[list["TestEvent"]] = relationship(
         back_populates="test_execution",

--- a/backend/tests/controllers/test_executions/test_get_test_results_sorting.py
+++ b/backend/tests/controllers/test_executions/test_get_test_results_sorting.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2023 Canonical Ltd.
+#
+# This file is part of Test Observer Backend.
+#
+# Test Observer Backend is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# Test Observer Backend is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+from fastapi.testclient import TestClient
+
+from test_observer.data_access.models_enums import StageName
+from tests.data_generator import DataGenerator
+
+
+def test_get_test_results_sorts_by_execution_order(
+    test_client: TestClient, generator: DataGenerator
+):
+ 
+    a = generator.gen_artefact(StageName.beta)
+    ab = generator.gen_artefact_build(a)
+    e = generator.gen_environment()
+    te = generator.gen_test_execution(ab, e)
+
+    tc_deploy = generator.gen_test_case("test_deploy")
+    tc_integration = generator.gen_test_case("test_integration")
+    tc_teardown = generator.gen_test_case("test_teardown")
+
+    generator.gen_test_result(tc_deploy, te)
+    generator.gen_test_result(tc_integration, te)
+    generator.gen_test_result(tc_teardown, te)
+
+    response = test_client.get(f"/v1/test-executions/{te.id}/test-results")
+
+    assert response.status_code == 200
+    json_response = response.json()
+    
+    result_ids = [result["id"] for result in json_response]
+    test_names = [result["name"] for result in json_response]
+
+    assert result_ids == sorted(result_ids)
+
+    expected_order = [
+        "test_deploy",      
+        "test_integration", 
+        "test_teardown"     
+    ]
+    
+    assert test_names == expected_order


### PR DESCRIPTION
## Description

Sort test results by execution order on artifact pages to improve test timeline visibility. Test results now display in chronological execution order rather than arbitrary database order. 

## Resolved issues

Resolves https://warthogs.atlassian.net/browse/SQT-464

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<img width="353" height="170" alt="image" src="https://github.com/user-attachments/assets/5413bc66-691f-418e-8bf2-2fa96c68be47" />


