### PR TITLE
[TO-151] Refactor test results search to use common filter model

### DIFF
--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -2163,7 +2163,7 @@
             "schema": {
               "type": "integer",
               "maximum": 1000,
-              "minimum": 1,
+              "minimum": 0,
               "description": "Maximum number of results to return",
               "default": 50,
               "title": "Limit"

--- a/backend/test_observer/controllers/test_results/filter_test_results.py
+++ b/backend/test_observer/controllers/test_results/filter_test_results.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from sqlalchemy import and_, desc, func, select, exists, values, column, true, Select
+from sqlalchemy import and_, func, select, exists, values, column, true, Select
 
 
 from test_observer.data_access.models import (
@@ -169,8 +169,7 @@ def filter_test_results(query: Select, filters: TestResultSearchFilters) -> Sele
     # Build the main query with only necessary joins
     query = apply_joins(query, joins_needed)
 
-    # Apply ordering and pagination
-    query = query.order_by(desc(TestExecution.created_at), desc(TestResult.id))
+    # Apply pagination
     if filters.offset is not None:
         query = query.offset(filters.offset)
     if filters.limit is not None:

--- a/frontend/lib/models/execution_metadata.dart
+++ b/frontend/lib/models/execution_metadata.dart
@@ -22,7 +22,7 @@ part 'execution_metadata.freezed.dart';
 abstract class ExecutionMetadata with _$ExecutionMetadata {
   const ExecutionMetadata._();
   const factory ExecutionMetadata({
-    required Map<String, Set<String>> data,
+    @Default({}) Map<String, Set<String>> data,
   }) = _ExecutionMetadata;
 
   factory ExecutionMetadata.fromJson(Map<String, Object?> json) {
@@ -60,9 +60,9 @@ abstract class ExecutionMetadata with _$ExecutionMetadata {
     return rows;
   }
 
-  factory ExecutionMetadata.fromQueryParams(List<String> params) {
+  factory ExecutionMetadata.fromQueryParams(List<String>? params) {
     final Set<(String, String)> rows = {};
-    for (final param in params) {
+    for (final param in params ?? <String>[]) {
       final pairs = param.split(',').where((s) => s.isNotEmpty);
       for (final pair in pairs) {
         final parts = pair.split(':');
@@ -94,4 +94,7 @@ abstract class ExecutionMetadata with _$ExecutionMetadata {
   (String, String) findFromString(String s) {
     return toRows().firstWhere((row) => '${row.$1} ${row.$2}' == s);
   }
+
+  bool get isEmpty => data.isEmpty;
+  bool get isNotEmpty => !isEmpty;
 }

--- a/frontend/lib/models/test_results_filters.dart
+++ b/frontend/lib/models/test_results_filters.dart
@@ -1,0 +1,150 @@
+// Copyright (C) 2023 Canonical Ltd.
+//
+// This file is part of Test Observer Frontend.
+//
+// Test Observer Frontend is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+//
+// Test Observer Frontend is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:dartx/dartx.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'execution_metadata.dart';
+import '../routing.dart';
+
+part 'test_results_filters.freezed.dart';
+part 'test_results_filters.g.dart';
+
+@freezed
+abstract class TestResultsFilters with _$TestResultsFilters {
+  const TestResultsFilters._();
+  const factory TestResultsFilters({
+    @Default([]) List<String> families,
+    @Default([]) List<String> environments,
+    @JsonKey(name: 'test_cases') @Default([]) List<String> testCases,
+    @JsonKey(name: 'template_ids') @Default([]) List<String> templateIds,
+    @JsonKey(name: 'execution_metadata')
+    @Default(ExecutionMetadata())
+    ExecutionMetadata executionMetadata,
+    @Default([]) List<int> issues,
+    @JsonKey(name: 'from_date') DateTime? fromDate,
+    @JsonKey(name: 'until_date') DateTime? untilDate,
+    int? offset,
+    int? limit,
+  }) = _TestResultsFilters;
+
+  factory TestResultsFilters.fromJson(Map<String, Object?> json) =>
+      _$TestResultsFiltersFromJson(json);
+
+  factory TestResultsFilters.fromQueryParams(
+    Map<String, List<String>> parameters,
+  ) {
+    List<String> parseParam(List<String>? values) {
+      return values != null && values.isNotEmpty
+          ? values.first
+              .split(',')
+              .map((s) => s.trim())
+              .where((s) => s.isNotEmpty)
+              .toList()
+          : <String>[];
+    }
+
+    final families = parseParam(parameters['families']);
+    final environments = parseParam(parameters['environments']);
+    final testCases = parseParam(parameters['test_cases']);
+    final templateIds = parseParam(parameters['template_ids']);
+    final executionMetadata = ExecutionMetadata.fromQueryParams(
+      parameters['execution_metadata'],
+    );
+    final issues = parseParam(parameters['issues'])
+        .map((s) => int.tryParse(s))
+        .whereNotNull()
+        .toList();
+    final fromDate = parseParam(parameters['from_date'])
+        .map((s) => DateTime.tryParse(s))
+        .firstOrNullWhere((v) => v != null);
+    final untilDate = parseParam(parameters['until_date'])
+        .map((s) => DateTime.tryParse(s))
+        .firstOrNullWhere((v) => v != null);
+    final offset = parseParam(parameters['offset'])
+        .map((s) => int.tryParse(s))
+        .firstOrNullWhere((v) => v != null);
+    final limit = parseParam(parameters['limit'])
+        .map((s) => int.tryParse(s))
+        .firstOrNullWhere((v) => v != null);
+
+    return TestResultsFilters(
+      families: families,
+      environments: environments,
+      testCases: testCases,
+      templateIds: templateIds,
+      executionMetadata: executionMetadata,
+      issues: issues,
+      fromDate: fromDate,
+      untilDate: untilDate,
+      offset: offset,
+      limit: limit,
+    );
+  }
+
+  Map<String, List<String>> toQueryParams() {
+    final params = <String, List<String>>{};
+    if (families.isNotEmpty) {
+      params['families'] = families;
+    }
+    if (environments.isNotEmpty) {
+      params['environments'] = environments;
+    }
+    if (testCases.isNotEmpty) {
+      params['test_cases'] = testCases;
+    }
+    if (templateIds.isNotEmpty) {
+      params['template_ids'] = templateIds;
+    }
+    if (executionMetadata.data.isNotEmpty) {
+      params['execution_metadata'] = executionMetadata.toQueryParams();
+    }
+    if (issues.isNotEmpty) {
+      params['issues'] = issues.map((i) => i.toString()).toList();
+    }
+    if (fromDate != null) {
+      params['from_date'] = [fromDate!.toIso8601String()];
+    }
+    if (untilDate != null) {
+      params['until_date'] = [untilDate!.toIso8601String()];
+    }
+    if (offset != null) {
+      params['offset'] = [offset!.toString()];
+    }
+    if (limit != null) {
+      params['limit'] = [limit!.toString()];
+    }
+    return params;
+  }
+
+  bool get hasFilters =>
+      families.isNotEmpty ||
+      environments.isNotEmpty ||
+      testCases.isNotEmpty ||
+      templateIds.isNotEmpty ||
+      executionMetadata.isNotEmpty ||
+      issues.isNotEmpty ||
+      fromDate != null ||
+      untilDate != null;
+
+  Uri toTestResultsUri() {
+    return Uri(
+      path: AppRoutes.testResults,
+      queryParameters:
+          toQueryParams().map((key, value) => MapEntry(key, value.join(','))),
+    );
+  }
+}

--- a/frontend/lib/repositories/api_repository.dart
+++ b/frontend/lib/repositories/api_repository.dart
@@ -16,19 +16,20 @@
 
 import 'package:dio/dio.dart';
 
-import '../models/artefact.dart';
-import '../models/execution_metadata.dart';
-import '../models/issue.dart';
 import '../models/artefact_build.dart';
 import '../models/artefact_version.dart';
+import '../models/artefact.dart';
 import '../models/detailed_test_results.dart';
 import '../models/environment_issue.dart';
 import '../models/environment_review.dart';
+import '../models/execution_metadata.dart';
 import '../models/family_name.dart';
+import '../models/issue.dart';
 import '../models/rerun_request.dart';
+import '../models/test_event.dart';
 import '../models/test_issue.dart';
 import '../models/test_result.dart';
-import '../models/test_event.dart';
+import '../models/test_results_filters.dart';
 import '../models/user.dart';
 
 class ApiRepository {
@@ -228,70 +229,14 @@ class ApiRepository {
     return testCasesData.map((item) => item['test_case'] as String).toList();
   }
 
-  Future<TestResultsSearchResult> searchTestResults({
-    List<String>? families,
-    List<String>? environments,
-    List<String>? testCases,
-    List<String>? templateIds,
-    ExecutionMetadata? executionMetadata,
-    List<int>? issues,
-    DateTime? fromDate,
-    DateTime? untilDate,
-    int? limit,
-    int? offset,
-  }) async {
-    final queryParams = <String, dynamic>{};
-
-    if (families != null && families.isNotEmpty) {
-      queryParams['families'] = families;
-    }
-
-    if (environments != null && environments.isNotEmpty) {
-      queryParams['environments'] = environments;
-    }
-
-    if (testCases != null && testCases.isNotEmpty) {
-      queryParams['test_cases'] = testCases;
-    }
-
-    if (templateIds != null && templateIds.isNotEmpty) {
-      queryParams['template_ids'] = templateIds;
-    }
-
-    if (executionMetadata != null && executionMetadata.data.isNotEmpty) {
-      queryParams['execution_metadata'] = executionMetadata.toQueryParams();
-    }
-
-    if (issues != null && issues.isNotEmpty) {
-      queryParams['issues'] = issues;
-    }
-
-    if (fromDate != null) {
-      queryParams['from_date'] = fromDate.toIso8601String();
-    }
-    if (untilDate != null) {
-      queryParams['until_date'] = untilDate.toIso8601String();
-    }
-
-    // Add pagination
-    queryParams['limit'] = limit ?? 500;
-    queryParams['offset'] = offset ?? 0;
-
-    final response =
-        await dio.get('/v1/test-results', queryParameters: queryParams);
-
-    final jsonData = response.data as Map<String, dynamic>;
-    final resultsList =
-        (jsonData['test_results'] as List).cast<Map<String, dynamic>>();
-
-    final testResults = resultsList
-        .map((jsonResult) => TestResultWithContext.fromJson(jsonResult))
-        .toList();
-
-    return TestResultsSearchResult(
-      count: jsonData['count'] as int,
-      testResults: testResults,
+  Future<TestResultsSearchResult> searchTestResults(
+    TestResultsFilters filters,
+  ) async {
+    final response = await dio.get(
+      '/v1/test-results',
+      queryParameters: filters.toQueryParams(),
     );
+    return TestResultsSearchResult.fromJson(response.data);
   }
 
   Future<Issue> attachIssueToTestResults({

--- a/frontend/lib/ui/test_results_page/test_results_page.dart
+++ b/frontend/lib/ui/test_results_page/test_results_page.dart
@@ -16,12 +16,13 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:yaru/widgets.dart';
 
+import '../../models/test_results_filters.dart';
+import '../../routing.dart';
 import '../spacing.dart';
-import 'test_results_filters_view.dart';
 import 'test_results_body.dart';
+import 'test_results_filters_view.dart';
 
 class TestResultsPage extends ConsumerStatefulWidget {
   const TestResultsPage({super.key});
@@ -35,7 +36,8 @@ class _TestResultsPageState extends ConsumerState<TestResultsPage> {
 
   @override
   Widget build(BuildContext context) {
-    final uri = GoRouterState.of(context).uri;
+    final uri = AppRoutes.uriFromContext(context);
+    final filters = TestResultsFilters.fromQueryParams(uri.queryParametersAll);
 
     return Padding(
       padding: const EdgeInsets.only(
@@ -65,11 +67,11 @@ class _TestResultsPageState extends ConsumerState<TestResultsPage> {
           ),
           const SizedBox(height: Spacing.level4),
           if (showFilters) ...[
-            TestResultsFiltersView(pageUri: uri),
+            TestResultsFiltersView(initialFilters: filters),
             const SizedBox(height: Spacing.level4),
           ],
           Expanded(
-            child: TestResultsBody(pageUri: uri),
+            child: TestResultsBody(filters: filters),
           ),
         ],
       ),


### PR DESCRIPTION
## Description

This refactor makes it much easier for other Test Observer components to query search results. It goes especially well with https://github.com/canonical/test_observer/pull/389, as the new `TestResultsFilter` model can be easily passed to that API as well as being used by the Test Results page.

The usefulness will be more apparent in the follow up PR that adds the create attachment rule panel, which includes the option to bulk attach issues.

## Resolved issues

[TO-151](https://warthogs.atlassian.net/browse/TO-151)

## Documentation

N/A

## Web service API changes

N/A

## Tests

Tested test results page locally to ensure all filters continue working.


[TO-151]: https://warthogs.atlassian.net/browse/TO-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ