### PR TITLE
[TO-158] Add execution metadata to test result search api

### DIFF
--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -2182,6 +2182,20 @@
               "title": "Offset"
             },
             "description": "Number of results to skip for pagination"
+          },
+          {
+            "name": "execution_metadata",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Filter by execution metadata (comma-separated, category:value). Category and value must be percent encoded.",
+              "title": "Execution Metadata"
+            },
+            "description": "Filter by execution metadata (comma-separated, category:value). Category and value must be percent encoded."
           }
         ],
         "responses": {

--- a/backend/tests/data_generator.py
+++ b/backend/tests/data_generator.py
@@ -240,9 +240,19 @@ class DataGenerator:
         if execution_metadata:
             for category, values in execution_metadata.items():
                 for value in values:
-                    execution_metadata_rows.append(
-                        TestExecutionMetadata(category=category, value=value)
+                    existing_row = (
+                        self.db_session.query(TestExecutionMetadata)
+                        .filter_by(category=category, value=value)
+                        .first()
                     )
+                    if existing_row:
+                        execution_metadata_row = existing_row
+                    else:
+                        execution_metadata_row = TestExecutionMetadata(
+                            category=category, value=value
+                        )
+                        self._add_object(execution_metadata_row)
+                    execution_metadata_rows.append(execution_metadata_row)
 
         test_execution = TestExecution(
             artefact_build=artefact_build,


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->
