### PR TITLE
[TO-151] Add attachment rule to detach dialog

### DIFF
--- a/backend/test_observer/controllers/test_results/filter_test_results.py
+++ b/backend/test_observer/controllers/test_results/filter_test_results.py
@@ -133,12 +133,10 @@ def build_query_filters_and_joins(
         )
 
     if filters.from_date is not None:
-        query_filters.append(TestExecution.created_at >= filters.from_date)
-        joins_needed.add("test_execution")
+        query_filters.append(TestResult.created_at >= filters.from_date)
 
     if filters.until_date is not None:
-        query_filters.append(TestExecution.created_at <= filters.until_date)
-        joins_needed.add("test_execution")
+        query_filters.append(TestResult.created_at <= filters.until_date)
 
     return query_filters, joins_needed
 

--- a/frontend/lib/models/attachment_rule_filters.dart
+++ b/frontend/lib/models/attachment_rule_filters.dart
@@ -18,6 +18,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 import 'execution_metadata.dart';
 import 'test_results_filters.dart';
+import 'attachment_rule.dart';
 
 part 'attachment_rule_filters.freezed.dart';
 part 'attachment_rule_filters.g.dart';
@@ -48,6 +49,16 @@ abstract class AttachmentRuleFilters with _$AttachmentRuleFilters {
       testCases: testCaseNames,
       templateIds: templateIds,
       executionMetadata: executionMetadata,
+    );
+  }
+
+  factory AttachmentRuleFilters.fromAttachmentRule(AttachmentRule rule) {
+    return AttachmentRuleFilters(
+      families: rule.families,
+      environmentNames: rule.environmentNames,
+      testCaseNames: rule.testCaseNames,
+      templateIds: rule.templateIds,
+      executionMetadata: rule.executionMetadata,
     );
   }
 

--- a/frontend/lib/providers/issue.dart
+++ b/frontend/lib/providers/issue.dart
@@ -61,7 +61,76 @@ class Issue extends _$Issue {
     return attachmentRule;
   }
 
-  Future attachIssueToTestResults({
+  Future<void> deleteAttachmentRule({
+    required int issueId,
+    required int attachmentRuleId,
+  }) async {
+    final api = ref.read(apiProvider);
+    await api.deleteAttachmentRule(
+      issueId: issueId,
+      attachmentRuleId: attachmentRuleId,
+    );
+    final issue = await future;
+    final updatedAttachmentRules = issue.attachmentRules
+        .where((rule) => rule.id != attachmentRuleId)
+        .toList();
+    state = AsyncData(
+      issue.copyWith(
+        attachmentRules: updatedAttachmentRules,
+      ),
+    );
+  }
+
+  Future<void> enableAttachmentRule({
+    required int issueId,
+    required int attachmentRuleId,
+  }) async {
+    final api = ref.read(apiProvider);
+    await api.patchAttachmentRule(
+      issueId: issueId,
+      attachmentRuleId: attachmentRuleId,
+      enabled: true,
+    );
+    final issue = await future;
+    final updatedAttachmentRules = issue.attachmentRules
+        .map(
+          (rule) =>
+              rule.id == attachmentRuleId ? rule.copyWith(enabled: true) : rule,
+        )
+        .toList();
+    state = AsyncData(
+      issue.copyWith(
+        attachmentRules: updatedAttachmentRules,
+      ),
+    );
+  }
+
+  Future<void> disableAttachmentRule({
+    required int issueId,
+    required int attachmentRuleId,
+  }) async {
+    final api = ref.read(apiProvider);
+    await api.patchAttachmentRule(
+      issueId: issueId,
+      attachmentRuleId: attachmentRuleId,
+      enabled: false,
+    );
+    final issue = await future;
+    final updatedAttachmentRules = issue.attachmentRules
+        .map(
+          (rule) => rule.id == attachmentRuleId
+              ? rule.copyWith(enabled: false)
+              : rule,
+        )
+        .toList();
+    state = AsyncData(
+      issue.copyWith(
+        attachmentRules: updatedAttachmentRules,
+      ),
+    );
+  }
+
+  Future<void> attachIssueToTestResults({
     required int issueId,
     required TestResultsFilters filters,
     int? attachmentRuleId,
@@ -74,7 +143,7 @@ class Issue extends _$Issue {
     );
   }
 
-  Future detachIssueFromTestResults({
+  Future<void> detachIssueFromTestResults({
     required int issueId,
     required TestResultsFilters filters,
   }) async {

--- a/frontend/lib/repositories/api_repository.dart
+++ b/frontend/lib/repositories/api_repository.dart
@@ -332,4 +332,26 @@ class ApiRepository {
     );
     return AttachmentRule.fromJson(response.data);
   }
+
+  Future<void> deleteAttachmentRule({
+    required int issueId,
+    required int attachmentRuleId,
+  }) async {
+    await dio.delete(
+      '/v1/issues/$issueId/attachment-rules/$attachmentRuleId',
+    );
+  }
+
+  Future<void> patchAttachmentRule({
+    required int issueId,
+    required int attachmentRuleId,
+    bool? enabled,
+  }) async {
+    await dio.patch(
+      '/v1/issues/$issueId/attachment-rules/$attachmentRuleId',
+      data: {
+        if (enabled != null) 'enabled': enabled,
+      },
+    );
+  }
 }

--- a/frontend/lib/ui/artefact_page/issue_attachments/issue_attachment_widget.dart
+++ b/frontend/lib/ui/artefact_page/issue_attachments/issue_attachment_widget.dart
@@ -35,17 +35,22 @@ class IssueAttachmentWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final attachmentRule = issueAttachment.attachmentRule;
     return Row(
       children: [
         Expanded(
           child: IssueWidget(issue: issueAttachment.issue),
         ),
-        if (issueAttachment.attachmentRule != null) ...[
+        if (attachmentRule != null) ...[
           Tooltip(
-            message: 'Attached by a rule',
+            message: attachmentRule.enabled
+                ? 'Attached by an enabled attachment rule'
+                : 'Attached by a disabled attachment rule',
             child: InkWell(
               onTap: () {}, // Placeholder link
-              child: const Icon(Icons.attachment, size: 20),
+              child: attachmentRule.enabled
+                  ? const Icon(Icons.attachment, size: 20)
+                  : const Icon(Icons.link_off, size: 20, color: Colors.grey),
             ),
           ),
           SizedBox(width: Spacing.level3),

--- a/frontend/lib/ui/artefact_page/issue_attachments/issue_forms/bulk_attach_section.dart
+++ b/frontend/lib/ui/artefact_page/issue_attachments/issue_forms/bulk_attach_section.dart
@@ -51,7 +51,7 @@ class BulkAttachSection extends ConsumerWidget {
           'Attach to existing test results',
           style: Theme.of(context).textTheme.titleLarge,
         ),
-        _BulkAttachIssueOption(
+        BulkAttachIssueOption(
           title: 'Older test results',
           value: selectedBulkAttachOlder,
           filters: attachmentRuleFilters.toTestResultsFilters().copyWith(
@@ -60,7 +60,7 @@ class BulkAttachSection extends ConsumerWidget {
           loadNumberResults: attachmentRuleFilters.hasFilters,
           onChanged: onBulkAttachOlderChanged,
         ),
-        _BulkAttachIssueOption(
+        BulkAttachIssueOption(
           title: 'Newer test results',
           value: selectedBulkAttachNewer,
           filters: attachmentRuleFilters.toTestResultsFilters().copyWith(
@@ -74,54 +74,64 @@ class BulkAttachSection extends ConsumerWidget {
   }
 }
 
-class _BulkAttachIssueOption extends ConsumerWidget {
-  const _BulkAttachIssueOption({
+class BulkAttachIssueOption extends ConsumerWidget {
+  const BulkAttachIssueOption({
+    super.key,
     required this.title,
     required this.value,
     required this.filters,
     this.loadNumberResults = false,
     required this.onChanged,
+    this.detach = false,
   });
 
   final String title;
   final bool value;
   final TestResultsFilters filters;
   final bool loadNumberResults;
-  final ValueChanged<bool> onChanged;
+  final ValueChanged<bool>? onChanged;
+  final bool detach;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final matchingTestResults = loadNumberResults
         ? ref.watch(testResultsSearchProvider(filters.copyWith(limit: 0)))
         : null;
-    return CheckboxListTile(
-      title: Row(
-        spacing: Spacing.level3,
-        children: [
-          Text(title),
-          if (loadNumberResults)
-            matchingTestResults!.isLoading
-                ? const SizedBox(
-                    width: 20,
-                    height: 20,
-                    child: YaruCircularProgressIndicator(),
-                  )
-                : InlineUrlText(
-                    url: '/#${filters.toTestResultsUri()}',
-                    urlText:
-                        'Matches ${matchingTestResults.value?.count ?? 0} test results',
-                    fontStyle: DefaultTextStyle.of(context).style.apply(
-                          color: Theme.of(context).colorScheme.primary,
-                          fontStyle: FontStyle.italic,
-                          decoration: TextDecoration.none,
-                        ),
-                  ),
-        ],
+    final isDisabled = onChanged == null;
+    return Opacity(
+      opacity: isDisabled ? 0.5 : 1.0,
+      child: IgnorePointer(
+        ignoring: isDisabled,
+        child: CheckboxListTile(
+          title: Row(
+            spacing: Spacing.level3,
+            children: [
+              Text(title),
+              if (loadNumberResults)
+                matchingTestResults!.isLoading
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: YaruCircularProgressIndicator(),
+                      )
+                    : InlineUrlText(
+                        url: '/#${filters.toTestResultsUri()}',
+                        urlText:
+                            'Matches ${matchingTestResults.value?.count ?? 0} test results',
+                        fontStyle: DefaultTextStyle.of(context).style.apply(
+                              color: Theme.of(context).colorScheme.primary,
+                              fontStyle: FontStyle.italic,
+                              decoration: TextDecoration.none,
+                            ),
+                      ),
+            ],
+          ),
+          value: value,
+          onChanged: (selected) {
+            onChanged?.call(selected ?? false);
+          },
+        ),
       ),
-      value: value,
-      onChanged: (selected) {
-        onChanged(selected ?? false);
-      },
     );
   }
 }

--- a/frontend/lib/ui/artefact_page/issue_attachments/issue_forms/detach_issue_form.dart
+++ b/frontend/lib/ui/artefact_page/issue_attachments/issue_forms/detach_issue_form.dart
@@ -14,68 +14,225 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import 'package:dartx/dartx.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../models/attachment_rule_filters.dart';
 import '../../../../models/issue.dart';
 import '../../../../providers/test_results.dart';
+import '../../../../providers/issue.dart' as ip;
 import '../../../../routing.dart';
+import '../../../attachment_rule.dart';
 import '../../../spacing.dart';
 import '../issue_widget.dart';
+import 'bulk_attach_section.dart';
 
-class _DetachIssueDialog extends ConsumerWidget {
-  const _DetachIssueDialog({
+class DetachIssueForm extends ConsumerStatefulWidget {
+  final Issue issue;
+  final int testExecutionId;
+  final int testResultId;
+
+  const DetachIssueForm({
+    super.key,
     required this.issue,
     required this.testExecutionId,
     required this.testResultId,
   });
 
-  final Issue issue;
-  final int testExecutionId;
-  final int testResultId;
+  @override
+  ConsumerState<DetachIssueForm> createState() => _DetachIssueFormState();
+}
+
+class _DetachIssueFormState extends ConsumerState<DetachIssueForm> {
+  late final GlobalKey<FormState> formKey;
+  bool _disableAttachmentRule = false;
+  bool _deleteNewerAttachments = false;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return AlertDialog(
-      title: const Text('Are you sure you want to detach this issue?'),
-      content: SizedBox(
-        width: Spacing.formWidth,
-        child: InkWell(
-          borderRadius: BorderRadius.circular(12),
-          onTap: () {
-            navigateToIssuePage(context, issue.id);
-          },
-          child: Card(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: Spacing.level3,
-                horizontal: Spacing.level4,
-              ),
-              child: IssueWidget(issue: issue),
+  void initState() {
+    super.initState();
+    formKey = GlobalKey<FormState>();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final buttonFontStyle = Theme.of(context).textTheme.labelLarge;
+    final testResult = ref
+        .watch(
+          testResultsProvider(widget.testExecutionId).select(
+            (value) => value.whenData(
+              (results) => results
+                  .firstWhere((result) => result.id == widget.testResultId),
             ),
           ),
+        )
+        .value;
+    final issueAttachment = testResult?.issueAttachments.firstOrNullWhere(
+      (attachment) => attachment.issue.id == widget.issue.id,
+    );
+    final attachmentRule = issueAttachment?.attachmentRule;
+    final attachmentRuleFilters = attachmentRule != null
+        ? AttachmentRuleFilters.fromAttachmentRule(attachmentRule)
+        : null;
+    final deleteNewerAttachmentsTestResultFilters =
+        attachmentRuleFilters != null
+            ? attachmentRuleFilters.toTestResultsFilters().copyWith(
+                issues: [widget.issue.id],
+                fromDate: testResult?.createdAt,
+              )
+            : null;
+
+    return Form(
+      key: formKey,
+      child: SizedBox(
+        width: Spacing.formWidth,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Detach Issue', style: Theme.of(context).textTheme.titleLarge),
+            const SizedBox(height: Spacing.level4),
+            Flexible(
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  maxHeight: MediaQuery.of(context).size.height * 0.6,
+                ),
+                child: SingleChildScrollView(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    spacing: Spacing.level3,
+                    children: [
+                      InkWell(
+                        borderRadius: BorderRadius.circular(12),
+                        onTap: () {
+                          navigateToIssuePage(context, widget.issue.id);
+                        },
+                        child: Card(
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                              vertical: Spacing.level3,
+                              horizontal: Spacing.level4,
+                            ),
+                            child: IssueWidget(issue: widget.issue),
+                          ),
+                        ),
+                      ),
+                      if (attachmentRule != null) ...[
+                        CheckboxListTile(
+                          key: const Key('disableAttachmentRuleCheckbox'),
+                          title: Text('Disable attachment rule'),
+                          value: _disableAttachmentRule,
+                          onChanged: attachmentRule.enabled
+                              ? (selected) {
+                                  setState(() {
+                                    _disableAttachmentRule = selected ?? false;
+                                  });
+                                }
+                              : null,
+                        ),
+                        Card(
+                          margin: const EdgeInsets.only(
+                            left: 12.0,
+                            top: 8.0,
+                            bottom: 8.0,
+                            right: 0,
+                          ),
+                          elevation: 1.5,
+                          child: Padding(
+                            padding: const EdgeInsets.all(12.0),
+                            child: AttachmentRuleFiltersWidget(
+                              filters: attachmentRuleFilters!,
+                              editable: false,
+                            ),
+                          ),
+                        ),
+                        BulkAttachIssueOption(
+                          title: 'Detach for newer test results',
+                          value: _deleteNewerAttachments,
+                          filters: deleteNewerAttachmentsTestResultFilters!,
+                          loadNumberResults:
+                              deleteNewerAttachmentsTestResultFilters
+                                  .hasFilters,
+                          onChanged: (selected) {
+                            setState(() {
+                              _deleteNewerAttachments = selected;
+                            });
+                          },
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            Row(
+              children: [
+                TextButton(
+                  onPressed: () => context.pop(),
+                  child: Text(
+                    'cancel',
+                    style: buttonFontStyle?.apply(color: Colors.grey),
+                  ),
+                ),
+                const Spacer(),
+                TextButton(
+                  key: const Key('detachIssueFormSubmitButton'),
+                  onPressed: () async {
+                    // Ensure the form is valid before proceeding.
+                    if (formKey.currentState?.validate() != true) return;
+
+                    // Disable the attachment rule if requested
+                    if (attachmentRule != null && _disableAttachmentRule) {
+                      await ref
+                          .read(ip.issueProvider(widget.issue.id).notifier)
+                          .disableAttachmentRule(
+                            issueId: widget.issue.id,
+                            attachmentRuleId: attachmentRule.id,
+                          );
+                    }
+
+                    // Create the bulk detachment if requested.
+                    if (deleteNewerAttachmentsTestResultFilters != null &&
+                        _deleteNewerAttachments) {
+                      await ref
+                          .read(ip.issueProvider(widget.issue.id).notifier)
+                          .detachIssueFromTestResults(
+                            issueId: widget.issue.id,
+                            filters: deleteNewerAttachmentsTestResultFilters,
+                          );
+                    }
+
+                    // Detach the issue from the test result.
+                    await ref
+                        .read(
+                          testResultsProvider(widget.testExecutionId).notifier,
+                        )
+                        .detachIssueFromTestResult(
+                          widget.testResultId,
+                          widget.issue.id,
+                        );
+
+                    // Finish up.
+                    if (!context.mounted) return;
+                    Navigator.of(context).pop();
+                  },
+                  child: Text(
+                    'detach',
+                    style: buttonFontStyle?.apply(color: Colors.black),
+                  ),
+                ),
+              ],
+            ),
+          ],
         ),
       ),
-      actions: [
-        TextButton(
-          onPressed: () {
-            context.pop(false);
-          },
-          child: const Text('No'),
-        ),
-        TextButton(
-          key: const Key('detachIssueConfirmButton'),
-          onPressed: () async {
-            await ref
-                .read(testResultsProvider(testExecutionId).notifier)
-                .detachIssueFromTestResult(testResultId, issue.id);
-            if (!context.mounted) return;
-            Navigator.of(context).pop();
-          },
-          child: const Text('Yes'),
-        ),
-      ],
     );
   }
 }
@@ -88,9 +245,14 @@ void showDetachIssueDialog({
 }) =>
     showDialog(
       context: context,
-      builder: (_) => _DetachIssueDialog(
-        issue: issue,
-        testExecutionId: testExecutionId,
-        testResultId: testResultId,
+      builder: (_) => Dialog(
+        child: Padding(
+          padding: const EdgeInsets.all(Spacing.level4),
+          child: DetachIssueForm(
+            issue: issue,
+            testExecutionId: testExecutionId,
+            testResultId: testResultId,
+          ),
+        ),
       ),
     );

--- a/frontend/lib/ui/attachment_rule.dart
+++ b/frontend/lib/ui/attachment_rule.dart
@@ -109,6 +109,19 @@ class AttachmentRuleFiltersWidget extends StatelessWidget {
               ),
               _buildFilterSection(
                 context: context,
+                label: 'Environments',
+                allValues: filters.environmentNames,
+                selectedValues: selected.environmentNames.toSet(),
+                onChanged: (newEnvironments) {
+                  final newFilters = selected.copyWith(
+                    environmentNames: newEnvironments.toList(),
+                  );
+                  field.didChange(newFilters);
+                  onChanged?.call(newFilters);
+                },
+              ),
+              _buildFilterSection(
+                context: context,
                 label: 'Test Cases',
                 allValues: filters.testCaseNames,
                 selectedValues: selected.testCaseNames.toSet(),

--- a/frontend/lib/ui/date_time.dart
+++ b/frontend/lib/ui/date_time.dart
@@ -16,5 +16,5 @@
 
 String formatDateTime(DateTime dt) {
   return '${dt.year.toString().padLeft(4, '0')}-${dt.month.toString().padLeft(2, '0')}-${dt.day.toString().padLeft(2, '0')} '
-      '${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
+      '${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}:${dt.second.toString().padLeft(2, '0')}';
 }

--- a/frontend/lib/ui/page_filters/date_time_selector.dart
+++ b/frontend/lib/ui/page_filters/date_time_selector.dart
@@ -207,7 +207,7 @@ class _DateTimeSelectorState extends State<DateTimeSelector> {
                         child: TextFormField(
                           controller: _controller,
                           decoration: InputDecoration(
-                            hintText: 'YYYY-MM-DD HH:MM',
+                            hintText: 'YYYY-MM-DD HH:MM:SS',
                             errorText: _errorText,
                           ),
                           onChanged: _onTextChanged,


### PR DESCRIPTION
## Description

This PR rounds out [TO-151](https://warthogs.atlassian.net/browse/TO-151) by adding attachment rule features to the detach dialog

<img width="1152" height="633" alt="Screenshot from 2025-09-25 15-41-12" src="https://github.com/user-attachments/assets/e4d1d6e1-1d83-4af4-a870-f42b21a33c8a" />
<img width="1125" height="493" alt="Screenshot from 2025-09-25 15-40-33" src="https://github.com/user-attachments/assets/5ffd2afd-9319-41c3-9d0d-56ea7813e8a4" />


## Resolved issues

[TO-151](https://warthogs.atlassian.net/browse/TO-151)

## Documentation

N/A

## Web service API changes

N/A

## Tests

Tested locally and flutter tests added/modified.


[TO-151]: https://warthogs.atlassian.net/browse/TO-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TO-151]: https://warthogs.atlassian.net/browse/TO-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ