### PR TITLE
Fix frontend url is not passed to cors configuration

### DIFF
--- a/backend/charm/config.yaml
+++ b/backend/charm/config.yaml
@@ -16,6 +16,10 @@ options:
     default: test-observer-api
     description: Public hostname for the service.
     type: string
+  frontend_hostname:
+    default: test-observer
+    description: Public hostname for the frontend connected to this API
+    type: string
   sentry_dsn:
     default: ""
     description: value for SENTRY_DSN that is used to send errors to sentry

--- a/backend/charm/src/charm.py
+++ b/backend/charm/src/charm.py
@@ -245,6 +245,7 @@ class TestObserverBackendCharm(CharmBase):
             "SENTRY_DSN": self.config["sentry_dsn"],
             "CELERY_BROKER_URL": self._celery_broker_url,
             "SAML_SP_BASE_URL": f"https://{self.config['hostname']}",
+            "FRONTEND_URL": f"https://{self.config['frontend_hostname']}",
             "SESSIONS_SECRET": self.config["sessions_secret"],
         }
         # Only set SAML environment variables if IDP metadata URL is provided

--- a/terraform/ps5/test-observer.tf
+++ b/terraform/ps5/test-observer.tf
@@ -151,6 +151,7 @@ resource "juju_application" "test-observer-api" {
 
   config = {
     hostname              = var.api_hostname
+    frontend_hostname     = var.frontend_hostname
     port                  = var.environment == "development" ? 80 : 443
     sentry_dsn            = "${local.sentry_dsn_map[var.environment]}"
     saml_idp_metadata_url = var.saml_idp_metadata_url

--- a/terraform/ps6/main.tf
+++ b/terraform/ps6/main.tf
@@ -106,6 +106,7 @@ resource "juju_application" "test-observer-api" {
 
   config = {
     hostname              = var.api_hostname
+    frontend_hostname     = var.frontend_hostname
     port                  = var.api_port
     sentry_dsn            = var.sentry_dsn
     saml_idp_metadata_url = var.saml_idp_metadata_url


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This last [PR](https://github.com/canonical/test_observer/pull/364), made CORS more strict. In doing so it required the frontend url to be passed as an environment variable. But I've forgotten to do so through the charm and terraform. So this PR adds it.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->
