### PR TITLE
Use X-Forwarded-Proto header to see if the ingress got https

### DIFF
--- a/backend/test_observer/controllers/auth/saml.py
+++ b/backend/test_observer/controllers/auth/saml.py
@@ -211,12 +211,11 @@ async def _prepare_from_fastapi_request(request: Request) -> dict[str, Any]:
         "get_data": {},
     }
 
-    logger.info("Received a login request with the following parameters:")
-    logger.info(f"request.headers {request.headers.items()}")
-    logger.info(f"request.url.scheme {request.url.scheme}")
-    logger.info(f"result['server_port'] {result['server_port']}")
-
-    if request.url.scheme == "https" or result["server_port"] == 443:
+    if (
+        request.url.scheme == "https"
+        or result["server_port"] == 443
+        or request.headers.get("x-forwarded-proto") == "https"
+    ):
         result["https"] = "on"
     if request.query_params:
         result["get_data"] = request.query_params


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

The SAML SSO flow was not working on staging or production. It was failing with the following error:
```
Error when processing SAML ACS Response: invalid_response The response was received at http://test-observer-api-staging.canonical.com/v1/auth/saml/acs instead of https://test-observer-api-staging.canonical.com/v1/auth/saml/acs
```

The logging statements made it clear how we can figure out whether the request had an HTTPS scheme even behind the deployed ingress. Specifically, one of the headers [x-forwarded-proto](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Proto) was set to "https" and so can be used reliably here.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Since this issue only appears in staging and production, we can only test it there. But the logs gives high confidence that this change should resolve the issue.
