### PR TITLE
[TO-151] Allow limit 0 test results search

### DIFF
--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -2163,7 +2163,7 @@
             "schema": {
               "type": "integer",
               "maximum": 1000,
-              "minimum": 1,
+              "minimum": 0,
               "description": "Maximum number of results to return",
               "default": 50,
               "title": "Limit"

--- a/backend/test_observer/controllers/test_results/filter_test_results.py
+++ b/backend/test_observer/controllers/test_results/filter_test_results.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from sqlalchemy import and_, desc, func, select, exists, values, column, true, Select
+from sqlalchemy import and_, func, select, exists, values, column, true, Select
 
 
 from test_observer.data_access.models import (
@@ -169,8 +169,7 @@ def filter_test_results(query: Select, filters: TestResultSearchFilters) -> Sele
     # Build the main query with only necessary joins
     query = apply_joins(query, joins_needed)
 
-    # Apply ordering and pagination
-    query = query.order_by(desc(TestExecution.created_at), desc(TestResult.id))
+    # Apply pagination
     if filters.offset is not None:
         query = query.offset(filters.offset)
     if filters.limit is not None:


### PR DESCRIPTION
## Description

Allows the sending of `limit: 0` to `GET /test-results`. This is useful if you want to know how many test results exist but you don't actually need any results.

## Resolved issues

[TO-151](https://warthogs.atlassian.net/browse/TO-151)

## Documentation


## Web service API changes

Updated OpenAPI schema.

## Tests

Added test for limit=0

[TO-151]: https://warthogs.atlassian.net/browse/TO-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ