### PR TITLE
[TO-147] Add attachment rule models

### DIFF
--- a/backend/migrations/versions/2025_08_06_1803-18ddcbd0fe0b_add_issue_test_result_attachment_rules.py
+++ b/backend/migrations/versions/2025_08_06_1803-18ddcbd0fe0b_add_issue_test_result_attachment_rules.py
@@ -105,6 +105,12 @@ def upgrade() -> None:
         ["id"],
         ondelete="SET NULL",
     )
+    op.create_index(
+        op.f("issue_test_result_attachment_attachment_rule_id_ix"),
+        "issue_test_result_attachment",
+        ["attachment_rule_id"],
+        unique=False,
+    )
 
 
 def downgrade() -> None:

--- a/backend/migrations/versions/2025_08_06_1803-18ddcbd0fe0b_add_issue_test_result_attachment_rules.py
+++ b/backend/migrations/versions/2025_08_06_1803-18ddcbd0fe0b_add_issue_test_result_attachment_rules.py
@@ -1,3 +1,19 @@
+# Copyright (C) 2023 Canonical Ltd.
+#
+# This file is part of Test Observer Backend.
+#
+# Test Observer Backend is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# Test Observer Backend is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """Add issue test result attachment rules
 
 Revision ID: 18ddcbd0fe0b

--- a/backend/migrations/versions/2025_08_06_1803-18ddcbd0fe0b_add_issue_test_result_attachment_rules.py
+++ b/backend/migrations/versions/2025_08_06_1803-18ddcbd0fe0b_add_issue_test_result_attachment_rules.py
@@ -1,0 +1,97 @@
+"""Add issue test result attachment rules
+
+Revision ID: 18ddcbd0fe0b
+Revises: a23713521472
+Create Date: 2025-08-06 18:03:03.281403+00:00
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "18ddcbd0fe0b"
+down_revision = "a23713521472"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "issue_test_result_attachment_rule",
+        sa.Column("issue_id", sa.Integer(), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False),
+        sa.Column(
+            "families",
+            postgresql.ARRAY(postgresql.ENUM(name="familyname", create_type=False)),
+            nullable=False,
+        ),
+        sa.Column("environment_names", postgresql.ARRAY(sa.String()), nullable=False),
+        sa.Column("test_case_names", postgresql.ARRAY(sa.String()), nullable=False),
+        sa.Column("template_ids", postgresql.ARRAY(sa.String()), nullable=False),
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["issue_id"],
+            ["issue.id"],
+            name=op.f("issue_test_result_attachment_rule_issue_id_fkey"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "id", name=op.f("issue_test_result_attachment_rule_pkey")
+        ),
+    )
+    op.create_index(
+        op.f("issue_test_result_attachment_rule_enabled_ix"),
+        "issue_test_result_attachment_rule",
+        ["enabled"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("issue_test_result_attachment_rule_issue_id_ix"),
+        "issue_test_result_attachment_rule",
+        ["issue_id"],
+        unique=False,
+    )
+    op.create_table(
+        "issue_test_result_attachment_rule_execution_metadata",
+        sa.Column("attachment_rule_id", sa.Integer(), nullable=False),
+        sa.Column("category", sa.String(length=200), nullable=False),
+        sa.Column("value", sa.String(length=200), nullable=False),
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["attachment_rule_id"],
+            ["issue_test_result_attachment_rule.id"],
+            name=op.f(
+                "issue_test_result_attachment_rule_execution_metadata_attachment_rule_id_fkey"
+            ),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "attachment_rule_id",
+            "id",
+            name=op.f("issue_test_result_attachment_rule_execution_metadata_pkey"),
+        ),
+    )
+    op.add_column(
+        "issue_test_result_attachment",
+        sa.Column("attachment_rule_id", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        op.f("issue_test_result_attachment_attachment_rule_id_fkey"),
+        "issue_test_result_attachment",
+        "issue_test_result_attachment_rule",
+        ["attachment_rule_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("issue_test_result_attachment", "attachment_rule_id")
+    op.drop_table("issue_test_result_attachment_rule_execution_metadata")
+    op.drop_table("issue_test_result_attachment_rule")

--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -3170,11 +3170,6 @@
       },
       "IssueTestResultAttachmentRulePostRequest": {
         "properties": {
-          "type": {
-            "type": "string",
-            "const": "test_result",
-            "title": "Type"
-          },
           "enabled": {
             "type": "boolean",
             "title": "Enabled",
@@ -3215,19 +3210,12 @@
         },
         "type": "object",
         "required": [
-          "type",
           "families"
         ],
         "title": "IssueTestResultAttachmentRulePostRequest"
       },
       "IssueTestResultAttachmentRuleResponse": {
         "properties": {
-          "type": {
-            "type": "string",
-            "const": "test_result",
-            "title": "Type",
-            "default": "test_result"
-          },
           "id": {
             "type": "integer",
             "title": "Id"

--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -3180,7 +3180,6 @@
               "$ref": "#/components/schemas/FamilyName"
             },
             "type": "array",
-            "minItems": 1,
             "title": "Families"
           },
           "environment_names": {
@@ -3209,9 +3208,6 @@
           }
         },
         "type": "object",
-        "required": [
-          "families"
-        ],
         "title": "IssueTestResultAttachmentRulePostRequest"
       },
       "IssueTestResultAttachmentRuleResponse": {

--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -1653,6 +1653,161 @@
         }
       }
     },
+    "/v1/issues/{issue_id}/attachment-rules": {
+      "post": {
+        "tags": [
+          "issues"
+        ],
+        "summary": "Post Attachment Rule",
+        "operationId": "post_attachment_rule_v1_issues__issue_id__attachment_rules_post",
+        "parameters": [
+          {
+            "name": "issue_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Issue Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IssueTestResultAttachmentRulePostRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IssueTestResultAttachmentRuleResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/issues/{issue_id}/attachment-rules/{attachment_rule_id}": {
+      "patch": {
+        "tags": [
+          "issues"
+        ],
+        "summary": "Patch Attachment Rule",
+        "operationId": "patch_attachment_rule_v1_issues__issue_id__attachment_rules__attachment_rule_id__patch",
+        "parameters": [
+          {
+            "name": "issue_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Issue Id"
+            }
+          },
+          {
+            "name": "attachment_rule_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Attachment Rule Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IssueTestResultAttachmentRulePatchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IssueTestResultAttachmentRuleResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "issues"
+        ],
+        "summary": "Delete Attachment Rule",
+        "operationId": "delete_attachment_rule_v1_issues__issue_id__attachment_rules__attachment_rule_id__delete",
+        "parameters": [
+          {
+            "name": "issue_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Issue Id"
+            }
+          },
+          {
+            "name": "attachment_rule_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Attachment Rule Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/issues": {
       "get": {
         "tags": [
@@ -2931,6 +3086,13 @@
             },
             "type": "array",
             "title": "Test Results"
+          },
+          "attachment_rules": {
+            "items": {
+              "$ref": "#/components/schemas/IssueTestResultAttachmentRuleResponse"
+            },
+            "type": "array",
+            "title": "Attachment Rules"
           }
         },
         "type": "object",
@@ -2942,7 +3104,8 @@
           "title",
           "status",
           "url",
-          "test_results"
+          "test_results",
+          "attachment_rules"
         ],
         "title": "IssueResponse"
       },
@@ -2987,6 +3150,135 @@
           "artefact_build"
         ],
         "title": "IssueTestResultAttachmentResponse"
+      },
+      "IssueTestResultAttachmentRulePatchRequest": {
+        "properties": {
+          "enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Enabled"
+          }
+        },
+        "type": "object",
+        "title": "IssueTestResultAttachmentRulePatchRequest"
+      },
+      "IssueTestResultAttachmentRulePostRequest": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "test_result",
+            "title": "Type"
+          },
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled",
+            "default": true
+          },
+          "families": {
+            "items": {
+              "$ref": "#/components/schemas/FamilyName"
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Families"
+          },
+          "environment_names": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Environment Names"
+          },
+          "test_case_names": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Test Case Names"
+          },
+          "template_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Template Ids"
+          },
+          "execution_metadata": {
+            "$ref": "#/components/schemas/ExecutionMetadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "families"
+        ],
+        "title": "IssueTestResultAttachmentRulePostRequest"
+      },
+      "IssueTestResultAttachmentRuleResponse": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "test_result",
+            "title": "Type",
+            "default": "test_result"
+          },
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled"
+          },
+          "families": {
+            "items": {
+              "$ref": "#/components/schemas/FamilyName"
+            },
+            "type": "array",
+            "title": "Families"
+          },
+          "environment_names": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Environment Names"
+          },
+          "test_case_names": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Test Case Names"
+          },
+          "template_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Template Ids"
+          },
+          "execution_metadata": {
+            "$ref": "#/components/schemas/ExecutionMetadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "enabled",
+          "families",
+          "environment_names",
+          "test_case_names",
+          "template_ids",
+          "execution_metadata"
+        ],
+        "title": "IssueTestResultAttachmentRuleResponse"
       },
       "IssuesGetResponse": {
         "properties": {

--- a/backend/test_observer/controllers/execution_metadata/models.py
+++ b/backend/test_observer/controllers/execution_metadata/models.py
@@ -24,30 +24,28 @@ from typing import Annotated
 from test_observer.data_access.models import TestExecutionMetadata
 
 
-class ExecutionMetadata(
-    RootModel[
-        dict[
+class ExecutionMetadata(RootModel):
+    root: dict[
+        Annotated[
+            str,
+            Field(
+                min_length=1,
+                max_length=200,
+                description="Execution Metadata Category",
+            ),
+        ],
+        list[
             Annotated[
                 str,
                 Field(
                     min_length=1,
                     max_length=200,
-                    description="Execution Metadata Category",
+                    description="Execution Metadata Value",
                 ),
-            ],
-            list[
-                Annotated[
-                    str,
-                    Field(
-                        min_length=1,
-                        max_length=200,
-                        description="Execution Metadata Value",
-                    ),
-                ]
-            ],
-        ]
-    ]
-):
+            ]
+        ],
+    ] = Field(default_factory=dict)
+
     model_config = {
         "json_schema_extra": {
             "title": "Execution Metadata",

--- a/backend/test_observer/controllers/issues/attachment_rules.py
+++ b/backend/test_observer/controllers/issues/attachment_rules.py
@@ -45,7 +45,7 @@ def post_attachment_rule(
     # Get the issue
     issue = db.get(Issue, issue_id)
     if issue is None:
-        raise HTTPException(status_code=404, detail="Attachment rule not found")
+        raise HTTPException(status_code=404, detail="Issue not found")
 
     # Create the attachment rule
     attachment_rule = IssueTestResultAttachmentRule(

--- a/backend/test_observer/controllers/issues/attachment_rules.py
+++ b/backend/test_observer/controllers/issues/attachment_rules.py
@@ -87,7 +87,7 @@ def patch_attachment_rule(
         raise HTTPException(status_code=404, detail="Attachment rule not found")
     if attachment_rule.issue_id != issue_id:
         raise HTTPException(
-            status_code=403, detail="Attachment rule not attached to given issue"
+            status_code=400, detail="Attachment rule not attached to given issue"
         )
 
     # Modify the attachment rule
@@ -112,7 +112,7 @@ def delete_attachment_rule(
         return
     if attachment_rule.issue_id != issue_id:
         raise HTTPException(
-            status_code=403, detail="Attachment rule not attached to given issue"
+            status_code=400, detail="Attachment rule not attached to given issue"
         )
 
     # Delete the attachment rule

--- a/backend/test_observer/controllers/issues/attachment_rules.py
+++ b/backend/test_observer/controllers/issues/attachment_rules.py
@@ -1,0 +1,120 @@
+# Copyright (C) 2023 Canonical Ltd.
+#
+# This file is part of Test Observer Backend.
+#
+# Test Observer Backend is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# Test Observer Backend is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from test_observer.data_access.setup import get_db
+from test_observer.data_access.models import (
+    IssueTestResultAttachmentRule,
+    Issue,
+    IssueTestResultAttachmentRuleExecutionMetadata,
+)
+
+from .models import (
+    IssueTestResultAttachmentRuleResponse,
+    IssueTestResultAttachmentRulePostRequest,
+    IssueTestResultAttachmentRulePatchRequest,
+)
+
+router = APIRouter()
+
+
+@router.post(
+    "/{issue_id}/attachment-rules", response_model=IssueTestResultAttachmentRuleResponse
+)
+def post_attachment_rule(
+    issue_id: int,
+    request: IssueTestResultAttachmentRulePostRequest,
+    db: Session = Depends(get_db),
+):
+    # Get the issue
+    issue = db.get(Issue, issue_id)
+    if issue is None:
+        raise HTTPException(status_code=404, detail="Attachment rule not found")
+
+    # Create the attachment rule
+    attachment_rule = IssueTestResultAttachmentRule(
+        issue_id=issue.id,
+        enabled=request.enabled,
+        families=request.families,
+        environment_names=request.environment_names,
+        test_case_names=request.test_case_names,
+        template_ids=request.template_ids,
+        execution_metadata=[
+            IssueTestResultAttachmentRuleExecutionMetadata(
+                category=metadata.category,
+                value=metadata.value,
+            )
+            for metadata in request.execution_metadata.to_rows()
+        ],
+    )
+
+    # Add the attachment rule
+    db.add(attachment_rule)
+    db.commit()
+    db.refresh(attachment_rule)
+    return attachment_rule
+
+
+@router.patch(
+    "/{issue_id}/attachment-rules/{attachment_rule_id}",
+    response_model=IssueTestResultAttachmentRuleResponse,
+)
+def patch_attachment_rule(
+    issue_id: int,
+    attachment_rule_id: int,
+    request: IssueTestResultAttachmentRulePatchRequest,
+    db: Session = Depends(get_db),
+):
+    # Get the attachment rule
+    attachment_rule = db.get(IssueTestResultAttachmentRule, attachment_rule_id)
+    if attachment_rule is None:
+        raise HTTPException(status_code=404, detail="Attachment rule not found")
+    if attachment_rule.issue_id != issue_id:
+        raise HTTPException(
+            status_code=403, detail="Attachment rule not attached to given issue"
+        )
+
+    # Modify the attachment rule
+    if request.enabled is not None:
+        attachment_rule.enabled = request.enabled
+
+    # Save the attachment rule
+    db.commit()
+    db.refresh(attachment_rule)
+    return attachment_rule
+
+
+@router.delete("/{issue_id}/attachment-rules/{attachment_rule_id}", status_code=204)
+def delete_attachment_rule(
+    issue_id: int,
+    attachment_rule_id: int,
+    db: Session = Depends(get_db),
+):
+    # Get the attachment rule
+    attachment_rule = db.get(IssueTestResultAttachmentRule, attachment_rule_id)
+    if attachment_rule is None:
+        return
+    if attachment_rule.issue_id != issue_id:
+        raise HTTPException(
+            status_code=403, detail="Attachment rule not attached to given issue"
+        )
+
+    # Delete the attachment rule
+    db.delete(attachment_rule)
+    db.commit()

--- a/backend/test_observer/controllers/issues/issues.py
+++ b/backend/test_observer/controllers/issues/issues.py
@@ -40,10 +40,11 @@ from .models import (
 )
 from .issue_url_parser import issue_source_project_key_from_url
 
-from . import issue_attachments
+from . import issue_attachments, attachment_rules
 
 router = APIRouter(tags=["issues"])
 router.include_router(issue_attachments.router)
+router.include_router(attachment_rules.router)
 
 
 @router.get("", response_model=IssuesGetResponse)

--- a/backend/test_observer/controllers/issues/models.py
+++ b/backend/test_observer/controllers/issues/models.py
@@ -61,7 +61,7 @@ class IssueTestResultAttachmentResponse(BaseModel):
 class IssueTestResultAttachmentRulePostRequest(BaseModel):
     enabled: bool = Field(default=True)
 
-    families: list[FamilyName] = Field(min_length=1)
+    families: list[FamilyName] = Field(default_factory=list)
     environment_names: list[str] = Field(default_factory=list)
     test_case_names: list[str] = Field(default_factory=list)
     template_ids: list[str] = Field(default_factory=list)

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -648,6 +648,7 @@ class IssueTestResultAttachment(Base):
     attachment_rule_id: Mapped[int] = mapped_column(
         ForeignKey("issue_test_result_attachment_rule.id", ondelete="SET NULL"),
         nullable=True,
+        index=True,
     )
     attachment_rule: Mapped["IssueTestResultAttachmentRule"] = relationship(
         back_populates="test_results"

--- a/backend/tests/controllers/issues/test_attachment_rules.py
+++ b/backend/tests/controllers/issues/test_attachment_rules.py
@@ -158,7 +158,7 @@ def test_patch_attachment_rule_wrong_issue(
         json={},
     )
 
-    assert patch_response.status_code == 403
+    assert patch_response.status_code == 400
 
 
 def test_patch_attachment_rule_disable(
@@ -204,7 +204,7 @@ def test_delete_attachment_rule_wrong_issue(
         )
     )
 
-    assert delete_response.status_code == 403
+    assert delete_response.status_code == 400
 
 
 def test_delete_attachment_rule(

--- a/backend/tests/controllers/issues/test_attachment_rules.py
+++ b/backend/tests/controllers/issues/test_attachment_rules.py
@@ -1,0 +1,229 @@
+# Copyright (C) 2023 Canonical Ltd.
+#
+# This file is part of Test Observer Backend.
+#
+# Test Observer Backend is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# Test Observer Backend is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+from fastapi.testclient import TestClient
+import pytest
+
+from tests.data_generator import DataGenerator
+from sqlalchemy.orm import Session
+from test_observer.data_access.models import (
+    IssueTestResultAttachmentRuleExecutionMetadata,
+)
+
+issue_endpoint = "/v1/issues/{issue_id}"
+post_endpoint = issue_endpoint + "/attachment-rules"
+patch_endpoint = post_endpoint + "/{attachment_rule_id}"
+delete_endpoint = patch_endpoint
+
+
+@pytest.fixture
+def post_attachment_rule():
+    return {
+        "enabled": True,
+        "families": ["charm"],
+        "environment_names": ["environment-1"],
+        "test_case_names": ["test-case-1"],
+        "template_ids": ["template-id-1"],
+        "execution_metadata": {"category-1": ["value-1", "value-2"]},
+    }
+
+
+def test_post_attachment_rule_issue_not_found(
+    test_client: TestClient, post_attachment_rule: dict
+):
+    response = test_client.post(
+        post_endpoint.format(issue_id=999), json=post_attachment_rule
+    )
+
+    assert response.status_code == 404
+
+
+def test_post_attachment_rule(
+    test_client: TestClient, generator: DataGenerator, post_attachment_rule: dict
+):
+    issue = generator.gen_issue()
+
+    response = test_client.post(
+        post_endpoint.format(issue_id=issue.id), json=post_attachment_rule
+    )
+
+    assert response.status_code == 200
+    assert set(response.json().keys()) == {
+        "environment_names",
+        "execution_metadata",
+        "id",
+        "families",
+        "template_ids",
+        "enabled",
+        "test_case_names",
+    }
+    assert response.json()["enabled"]
+    assert response.json()["families"] == ["charm"]
+    assert response.json()["environment_names"] == ["environment-1"]
+    assert response.json()["test_case_names"] == ["test-case-1"]
+    assert response.json()["template_ids"] == ["template-id-1"]
+    assert response.json()["execution_metadata"] == {
+        "category-1": ["value-1", "value-2"]
+    }
+
+    issue_response = test_client.get(issue_endpoint.format(issue_id=issue.id))
+
+    assert issue_response.status_code == 200
+    assert len(issue_response.json()["attachment_rules"]) == 1
+    assert issue_response.json()["attachment_rules"][0]["id"] == response.json()["id"]
+
+
+def test_post_attachment_rule_twice(
+    test_client: TestClient, generator: DataGenerator, post_attachment_rule: dict
+):
+    issue = generator.gen_issue()
+
+    response_1 = test_client.post(
+        post_endpoint.format(issue_id=issue.id), json=post_attachment_rule
+    )
+
+    response_2 = test_client.post(
+        post_endpoint.format(issue_id=issue.id), json=post_attachment_rule
+    )
+
+    issue_response = test_client.get(issue_endpoint.format(issue_id=issue.id))
+
+    assert issue_response.status_code == 200
+    assert {rule["id"] for rule in issue_response.json()["attachment_rules"]} == {
+        response_1.json()["id"],
+        response_2.json()["id"],
+    }
+
+
+def test_patch_attachment_rule_no_change(
+    test_client: TestClient, generator: DataGenerator, post_attachment_rule: dict
+):
+    issue = generator.gen_issue()
+
+    post_response = test_client.post(
+        post_endpoint.format(issue_id=issue.id), json=post_attachment_rule
+    )
+    attachment_rule_id = post_response.json()["id"]
+
+    patch_response = test_client.patch(
+        patch_endpoint.format(issue_id=issue.id, attachment_rule_id=attachment_rule_id),
+        json={},
+    )
+
+    assert patch_response.status_code == 200
+    assert patch_response.json()["enabled"]
+
+
+def test_patch_attachment_rule_not_found(
+    test_client: TestClient, generator: DataGenerator
+):
+    issue = generator.gen_issue()
+
+    response = test_client.patch(
+        patch_endpoint.format(issue_id=issue.id, attachment_rule_id=999),
+        json={},
+    )
+
+    assert response.status_code == 404
+
+
+def test_patch_attachment_rule_wrong_issue(
+    test_client: TestClient, generator: DataGenerator, post_attachment_rule: dict
+):
+    issue = generator.gen_issue()
+
+    post_response = test_client.post(
+        post_endpoint.format(issue_id=issue.id), json=post_attachment_rule
+    )
+    attachment_rule_id = post_response.json()["id"]
+
+    patch_response = test_client.patch(
+        patch_endpoint.format(
+            issue_id=issue.id + 1, attachment_rule_id=attachment_rule_id
+        ),
+        json={},
+    )
+
+    assert patch_response.status_code == 403
+
+
+def test_patch_attachment_rule_disable(
+    test_client: TestClient, generator: DataGenerator, post_attachment_rule: dict
+):
+    issue = generator.gen_issue()
+
+    post_response = test_client.post(
+        post_endpoint.format(issue_id=issue.id), json=post_attachment_rule
+    )
+    attachment_rule_id = post_response.json()["id"]
+
+    patch_response = test_client.patch(
+        patch_endpoint.format(issue_id=issue.id, attachment_rule_id=attachment_rule_id),
+        json={"enabled": False},
+    )
+
+    assert patch_response.status_code == 200
+    assert not patch_response.json()["enabled"]
+
+
+def test_delete_attachment_rule_not_exist(test_client: TestClient):
+    response = test_client.delete(
+        delete_endpoint.format(issue_id=999, attachment_rule_id=999),
+    )
+
+    assert response.status_code == 204
+
+
+def test_delete_attachment_rule_wrong_issue(
+    test_client: TestClient, generator: DataGenerator, post_attachment_rule: dict
+):
+    issue = generator.gen_issue()
+
+    post_response = test_client.post(
+        post_endpoint.format(issue_id=issue.id), json=post_attachment_rule
+    )
+    attachment_rule_id = post_response.json()["id"]
+
+    delete_response = test_client.delete(
+        delete_endpoint.format(
+            issue_id=issue.id + 1, attachment_rule_id=attachment_rule_id
+        )
+    )
+
+    assert delete_response.status_code == 403
+
+
+def test_delete_attachment_rule(
+    test_client: TestClient,
+    generator: DataGenerator,
+    post_attachment_rule: dict,
+    db_session: Session,
+):
+    issue = generator.gen_issue()
+
+    post_response = test_client.post(
+        post_endpoint.format(issue_id=issue.id), json=post_attachment_rule
+    )
+    attachment_rule_id = post_response.json()["id"]
+
+    delete_response = test_client.delete(
+        delete_endpoint.format(issue_id=issue.id, attachment_rule_id=attachment_rule_id)
+    )
+
+    assert delete_response.status_code == 204
+
+    assert db_session.query(IssueTestResultAttachmentRuleExecutionMetadata).count() == 0

--- a/backend/tests/controllers/issues/test_attachment_rules.py
+++ b/backend/tests/controllers/issues/test_attachment_rules.py
@@ -60,9 +60,7 @@ def _assert_attachment_rule_response(
     assert json["id"] == model.id
     assert json["enabled"] == model.enabled
     assert sorted(json["families"]) == sorted(model.families)
-    assert sorted(json["environment_names"]) == sorted(
-        model.environment_names
-    )
+    assert sorted(json["environment_names"]) == sorted(model.environment_names)
     assert sorted(json["test_case_names"]) == sorted(model.test_case_names)
     assert sorted(json["template_ids"]) == sorted(model.template_ids)
     assert sorted(json["execution_metadata"]) == sorted(

--- a/backend/tests/controllers/issues/test_issues.py
+++ b/backend/tests/controllers/issues/test_issues.py
@@ -70,6 +70,17 @@ def test_get_issue(test_client: TestClient, generator: DataGenerator):
     response = test_client.get(endpoint + f"/{issue.id}")
 
     assert response.status_code == 200
+    assert set(response.json().keys()) == {
+        "attachment_rules",
+        "url",
+        "test_results",
+        "key",
+        "id",
+        "project",
+        "source",
+        "title",
+        "status",
+    }
     assert response.json()["id"] == issue.id
     assert response.json()["source"] == issue.source
     assert response.json()["project"] == issue.project


### PR DESCRIPTION
## Description

Adds models for attachment rules, rules that automatically attach issues to test results based on attributes of the test result, and the API endpoints to create, modify, and delete them. This PR includes the follow attributes for matching:

- Family
- Environment name
- Test case name
- Template id
- Execution Metdata

## Resolved issues

[TO-147](https://warthogs.atlassian.net/browse/TO-147)

## Documentation

OpenAPI reflects endpoint changes.

## Web service API changes

- `POST /issues/{id}/attachment-rules`: Create new attachment rules. Not indepotent. May create multiple attachment rules with the same set of criteria.
- `PATCH /issues/{id}/attachment-rules/{id}`: Modify an attachment rule (only enable or disable allowed).
- `DELETE /issues/{id}/attachment-rules/{id}`: Delete the attachment rule.

## Tests

Unit tests added for all the endpoints which verify the models too.


[TO-147]: https://warthogs.atlassian.net/browse/TO-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ