### PR TITLE
[TS-143] Add issue attachments for test results

### DIFF
--- a/backend/migrations/versions/2025_07_22_1612-0110872321dc_add_issue_to_test_result_attachments.py
+++ b/backend/migrations/versions/2025_07_22_1612-0110872321dc_add_issue_to_test_result_attachments.py
@@ -1,0 +1,80 @@
+# Copyright (C) 2023 Canonical Ltd.
+#
+# This file is part of Test Observer Backend.
+#
+# Test Observer Backend is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# Test Observer Backend is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Add issue to test result attachments
+
+Revision ID: 0110872321dc
+Revises: ab74101e7373
+Create Date: 2025-07-22 16:12:22.752629+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0110872321dc"
+down_revision = "ab74101e7373"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "issue_test_result_attachment",
+        sa.Column("issue_id", sa.Integer(), nullable=False),
+        sa.Column("test_result_id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["issue_id"],
+            ["issue.id"],
+            name=op.f("issue_test_result_attachment_issue_id_fkey"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["test_result_id"],
+            ["test_result.id"],
+            name=op.f("issue_test_result_attachment_test_result_id_fkey"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "id",
+            name=op.f("issue_test_result_attachment_pkey"),
+        ),
+        sa.UniqueConstraint(
+            "issue_id",
+            "test_result_id",
+            name=op.f("issue_test_result_attachment_issue_id_test_result_id_key"),
+        ),
+    )
+    op.create_index(
+        op.f("issue_test_result_attachment_issue_id_ix"),
+        "issue_test_result_attachment",
+        ["issue_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("issue_test_result_attachment_test_result_id_ix"),
+        "issue_test_result_attachment",
+        ["test_result_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("issue_test_result_attachment")

--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -1505,6 +1505,110 @@
         }
       }
     },
+    "/v1/issues/{issue_id}/attach": {
+      "post": {
+        "tags": [
+          "issues"
+        ],
+        "summary": "Add Issue Attachments",
+        "operationId": "add_issue_attachments_v1_issues__issue_id__attach_post",
+        "parameters": [
+          {
+            "name": "issue_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Issue Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IssueAttachmentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IssueResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/issues/{issue_id}/detach": {
+      "post": {
+        "tags": [
+          "issues"
+        ],
+        "summary": "Remove Issue Attachments",
+        "operationId": "remove_issue_attachments_v1_issues__issue_id__detach_post",
+        "parameters": [
+          {
+            "name": "issue_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Issue Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IssueAttachmentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IssueResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/issues": {
       "get": {
         "tags": [
@@ -2385,6 +2489,19 @@
         ],
         "title": "ImageStage"
       },
+      "IssueAttachmentRequest": {
+        "properties": {
+          "test_results": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Test Results"
+          }
+        },
+        "type": "object",
+        "title": "IssueAttachmentRequest"
+      },
       "IssuePatchRequest": {
         "properties": {
           "title": {
@@ -2479,6 +2596,13 @@
             "minLength": 1,
             "format": "uri",
             "title": "Url"
+          },
+          "test_results": {
+            "items": {
+              "$ref": "#/components/schemas/IssueTestResultAttachmentResponse"
+            },
+            "type": "array",
+            "title": "Test Results"
           }
         },
         "type": "object",
@@ -2489,7 +2613,8 @@
           "key",
           "title",
           "status",
-          "url"
+          "url",
+          "test_results"
         ],
         "title": "IssueResponse"
       },
@@ -2510,6 +2635,30 @@
           "closed"
         ],
         "title": "IssueStatus"
+      },
+      "IssueTestResultAttachmentResponse": {
+        "properties": {
+          "test_result": {
+            "$ref": "#/components/schemas/TestResultResponse"
+          },
+          "test_execution": {
+            "$ref": "#/components/schemas/TestExecutionResponse"
+          },
+          "artefact": {
+            "$ref": "#/components/schemas/ArtefactResponse"
+          },
+          "artefact_build": {
+            "$ref": "#/components/schemas/ArtefactBuildMinimalResponse"
+          }
+        },
+        "type": "object",
+        "required": [
+          "test_result",
+          "test_execution",
+          "artefact",
+          "artefact_build"
+        ],
+        "title": "IssueTestResultAttachmentResponse"
       },
       "IssuesGetResponse": {
         "properties": {
@@ -2570,6 +2719,18 @@
           "url"
         ],
         "title": "MinimalIssueResponse"
+      },
+      "MinimalIssueTestResultAttachmentResponse": {
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/MinimalIssueResponse"
+          }
+        },
+        "type": "object",
+        "required": [
+          "issue"
+        ],
+        "title": "MinimalIssueTestResultAttachmentResponse"
       },
       "PendingRerun": {
         "properties": {
@@ -3437,6 +3598,13 @@
             "title": "Previous Results",
             "description": "The last 10 test results matched with the current test execution. The items are sorted in descending order, the first test result is the most recent, while the last one is the oldest one.",
             "default": []
+          },
+          "issues": {
+            "items": {
+              "$ref": "#/components/schemas/MinimalIssueTestResultAttachmentResponse"
+            },
+            "type": "array",
+            "title": "Issues"
           }
         },
         "type": "object",
@@ -3447,7 +3615,8 @@
           "template_id",
           "status",
           "comment",
-          "io_log"
+          "io_log",
+          "issues"
         ],
         "title": "TestResultResponse"
       },

--- a/backend/test_observer/controllers/issues/issue_attachments.py
+++ b/backend/test_observer/controllers/issues/issue_attachments.py
@@ -1,0 +1,89 @@
+# Copyright (C) 2023 Canonical Ltd.
+#
+# This file is part of Test Observer Backend.
+#
+# Test Observer Backend is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# Test Observer Backend is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+from fastapi import APIRouter, Depends
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+from sqlalchemy import delete
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from test_observer.data_access.setup import get_db
+from test_observer.data_access.models import Issue, IssueTestResultAttachment
+
+from .models import (
+    IssueResponse,
+    IssueAttachmentRequest,
+)
+
+router = APIRouter()
+
+
+def modify_issue_attachments(
+    db: Session,
+    issue_id: int,
+    request: IssueAttachmentRequest,
+    detach: bool = False,
+) -> Issue:
+    # Retrieve the issue
+    issue = db.get(Issue, issue_id)
+    if issue is None:
+        raise HTTPException(status_code=404, detail="Issue not found")
+
+    # Add or remove any requested test result attachments
+    test_result_ids = set(request.test_results)
+    if test_result_ids:
+        if detach:
+            db.execute(
+                delete(IssueTestResultAttachment).where(
+                    IssueTestResultAttachment.issue_id == issue_id,
+                    IssueTestResultAttachment.test_result_id.in_(test_result_ids),
+                )
+            )
+        else:
+            db.execute(
+                pg_insert(IssueTestResultAttachment)
+                .values(
+                    [
+                        {"issue_id": issue_id, "test_result_id": test_result_id}
+                        for test_result_id in test_result_ids
+                    ]
+                )
+                .on_conflict_do_nothing()
+            )
+
+    # Save and return the issue
+    db.commit()
+    db.refresh(issue)
+    return issue
+
+
+@router.post("/{issue_id}/attach", response_model=IssueResponse)
+def add_issue_attachments(
+    issue_id: int,
+    request: IssueAttachmentRequest,
+    db: Session = Depends(get_db),
+):
+    return modify_issue_attachments(db, issue_id, request, detach=False)
+
+
+@router.post("/{issue_id}/detach", response_model=IssueResponse)
+def remove_issue_attachments(
+    issue_id: int,
+    request: IssueAttachmentRequest,
+    db: Session = Depends(get_db),
+):
+    return modify_issue_attachments(db, issue_id, request, detach=True)

--- a/backend/test_observer/controllers/issues/shared_models.py
+++ b/backend/test_observer/controllers/issues/shared_models.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2023 Canonical Ltd.
+#
+# This file is part of Test Observer Backend.
+#
+# Test Observer Backend is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# Test Observer Backend is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from pydantic import BaseModel, HttpUrl
+from test_observer.data_access.models_enums import IssueSource, IssueStatus
+
+from pydantic import ConfigDict, Field, AliasPath
+
+
+class MinimalIssueResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    source: IssueSource
+    project: str
+    key: str
+    title: str
+    status: IssueStatus
+    url: HttpUrl
+
+
+class MinimalIssueTestResultAttachmentResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    issue: MinimalIssueResponse = Field(validation_alias=AliasPath("issue"))

--- a/backend/test_observer/controllers/test_executions/get_test_results.py
+++ b/backend/test_observer/controllers/test_executions/get_test_results.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import Session, selectinload
 from test_observer.data_access.models import (
     TestExecution,
     TestResult,
+    IssueTestResultAttachment,
 )
 from test_observer.data_access.setup import get_db
 
@@ -42,7 +43,11 @@ def get_test_results(id: int, db: Session = Depends(get_db)):
         select(TestResult)
         .where(TestResult.test_execution_id == id)
         .order_by(TestResult.id)
-        .options(selectinload(TestResult.test_case))
+        .options(
+            selectinload(TestResult.test_case),
+            selectinload(TestResult.issue_attachments)
+            .selectinload(IssueTestResultAttachment.issue),
+        )
     ).scalars().all()
 
     previous_test_results = get_previous_test_results(db, test_execution)

--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -45,6 +45,9 @@ from test_observer.data_access.models_enums import (
     TestExecutionStatus,
     TestResultStatus,
 )
+from test_observer.controllers.issues.shared_models import (
+    MinimalIssueTestResultAttachmentResponse,
+)
 
 
 class _StartTestExecutionRequest(BaseModel):
@@ -182,6 +185,9 @@ class TestResultResponse(BaseModel):
             "the first test result is the most recent, while "
             "the last one is the oldest one."
         ),
+    )
+    issues: list[MinimalIssueTestResultAttachmentResponse] = Field(
+        validation_alias=AliasPath("issue_attachments"),
     )
 
 

--- a/backend/test_observer/data_access/models_enums.py
+++ b/backend/test_observer/data_access/models_enums.py
@@ -115,6 +115,7 @@ class IssueSource(StrEnum):
     GITHUB = "github"
     LAUNCHPAD = "launchpad"
 
+
 class IssueStatus(StrEnum):
     UNKNOWN = "unknown"
     OPEN = "open"

--- a/backend/tests/controllers/issues/test_issue_attachments.py
+++ b/backend/tests/controllers/issues/test_issue_attachments.py
@@ -1,0 +1,128 @@
+# Copyright (C) 2023 Canonical Ltd.
+#
+# This file is part of Test Observer Backend.
+#
+# Test Observer Backend is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# Test Observer Backend is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+from fastapi.testclient import TestClient
+
+from tests.data_generator import DataGenerator
+
+attach_endpoint = "/v1/issues/{id}/attach"
+detach_endpoint = "/v1/issues/{id}/detach"
+
+
+def gen_test_results(generator: DataGenerator):
+    environment = generator.gen_environment()
+    test_case = generator.gen_test_case()
+    artefact = generator.gen_artefact()
+    artefact_build = generator.gen_artefact_build(artefact)
+    test_execution = generator.gen_test_execution(artefact_build, environment)
+    test_result_1 = generator.gen_test_result(test_case, test_execution)
+    test_result_2 = generator.gen_test_result(test_case, test_execution)
+    return test_result_1, test_result_2
+
+
+def test_issue_attach_empty(test_client: TestClient, generator: DataGenerator):
+    issue = generator.gen_issue()
+    response = test_client.post(
+        attach_endpoint.format(id=issue.id),
+        json={"test_results": []},
+    )
+    assert response.json()["test_results"] == []
+
+
+def test_issue_attach_one(test_client: TestClient, generator: DataGenerator):
+    test_result = gen_test_results(generator)[0]
+    issue = generator.gen_issue()
+    response = test_client.post(
+        attach_endpoint.format(id=issue.id), json={"test_results": [test_result.id]}
+    )
+    assert {
+        attachment["test_result"]["id"]
+        for attachment in response.json()["test_results"]
+    } == {test_result.id}
+
+
+def test_issue_attach_repeat(test_client: TestClient, generator: DataGenerator):
+    test_result = gen_test_results(generator)[0]
+    issue = generator.gen_issue()
+    response = test_client.post(
+        attach_endpoint.format(id=issue.id), json={"test_results": [test_result.id]}
+    )
+    response = test_client.post(
+        attach_endpoint.format(id=issue.id), json={"test_results": [test_result.id]}
+    )
+    assert {
+        attachment["test_result"]["id"]
+        for attachment in response.json()["test_results"]
+    } == {test_result.id}
+
+
+def test_issue_attach_multiple(test_client: TestClient, generator: DataGenerator):
+    test_results = gen_test_results(generator)
+    issue = generator.gen_issue()
+    response = test_client.post(
+        attach_endpoint.format(id=issue.id), json={"test_results": [test_results[0].id]}
+    )
+    response = test_client.post(
+        attach_endpoint.format(id=issue.id), json={"test_results": [test_results[1].id]}
+    )
+    assert {
+        attachment["test_result"]["id"]
+        for attachment in response.json()["test_results"]
+    } == {test_results[0].id, test_results[1].id}
+
+
+def test_issue_detach_one(test_client: TestClient, generator: DataGenerator):
+    test_result = gen_test_results(generator)[0]
+    issue = generator.gen_issue()
+    response = test_client.post(
+        attach_endpoint.format(id=issue.id), json={"test_results": [test_result.id]}
+    )
+    response = test_client.post(
+        detach_endpoint.format(id=issue.id), json={"test_results": [test_result.id]}
+    )
+    assert response.json()["test_results"] == []
+
+
+def test_issue_detach_repeat(test_client: TestClient, generator: DataGenerator):
+    test_result = gen_test_results(generator)[0]
+    issue = generator.gen_issue()
+    response = test_client.post(
+        attach_endpoint.format(id=issue.id), json={"test_results": [test_result.id]}
+    )
+    response = test_client.post(
+        detach_endpoint.format(id=issue.id), json={"test_results": [test_result.id]}
+    )
+    response = test_client.post(
+        detach_endpoint.format(id=issue.id), json={"test_results": [test_result.id]}
+    )
+    assert response.json()["test_results"] == []
+
+
+def test_issue_detach_some(test_client: TestClient, generator: DataGenerator):
+    test_results = gen_test_results(generator)
+    issue = generator.gen_issue()
+    response = test_client.post(
+        attach_endpoint.format(id=issue.id),
+        json={"test_results": [test_results[0].id, test_results[1].id]},
+    )
+    response = test_client.post(
+        detach_endpoint.format(id=issue.id), json={"test_results": [test_results[0].id]}
+    )
+    assert {
+        attachment["test_result"]["id"]
+        for attachment in response.json()["test_results"]
+    } == {test_results[1].id}

--- a/backend/tests/controllers/issues/test_issue_url_parser.py
+++ b/backend/tests/controllers/issues/test_issue_url_parser.py
@@ -19,9 +19,10 @@ import pytest
 from pydantic import HttpUrl
 
 from test_observer.controllers.issues.issue_url_parser import (
-    issue_source_project_key_from_url
+    issue_source_project_key_from_url,
 )
 from test_observer.data_access.models_enums import IssueSource
+
 
 @pytest.mark.parametrize(
     "url,expected",
@@ -68,22 +69,22 @@ from test_observer.data_access.models_enums import IssueSource
         ("https://bugs.launchpad.net/abc/+bug/abc", None),
         # Good launchpad
         (
-            "https://bugs.launchpad.net/abc/+bug/123", 
+            "https://bugs.launchpad.net/abc/+bug/123",
             (IssueSource.LAUNCHPAD, "abc", "123"),
         ),
         # Lowercase launchpad project
         (
-            "https://bugs.launchpad.net/ABC/+bug/123", 
+            "https://bugs.launchpad.net/ABC/+bug/123",
             (IssueSource.LAUNCHPAD, "abc", "123"),
         ),
         # Accept http
         (
-            "http://github.com/canonical/test_observer/issues/71", 
+            "http://github.com/canonical/test_observer/issues/71",
             (IssueSource.GITHUB, "canonical/test_observer", "71"),
         ),
         # Ignore query params
         (
-            "http://github.com/canonical/test_observer/issues/71?some=param", 
+            "http://github.com/canonical/test_observer/issues/71?some=param",
             (IssueSource.GITHUB, "canonical/test_observer", "71"),
         ),
     ],

--- a/backend/tests/controllers/issues/test_issues.py
+++ b/backend/tests/controllers/issues/test_issues.py
@@ -18,6 +18,7 @@
 from fastapi.testclient import TestClient
 
 from tests.asserts import assert_fails_validation
+from tests.data_generator import DataGenerator
 
 endpoint = "/v1/issues"
 valid_put_data = {
@@ -25,58 +26,102 @@ valid_put_data = {
     "title": "some title",
     "status": "open",
 }
-sample_issue_json = {
-    "url": valid_put_data["url"],
-    "title": valid_put_data["title"],
-    "status": valid_put_data["status"],
-    "source": "github",
-    "project": "canonical/test_observer",
-    "key": "71",
-}
+
 
 def test_empty_get_all(test_client: TestClient):
     response = test_client.get(endpoint)
     assert response.status_code == 200
     assert response.json() == {"issues": []}
 
-def test_get_all(test_client: TestClient):
-    put_response = test_client.put(endpoint, json=valid_put_data)
+
+def test_get_all(test_client: TestClient, generator: DataGenerator):
+    issue = generator.gen_issue()
+
     response = test_client.get(endpoint)
+
     assert response.status_code == 200
     assert response.json() == {
-        "issues": [{**sample_issue_json, "id": put_response.json()["id"]}],
+        "issues": [
+            {
+                "id": issue.id,
+                "source": issue.source,
+                "project": issue.project,
+                "key": issue.key,
+                "title": issue.title,
+                "status": issue.status,
+                "url": issue.url,
+            }
+        ],
     }
 
-def test_get_issue(test_client: TestClient):
-    put_response = test_client.put(endpoint, json=valid_put_data)
-    response = test_client.get(endpoint + f"/{put_response.json()['id']}")
+
+def test_get_issue(test_client: TestClient, generator: DataGenerator):
+    environment = generator.gen_environment()
+    test_case = generator.gen_test_case()
+    artefact = generator.gen_artefact()
+    artefact_build = generator.gen_artefact_build(artefact)
+    test_execution = generator.gen_test_execution(artefact_build, environment)
+    test_result = generator.gen_test_result(test_case, test_execution)
+    issue = generator.gen_issue()
+    response = test_client.post(
+        f"/v1/issues/{issue.id}/attach", json={"test_results": [test_result.id]}
+    )
+
+    response = test_client.get(endpoint + f"/{issue.id}")
+
     assert response.status_code == 200
-    assert response.json() == {**sample_issue_json, "id": put_response.json()["id"]}
+    assert response.json()["id"] == issue.id
+    assert response.json()["source"] == issue.source
+    assert response.json()["project"] == issue.project
+    assert response.json()["key"] == issue.key
+    assert response.json()["title"] == issue.title
+    assert response.json()["status"] == issue.status
+    assert response.json()["url"] == issue.url
+    assert len(response.json()["test_results"]) == 1
+    assert response.json()["test_results"][0]["test_result"]["id"] == test_result.id
+    assert (
+        response.json()["test_results"][0]["test_execution"]["id"] == test_execution.id
+    )
+    assert response.json()["test_results"][0]["artefact"]["id"] == artefact.id
+    assert (
+        response.json()["test_results"][0]["artefact_build"]["id"] == artefact_build.id
+    )
+
 
 def test_patch_invalid_status(test_client: TestClient):
     put_response = test_client.put(endpoint, json=valid_put_data)
-    response = test_client.patch(endpoint + f"/{put_response.json()['id']}", json={
-        "status": "unknown-status",
-    })
+    response = test_client.patch(
+        endpoint + f"/{put_response.json()['id']}",
+        json={
+            "status": "unknown-status",
+        },
+    )
     assert response.status_code == 422
+
 
 def test_patch_no_change(test_client: TestClient):
     put_response = test_client.put(endpoint, json=valid_put_data)
     response = test_client.patch(endpoint + f"/{put_response.json()['id']}", json={})
     assert put_response.json() == response.json()
 
+
 def test_patch_all(test_client: TestClient):
     put_response = test_client.put(endpoint, json=valid_put_data)
-    response = test_client.patch(endpoint + f"/{put_response.json()['id']}", json={
-        "title": "new title",
-        "status": "closed",
-    })
+    response = test_client.patch(
+        endpoint + f"/{put_response.json()['id']}",
+        json={
+            "title": "new title",
+            "status": "closed",
+        },
+    )
     assert response.json()["title"] == "new title"
     assert response.json()["status"] == "closed"
+
 
 def test_put_requires_url(test_client: TestClient):
     response = test_client.put(endpoint, json={})
     assert_fails_validation(response, "url", "missing")
+
 
 def test_put_indempotent(test_client: TestClient):
     test_client.put(endpoint, json=valid_put_data)
@@ -84,21 +129,25 @@ def test_put_indempotent(test_client: TestClient):
     response = test_client.get(endpoint)
     assert len(response.json()["issues"]) == 1
 
+
 def test_put_update_existing(test_client: TestClient):
     test_client.put(endpoint, json=valid_put_data)
     test_client.put(endpoint, json={**valid_put_data, "title": "new title"})
     response = test_client.get(endpoint)
     assert response.json()["issues"][0]["title"] == "new title"
 
+
 def test_put_invalid_url(test_client: TestClient):
     put_data = {**valid_put_data, "url": "http://unknown.com/bug/1"}
     response = test_client.put(endpoint, json=put_data)
     assert response.status_code == 422
 
+
 def test_put_invalid_status(test_client: TestClient):
     put_data = {**valid_put_data, "status": "random"}
     response = test_client.put(endpoint, json=put_data)
     assert response.status_code == 422
+
 
 def test_put_defaults(test_client: TestClient):
     put_data = {"url": valid_put_data["url"]}

--- a/backend/tests/controllers/test_executions/test_get_test_results.py
+++ b/backend/tests/controllers/test_executions/test_get_test_results.py
@@ -52,6 +52,11 @@ def test_fetch_test_results(test_client: TestClient, generator: DataGenerator):
         test_execution_second,
     )
 
+    issue = generator.gen_issue()
+    response = test_client.post(
+        f"/v1/issues/{issue.id}/attach", json={"test_results": [test_result_second.id]}
+    )
+
     response = test_client.get(
         f"/v1/test-executions/{test_execution_second.id}/test-results"
     )
@@ -69,6 +74,19 @@ def test_fetch_test_results(test_client: TestClient, generator: DataGenerator):
             "status": test_result_first.status,
             "version": artefact_first.version,
             "artefact_id": artefact_first.id,
+        }
+    ]
+    assert json[0]["issues"] == [
+        {
+            "issue": {
+                "id": issue.id,
+                "source": issue.source,
+                "project": issue.project,
+                "key": issue.key,
+                "title": issue.title,
+                "status": issue.status,
+                "url": issue.url,
+            }
         }
     ]
 
@@ -107,6 +125,7 @@ def test_previous_results_shows_reruns(
                     "artefact_id": a.id,
                 }
             ],
+            "issues": [],
         }
     ]
 
@@ -148,6 +167,7 @@ def test_previous_results_orders_by_artefact(
                     "artefact_id": a1.id,
                 }
             ],
+            "issues": [],
         }
     ]
 

--- a/backend/tests/data_generator.py
+++ b/backend/tests/data_generator.py
@@ -31,6 +31,7 @@ from test_observer.data_access.models import (
     TestExecutionRelevantLink,
     TestResult,
     User,
+    Issue,
 )
 from test_observer.data_access.models_enums import (
     ArtefactBuildEnvironmentReviewDecision,
@@ -39,6 +40,8 @@ from test_observer.data_access.models_enums import (
     StageName,
     TestExecutionStatus,
     TestResultStatus,
+    IssueSource,
+    IssueStatus,
 )
 
 DEFAULT_ARCHITECTURE = "amd64"
@@ -286,6 +289,24 @@ class DataGenerator:
         )
         self._add_object(test_event)
         return test_event
+
+    def gen_issue(
+        self,
+        source: IssueSource = IssueSource.GITHUB,
+        project: str = "canonical/test_observer",
+        key: str = "42",
+        title: str = "there is a bug",
+        status: IssueStatus = IssueStatus.OPEN,
+    ) -> Issue:
+        issue = Issue(
+            source=source,
+            project=project,
+            key=key,
+            title=title,
+            status=status,
+        )
+        self._add_object(issue)
+        return issue
 
     def _add_object(self, instance: object) -> None:
         self.db_session.add(instance)


### PR DESCRIPTION
## Description

Adds new issue model and issue management APIs in accordance with [SQ079](https://docs.google.com/document/d/1Kc8sRSoH2TIKTmwZ5AkUYtkGurolaKDAbEl9SOUUBEk/edit).

## Resolved issues

[TO-143](https://warthogs.atlassian.net/browse/TO-143)

## Web service API changes

The OpenAPI schema has been updated, but to summarize:

New endpoints to attach and detach:
- `POST /v1/issues/{issue_id}/attach`
- `POST /v1/issues/{issue_id}/detach`

Modify endpoints to include attachments:
- `GET /test-execution/{id}/test-results`
- `GET /issues/{id}`

There are database migrations as well for the new models.

## Tests

Tested tickets with the unit tests, as well as just hitting the endpoints manually.

[TO-143]: https://warthogs.atlassian.net/browse/TO-143