### PR TITLE
[TO-157] Add test execution metadata table to artefact page

### DIFF
--- a/frontend/lib/models/execution_metadata.dart
+++ b/frontend/lib/models/execution_metadata.dart
@@ -1,0 +1,44 @@
+// Copyright (C) 2023 Canonical Ltd.
+//
+// This file is part of Test Observer Frontend.
+//
+// Test Observer Frontend is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+//
+// Test Observer Frontend is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'execution_metadata.freezed.dart';
+
+@freezed
+abstract class ExecutionMetadata with _$ExecutionMetadata {
+  const ExecutionMetadata._();
+  const factory ExecutionMetadata({
+    required Map<String, List<String>> data,
+  }) = _ExecutionMetadata;
+
+  factory ExecutionMetadata.fromJson(Map<String, Object?> json) {
+    return ExecutionMetadata(
+      data: json.map(
+        (k, v) => MapEntry(
+          k,
+          (v as List).map((e) => e.toString()).toList(),
+        ),
+      ),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'data': data,
+    };
+  }
+}

--- a/frontend/lib/models/test_execution.dart
+++ b/frontend/lib/models/test_execution.dart
@@ -20,6 +20,7 @@ import 'package:yaru/yaru.dart';
 
 import 'test_execution_relevant_link.dart';
 import 'environment.dart';
+import 'execution_metadata.dart';
 
 part 'test_execution.freezed.dart';
 part 'test_execution.g.dart';
@@ -42,6 +43,9 @@ abstract class TestExecution with _$TestExecution {
     @Default([])
     @JsonKey(name: 'relevant_links')
     List<TestExecutionRelevantLink> relevantLinks,
+    @Default(ExecutionMetadata(data: {}))
+    @JsonKey(name: 'execution_metadata')
+    ExecutionMetadata executionMetadata,
   }) = _TestExecution;
 
   factory TestExecution.fromJson(Map<String, Object?> json) =>

--- a/frontend/lib/ui/artefact_page/execution_metadata_expandable.dart
+++ b/frontend/lib/ui/artefact_page/execution_metadata_expandable.dart
@@ -1,0 +1,43 @@
+// Copyright (C) 2023 Canonical Ltd.
+//
+// This file is part of Test Observer Frontend.
+//
+// Test Observer Frontend is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+//
+// Test Observer Frontend is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+
+import '../expandable.dart';
+import '../../models/execution_metadata.dart';
+import 'execution_metadata_table.dart';
+
+class ExecutionMetadataExpandable extends StatelessWidget {
+  const ExecutionMetadataExpandable({
+    super.key,
+    required this.executionMetadata,
+    required this.initiallyExpanded,
+  });
+
+  final ExecutionMetadata executionMetadata;
+  final bool initiallyExpanded;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expandable(
+      title: const Text('Execution Metadata'),
+      initiallyExpanded: initiallyExpanded,
+      children: [
+        ExecutionMetadataTable(metadata: executionMetadata),
+      ],
+    );
+  }
+}

--- a/frontend/lib/ui/artefact_page/execution_metadata_table.dart
+++ b/frontend/lib/ui/artefact_page/execution_metadata_table.dart
@@ -32,35 +32,47 @@ class ExecutionMetadataTable extends StatelessWidget {
       dataRowMaxHeight: double.infinity,
       columns: const [
         DataColumn(
-            label: Text('Category',
-                style: TextStyle(fontStyle: FontStyle.italic))),
+          label: Text(
+            'Category',
+            style: TextStyle(fontStyle: FontStyle.italic),
+          ),
+        ),
         DataColumn(
-            label:
-                Text('Values', style: TextStyle(fontStyle: FontStyle.italic))),
+          label: Text(
+            'Values',
+            style: TextStyle(fontStyle: FontStyle.italic),
+          ),
+        ),
       ],
       rows: entries
-          .map((entry) => DataRow(cells: [
+          .map(
+            (entry) => DataRow(
+              cells: [
                 DataCell(Text(entry.key)),
                 DataCell(
                   Column(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: entry.value
-                        .expand((v) => [
-                              const SizedBox(height: Spacing.level3),
-                              Tooltip(
-                                message: v,
-                                child: Text(
-                                  v,
-                                  overflow: TextOverflow.ellipsis,
-                                  maxLines: 1,
-                                ),
+                        .expand(
+                          (v) => [
+                            const SizedBox(height: Spacing.level3),
+                            Tooltip(
+                              message: v,
+                              child: Text(
+                                v,
+                                overflow: TextOverflow.ellipsis,
+                                maxLines: 1,
                               ),
-                              const SizedBox(height: Spacing.level3)
-                            ])
+                            ),
+                            const SizedBox(height: Spacing.level3),
+                          ],
+                        )
                         .toList(),
                   ),
                 ),
-              ]))
+              ],
+            ),
+          )
           .toList(),
     );
   }

--- a/frontend/lib/ui/artefact_page/execution_metadata_table.dart
+++ b/frontend/lib/ui/artefact_page/execution_metadata_table.dart
@@ -1,0 +1,67 @@
+// Copyright (C) 2023 Canonical Ltd.
+//
+// This file is part of Test Observer Frontend.
+//
+// Test Observer Frontend is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+//
+// Test Observer Frontend is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+import '../../models/execution_metadata.dart';
+import '../spacing.dart';
+
+class ExecutionMetadataTable extends StatelessWidget {
+  final ExecutionMetadata metadata;
+  const ExecutionMetadataTable({super.key, required this.metadata});
+
+  @override
+  Widget build(BuildContext context) {
+    final entries = metadata.data.entries.toList();
+    if (entries.isEmpty) {
+      return const Text('No execution metadata available.');
+    }
+    return DataTable(
+      dataRowMaxHeight: double.infinity,
+      columns: const [
+        DataColumn(
+            label: Text('Category',
+                style: TextStyle(fontStyle: FontStyle.italic))),
+        DataColumn(
+            label:
+                Text('Values', style: TextStyle(fontStyle: FontStyle.italic))),
+      ],
+      rows: entries
+          .map((entry) => DataRow(cells: [
+                DataCell(Text(entry.key)),
+                DataCell(
+                  Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: entry.value
+                        .expand((v) => [
+                              const SizedBox(height: Spacing.level3),
+                              Tooltip(
+                                message: v,
+                                child: Text(
+                                  v,
+                                  overflow: TextOverflow.ellipsis,
+                                  maxLines: 1,
+                                ),
+                              ),
+                              const SizedBox(height: Spacing.level3)
+                            ])
+                        .toList(),
+                  ),
+                ),
+              ]))
+          .toList(),
+    );
+  }
+}

--- a/frontend/lib/ui/artefact_page/test_execution_expandable/test_execution_expandable.dart
+++ b/frontend/lib/ui/artefact_page/test_execution_expandable/test_execution_expandable.dart
@@ -24,6 +24,7 @@ import '../../inline_url_text.dart';
 import '../../spacing.dart';
 import '../test_result_filter_expandable.dart';
 import '../test_event_log_expandable.dart';
+import '../execution_metadata_expandable.dart';
 
 class TestExecutionExpandable extends ConsumerWidget {
   const TestExecutionExpandable({
@@ -49,6 +50,10 @@ class TestExecutionExpandable extends ConsumerWidget {
         TestEventLogExpandable(
           testExecutionId: testExecution.id,
           initiallyExpanded: !testExecution.status.isCompleted,
+        ),
+        ExecutionMetadataExpandable(
+          executionMetadata: testExecution.executionMetadata,
+          initiallyExpanded: false,
         ),
         if (testExecution.status.isCompleted)
           Expandable(


### PR DESCRIPTION
## Description

Displays execution metadata in a table on the artefact page.

### Sample
<img width="1773" height="812" alt="Screenshot from 2025-08-15 15-14-37" src="https://github.com/user-attachments/assets/2f5f658a-18d1-404b-a904-44f3c8b502af" />

### Very long
<img width="1376" height="290" alt="Screenshot from 2025-08-15 15-13-10" src="https://github.com/user-attachments/assets/7dd3a8f2-8e66-435a-be01-c73ba3c1c047" />

### No execution metadata
<img width="1376" height="290" alt="Screenshot from 2025-08-15 15-13-17" src="https://github.com/user-attachments/assets/f6800977-fc6a-4144-881b-bec2fcdfdb2b" />

### Many values for a category
<img width="1294" height="471" alt="Screenshot from 2025-08-15 15-13-55" src="https://github.com/user-attachments/assets/404640e6-d21f-4f4c-bee3-4fffd572af09" />


## Resolved issues

[TO-157](https://warthogs.atlassian.net/browse/TO-157)

## Documentation

N/A

## Web service API changes

N/A

## Tests

Added execution metadata to seed data for testing manually, locally. Is there a way to test this otherwise?


[TO-157]: https://warthogs.atlassian.net/browse/TO-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ