### PR TITLE
Add user teams

### DIFF
--- a/backend/migrations/versions/2025_09_05_1249-f496f12b66b8_add_launchpad_teams.py
+++ b/backend/migrations/versions/2025_09_05_1249-f496f12b66b8_add_launchpad_teams.py
@@ -1,0 +1,50 @@
+"""Add launchpad teams
+
+Revision ID: f496f12b66b8
+Revises: f9faab2e6886
+Create Date: 2025-09-05 12:49:49.974922+00:00
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "f496f12b66b8"
+down_revision = "f9faab2e6886"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "team",
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id", name=op.f("team_pkey")),
+        sa.UniqueConstraint("name", name=op.f("team_name_key")),
+    )
+    op.create_table(
+        "team_users_association",
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("team_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["team_id"], ["team.id"], name=op.f("team_users_association_team_id_fkey")
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["app_user.id"],
+            name=op.f("team_users_association_user_id_fkey"),
+        ),
+        sa.PrimaryKeyConstraint(
+            "user_id", "team_id", name=op.f("team_users_association_pkey")
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("team_users_association")
+    op.drop_table("team")


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

First step towards authorization. Adds launchpad teams to TO. Specifically those exposed by U1 SSO. Sadly, the initial plan of fetching user teams form launchpad API failed because launchpad API only provides direct team memberships and not indirect ones. So as a plan B we can get teams that a user belongs to using U1 SSO at login time. The main issue with this approach is that we can only get teams that were exposed by U1 for TO. It's a specific U1 SSO configuration parameter that can only be edited by IS. Currently it only includes "canonical" team. To add more teams, we have to open an RT with the teams we want exposed.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

Towards resolving https://warthogs.atlassian.net/browse/TO-174

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Added test to make sure the team is added.
