### PR TITLE
[TO-179] Add promote user to admin charm action

### DIFF
--- a/backend/charm/actions.yaml
+++ b/backend/charm/actions.yaml
@@ -24,3 +24,11 @@ change-assignee:
       description: "The id of the user that should be assigned to review this artefact"
       type: integer
   required: [artefact-id, user-id]
+
+promote-user-to-admin:
+  description: Promotes a user to admin role via their email address
+  params:
+    email:
+      description: "An email address of the user to promote to admin"
+      type: string
+  required: [email]

--- a/backend/charm/src/charm.py
+++ b/backend/charm/src/charm.py
@@ -82,6 +82,9 @@ class TestObserverBackendCharm(CharmBase):
         self.framework.observe(self.on.delete_artefact_action, self._on_delete_artefact_action)
         self.framework.observe(self.on.add_user_action, self._on_add_user_action)
         self.framework.observe(self.on.change_assignee_action, self._on_change_assignee_action)
+        self.framework.observe(
+            self.on.promote_user_to_admin_action, self._on_promote_user_to_admin_action
+        )
 
     def _setup_nginx(self):
         require_nginx_route(
@@ -388,6 +391,19 @@ class TestObserverBackendCharm(CharmBase):
         try:
             process.wait_output()
             event.set_results({"result": "Changed successfuly"})
+        except ExecError as e:
+            event.fail(e.stderr)
+
+    def _on_promote_user_to_admin_action(self, event) -> None:
+        email = event.params["email"]
+        process = self.api_container.exec(
+            command=["python", "-m", "scripts.promote_user_to_admin", email],
+            working_dir="/home/app",
+            environment=self._app_environment,
+        )
+        try:
+            process.wait_output()
+            event.set_results({"result": "Promoted successfuly"})
         except ExecError as e:
             event.fail(e.stderr)
 

--- a/backend/scripts/promote_user_to_admin.py
+++ b/backend/scripts/promote_user_to_admin.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# Copyright (C) 2023 Canonical Ltd.
+#
+# This file is part of Test Observer Backend.
+#
+# Test Observer Backend is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# Test Observer Backend is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+from argparse import ArgumentParser
+
+from test_observer.users.promote_user_to_admin import promote_user_to_admin
+
+if __name__ == "__main__":
+    parser = ArgumentParser(
+        prog="promote_user_to_admin",
+        description="Promotes a user to admin role via their email address",
+    )
+    parser.add_argument("email", type=str)
+    args = parser.parse_args()
+    promote_user_to_admin(args.email)

--- a/backend/test_observer/users/promote_user_to_admin.py
+++ b/backend/test_observer/users/promote_user_to_admin.py
@@ -1,0 +1,61 @@
+# Copyright (C) 2023 Canonical Ltd.
+#
+# This file is part of Test Observer Backend.
+#
+# Test Observer Backend is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# Test Observer Backend is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+
+from sqlalchemy.orm import Session
+from sqlalchemy import select
+
+from test_observer.data_access.models import User
+from test_observer.data_access.setup import SessionLocal
+
+logger = logging.getLogger("test-observer-backend")
+
+
+def promote_user_to_admin(
+    email: str,
+    session: Session | None = None,
+):
+    if session is None:
+        session = SessionLocal()
+        try:
+            return _promote_user(email, session)
+        finally:
+            session.close()
+    else:
+        return _promote_user(email, session)
+
+
+def _promote_user(email: str, session: Session) -> User:
+    user = session.scalar(select(User).where(User.email == email))
+    if not user:
+        raise ValueError(f"User with email {email} not found")
+
+    if user.is_admin:
+        logger.info(
+            "User with email %s is already admin. Skipping promotion.",
+            email,
+        )
+        return user
+
+    user.is_admin = True
+    session.commit()
+
+    logger.info(
+        "User with email %s promoted to admin successfully.",
+        email,
+    )
+    return user

--- a/backend/tests/users/test_promote_user_to_admin.py
+++ b/backend/tests/users/test_promote_user_to_admin.py
@@ -1,0 +1,71 @@
+# Copyright (C) 2023 Canonical Ltd.
+#
+# This file is part of Test Observer Backend.
+#
+# Test Observer Backend is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# Test Observer Backend is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from test_observer.data_access.models import User
+from test_observer.users.promote_user_to_admin import promote_user_to_admin
+
+
+def test_promote_user_to_admin(db_session: Session):
+    email = "john.doe@canonical.com"
+    user = User(
+        launchpad_handle="john-doe",
+        email=email,
+        name="John Doe",
+        is_admin=False,
+    )
+    db_session.add(user)
+    db_session.commit()
+
+    promoted_user = promote_user_to_admin(email, db_session)
+
+    assert promoted_user
+    assert promoted_user.is_admin is True
+
+    db_user = db_session.scalar(select(User).where(User.email == email))
+    assert db_user is not None
+    assert db_user.is_admin is True
+
+
+def test_promote_user_already_admin(db_session: Session):
+    email = "admin@canonical.com"
+
+    user = User(
+        launchpad_handle="admin-user",
+        email=email,
+        name="Admin User",
+        is_admin=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+
+    promoted_user = promote_user_to_admin(email, db_session)
+
+    assert promoted_user
+    assert promoted_user.is_admin is True
+
+
+def test_promote_user_not_found(db_session: Session):
+    email = "nonexistent@canonical.com"
+
+    with pytest.raises(
+        ValueError, match="User with email nonexistent@canonical.com not found"
+    ):
+        promote_user_to_admin(email, db_session)


### PR DESCRIPTION
## Description

Adds the charm action to promote a user with the specified email to admin.

## Resolved issues

Resolves TO-179

## Documentation

I haven't found any documentation regarding the similar command `add_user` under the `docs/` dir, that's why I haven't added any documentation

## Tests

The corresponding auto tests were added
