### PR TITLE
Set config_dict to test execution relevant link response

### DIFF
--- a/backend/test_observer/controllers/artefacts/models.py
+++ b/backend/test_observer/controllers/artefacts/models.py
@@ -93,7 +93,7 @@ class TestExecutionRelevantLinkCreate(BaseModel):
 
 class TestExecutionRelevantLinkResponse(TestExecutionRelevantLinkCreate):
     model_config = ConfigDict(from_attributes=True)
-    
+
     id: int
     label: str
     url: HttpUrl

--- a/backend/test_observer/controllers/artefacts/models.py
+++ b/backend/test_observer/controllers/artefacts/models.py
@@ -92,6 +92,8 @@ class TestExecutionRelevantLinkCreate(BaseModel):
 
 
 class TestExecutionRelevantLinkResponse(TestExecutionRelevantLinkCreate):
+    model_config = ConfigDict(from_attributes=True)
+    
     id: int
     label: str
     url: HttpUrl

--- a/backend/tests/controllers/test_results/test_test_results.py
+++ b/backend/tests/controllers/test_results/test_test_results.py
@@ -143,7 +143,7 @@ class TestSearchTestResults:
             name=generate_unique_name(f"family_{family.value}")
         )
         artefact = generator.gen_artefact(
-            family=family.value, name=generate_unique_name(f"{family.value}_family")
+            family=family, name=generate_unique_name(f"{family.value}_family")
         )
         artefact_build = generator.gen_artefact_build(artefact)
         test_execution = generator.gen_test_execution(artefact_build, environment)

--- a/backend/tests/controllers/test_results/test_test_results.py
+++ b/backend/tests/controllers/test_results/test_test_results.py
@@ -136,26 +136,50 @@ class TestSearchTestResults:
     def test_search_by_family(
         self, test_client: TestClient, generator: DataGenerator, family: FamilyName
     ):
-        """Test filtering by artefact family with window function"""
-        # Create a snap artefact with test results
-        environment = generator.gen_environment()
-        test_case = generator.gen_test_case(
+        """Parametric: the filter returns only results from the requested family."""
+        env = generator.gen_environment()
+        tc = generator.gen_test_case(
             name=generate_unique_name(f"family_{family.value}")
         )
-        artefact = generator.gen_artefact(
-            family=family, name=generate_unique_name(f"{family.value}_family")
+
+        # Matching family
+        artefact_yes = generator.gen_artefact(
+            family=family, name=generate_unique_name(f"{family.value}_yes")
         )
-        artefact_build = generator.gen_artefact_build(artefact)
-        test_execution = generator.gen_test_execution(artefact_build, environment)
-        test_result = generator.gen_test_result(test_case, test_execution)
+        ab_yes = generator.gen_artefact_build(artefact_yes)
+        te_yes = generator.gen_test_execution(ab_yes, env)
+        tr_yes = generator.gen_test_result(tc, te_yes)
 
-        response = test_client.get(f"/v1/test-results?families={family.value}")
+        # Non-matching family
+        all_families = [
+            FamilyName.snap,
+            FamilyName.deb,
+            FamilyName.image,
+            FamilyName.charm,
+        ]
 
-        assert response.status_code == 200
-        data = response.json()
-        assert data["count"] >= 1
-        assert any(
-            tr["test_result"]["id"] == test_result.id for tr in data["test_results"]
+        other_family = next(f for f in all_families if f != family)
+        artefact_no = generator.gen_artefact(
+            family=other_family, name=generate_unique_name(f"{other_family.value}_no")
+        )
+        ab_no = generator.gen_artefact_build(artefact_no)
+        te_no = generator.gen_test_execution(ab_no, env)
+        tr_no = generator.gen_test_result(tc, te_no)
+
+        resp = test_client.get(f"/v1/test-results?families={family.value}")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # Includes the matching result
+        ids = {tr["test_result"]["id"] for tr in data["test_results"]}
+        assert tr_yes.id in ids
+
+        # Excludes the other family's result
+        assert tr_no.id not in ids
+
+        # Every returned row belongs to the requested family
+        assert all(
+            tr["artefact"]["family"] == family.value for tr in data["test_results"]
         )
 
     def test_search_by_template_id(


### PR DESCRIPTION
## Description

The `/v1/test-results` API endpoint was returning 500 errors when searching for charm family test results, while working correctly for debs, snaps, and images.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->
