### PR TITLE
[TO-184] Add search functionality and pagination to environments endpoint

### DIFF
--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -1590,8 +1590,55 @@
           "environments"
         ],
         "summary": "Get Environments",
-        "description": "Returns list of distinct environments that have been used in test executions.",
+        "description": "Returns list of distinct environments that have been used in test executions.\n\nSupports pagination and search filtering.",
         "operationId": "get_environments_v1_environments_get",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Search term for environment names",
+              "title": "Q"
+            },
+            "description": "Search term for environment names"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "description": "Maximum number of results (defaults to 50 if not specified)",
+              "default": 50,
+              "title": "Limit"
+            },
+            "description": "Maximum number of results (defaults to 50 if not specified)"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Number of results to skip for pagination",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Number of results to skip for pagination"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -1599,6 +1646,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/EnvironmentsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }

--- a/backend/tests/controllers/environments/test_environments.py
+++ b/backend/tests/controllers/environments/test_environments.py
@@ -23,6 +23,27 @@ def generate_unique_name(prefix: str) -> str:
     return f"{prefix}_{uuid.uuid4().hex[:8]}"
 
 
+def _seed_environments(
+    generator: DataGenerator, count: int, prefix: str = "test_env"
+) -> list[str]:
+    """
+    Helper to create test environments with test results.
+    Creates its own artefact build for each environment.
+    """
+    art = generator.gen_artefact(name=generate_unique_name("artefact"))
+    art_build = generator.gen_artefact_build(art)
+    test_case = generator.gen_test_case(name=generate_unique_name("test_case"))
+
+    names: list[str] = []
+    for i in range(count):
+        name = f"{prefix}_{i:03d}_{uuid.uuid4().hex[:6]}"
+        env = generator.gen_environment(name=name)
+        te = generator.gen_test_execution(art_build, env)
+        generator.gen_test_result(test_case, te)
+        names.append(name)
+    return names
+
+
 def test_get_environments(test_client: TestClient):
     """Test getting environments endpoint"""
     response = test_client.get("/v1/environments")
@@ -76,3 +97,183 @@ def test_create_environment_and_validate_returned(
     assert unique_env_name in environments, (
         f"Environment {unique_env_name} not found in response: {environments}"
     )
+
+
+def test_default_limit_is_50(test_client: TestClient, generator: DataGenerator):
+    """When no limit is passed, endpoint should return up to 50 results."""
+    _seed_environments(generator, 60, prefix="default_limit")
+    resp = test_client.get("/v1/environments")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "environments" in data
+    assert len(data["environments"]) <= 50
+    assert len(data["environments"]) == 50  # exactly 50 when >=50 exist
+
+
+def test_explicit_limit_and_offset_window(
+    test_client: TestClient, generator: DataGenerator
+):
+    """
+    Verify limit/offset produce expected window with deterministic
+    ordering by name.
+    """
+    names = _seed_environments(generator, 20, prefix="window_check")
+    expected_sorted = sorted(names)
+
+    resp = test_client.get("/v1/environments", params={"limit": 5, "offset": 5})
+    assert resp.status_code == 200
+    got = resp.json()["environments"]
+    assert len(got) == 5
+    assert got == expected_sorted[5:10]
+
+
+def test_search_filter_q_ilike(test_client: TestClient, generator: DataGenerator):
+    """Search should filter by name (ILIKE)."""
+    # Create environments with specific patterns
+    art = generator.gen_artefact(name=generate_unique_name("artefact"))
+    art_build = generator.gen_artefact_build(art)
+    test_case = generator.gen_test_case(name=generate_unique_name("test_case"))
+
+    unique_marker = uuid.uuid4().hex[:8]
+    target_name = f"special_search_{unique_marker}"
+    other_name1 = f"other_env_{unique_marker}_1"
+    other_name2 = f"other_env_{unique_marker}_2"
+
+    for name in [target_name, other_name1, other_name2]:
+        env = generator.gen_environment(name=name)
+        te = generator.gen_test_execution(art_build, env)
+        generator.gen_test_result(test_case, te)
+
+    # Search for the specific pattern
+    resp = test_client.get("/v1/environments", params={"q": "special_search"})
+    assert resp.status_code == 200
+    got_environments = resp.json()["environments"]
+
+    # Should only find the target environment
+    assert target_name in got_environments
+    assert other_name1 not in got_environments
+    assert other_name2 not in got_environments
+
+
+def test_search_case_insensitive(test_client: TestClient, generator: DataGenerator):
+    """Search should be case-insensitive."""
+    art = generator.gen_artefact(name=generate_unique_name("artefact"))
+    art_build = generator.gen_artefact_build(art)
+    test_case = generator.gen_test_case(name=generate_unique_name("test_case"))
+
+    unique_marker = uuid.uuid4().hex[:8]
+    env_name = f"MixedCase_Environment_{unique_marker}"
+
+    env = generator.gen_environment(name=env_name)
+    te = generator.gen_test_execution(art_build, env)
+    generator.gen_test_result(test_case, te)
+
+    # Search with different cases
+    for search_term in ["mixedcase", "MIXEDCASE", "MixedCase"]:
+        resp = test_client.get("/v1/environments", params={"q": search_term})
+        assert resp.status_code == 200
+        got_environments = resp.json()["environments"]
+        assert env_name in got_environments
+
+
+def test_search_partial_match(test_client: TestClient, generator: DataGenerator):
+    """Search should support partial matching."""
+    art = generator.gen_artefact(name=generate_unique_name("artefact"))
+    art_build = generator.gen_artefact_build(art)
+    test_case = generator.gen_test_case(name=generate_unique_name("test_case"))
+
+    unique_marker = uuid.uuid4().hex[:8]
+    env_name = f"production_server_{unique_marker}"
+
+    env = generator.gen_environment(name=env_name)
+    te = generator.gen_test_execution(art_build, env)
+    generator.gen_test_result(test_case, te)
+
+    # Search with partial term
+    resp = test_client.get("/v1/environments", params={"q": "production"})
+    assert resp.status_code == 200
+    got_environments = resp.json()["environments"]
+    assert env_name in got_environments
+
+
+def test_search_with_pagination(test_client: TestClient, generator: DataGenerator):
+    """Search results should respect pagination parameters."""
+    names = []
+    art = generator.gen_artefact(name=generate_unique_name("artefact"))
+    art_build = generator.gen_artefact_build(art)
+    test_case = generator.gen_test_case(name=generate_unique_name("test_case"))
+
+    # Create 10 environments with common prefix
+    unique_marker = uuid.uuid4().hex[:8]
+    for i in range(10):
+        name = f"paginated_env_{unique_marker}_{i:02d}"
+        names.append(name)
+        env = generator.gen_environment(name=name)
+        te = generator.gen_test_execution(art_build, env)
+        generator.gen_test_result(test_case, te)
+
+    expected_sorted = sorted(names)
+
+    # Get first page
+    resp = test_client.get(
+        "/v1/environments",
+        params={"q": f"paginated_env_{unique_marker}", "limit": 3, "offset": 0},
+    )
+    assert resp.status_code == 200
+    page1 = resp.json()["environments"]
+    assert len(page1) == 3
+    assert page1 == expected_sorted[0:3]
+
+    # Get second page
+    resp = test_client.get(
+        "/v1/environments",
+        params={"q": f"paginated_env_{unique_marker}", "limit": 3, "offset": 3},
+    )
+    assert resp.status_code == 200
+    page2 = resp.json()["environments"]
+    assert len(page2) == 3
+    assert page2 == expected_sorted[3:6]
+
+
+def test_pagination_limits(test_client: TestClient):
+    """Test pagination parameter validation"""
+    # Test maximum limit
+    response = test_client.get("/v1/environments?limit=1001")
+    assert response.status_code == 422
+
+    # Test negative offset
+    response = test_client.get("/v1/environments?offset=-1")
+    assert response.status_code == 422
+
+    # Test minimum limit
+    response = test_client.get("/v1/environments?limit=0")
+    assert response.status_code == 422
+
+
+def test_empty_search_returns_empty_list(test_client: TestClient):
+    """Test search with no results returns empty list."""
+    resp = test_client.get(
+        "/v1/environments", params={"q": "nonexistent_environment_xyz_123"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["environments"] == []
+
+
+def test_search_strips_whitespace(test_client: TestClient, generator: DataGenerator):
+    """Test that search query strips leading/trailing whitespace."""
+    art = generator.gen_artefact(name=generate_unique_name("artefact"))
+    art_build = generator.gen_artefact_build(art)
+    test_case = generator.gen_test_case(name=generate_unique_name("test_case"))
+
+    unique_marker = uuid.uuid4().hex[:8]
+    env_name = f"whitespace_test_{unique_marker}"
+
+    env = generator.gen_environment(name=env_name)
+    te = generator.gen_test_execution(art_build, env)
+    generator.gen_test_result(test_case, te)
+
+    # Search with extra whitespace
+    resp = test_client.get("/v1/environments", params={"q": "  whitespace_test  "})
+    assert resp.status_code == 200
+    got_environments = resp.json()["environments"]
+    assert env_name in got_environments

--- a/frontend/lib/providers/test_results_environments.dart
+++ b/frontend/lib/providers/test_results_environments.dart
@@ -21,7 +21,12 @@ import 'api.dart';
 part 'test_results_environments.g.dart';
 
 @riverpod
-Future<List<String>> allEnvironments(Ref ref) async {
+Future<List<String>> suggestedEnvironments(Ref ref, String query) async {
+  // Only search if query is long enough
+  if (query.trim().length < 2) {
+    return [];
+  }
+
   final api = ref.watch(apiProvider);
-  return await api.getEnvironments();
+  return await api.searchEnvironments(query: query.trim(), limit: 50);
 }

--- a/frontend/lib/repositories/api_repository.dart
+++ b/frontend/lib/repositories/api_repository.dart
@@ -217,8 +217,22 @@ class ApiRepository {
     return EnvironmentReview.fromJson(response.data);
   }
 
-  Future<List<String>> getEnvironments() async {
-    final response = await dio.get('/v1/environments');
+  Future<List<String>> searchEnvironments({
+    String? query,
+    int limit = 50,
+    int offset = 0,
+  }) async {
+    final queryParams = <String, dynamic>{
+      'limit': limit,
+      'offset': offset,
+    };
+
+    if (query != null && query.trim().isNotEmpty) {
+      queryParams['q'] = query.trim();
+    }
+
+    final response =
+        await dio.get('/v1/environments', queryParameters: queryParams);
     final Map<String, dynamic> data = response.data;
     final List<dynamic> environments = data['environments'] ?? [];
     return environments.cast<String>();

--- a/frontend/lib/ui/test_results_page/test_results_filters_view.dart
+++ b/frontend/lib/ui/test_results_page/test_results_filters_view.dart
@@ -69,7 +69,6 @@ class _TestResultsFiltersViewState
 
   @override
   Widget build(BuildContext context) {
-    final environments = ref.watch(allEnvironmentsProvider).value ?? [];
     final allFamilyOptions = FamilyName.values.map((f) => f.name).toList();
     final executionMetadata = ref.watch(executionMetadataProvider).value ??
         ExecutionMetadata(data: {});
@@ -99,8 +98,13 @@ class _TestResultsFiltersViewState
         _box(
           MultiSelectCombobox(
             title: 'Environment',
-            allOptions: environments,
+            allOptions: const [],
             initialSelected: _selectedFilters.environments.toSet(),
+            asyncSuggestionsCallback: (pattern) async {
+              return await ref
+                  .read(suggestedEnvironmentsProvider(pattern).future);
+            },
+            minCharsForAsyncSearch: 2,
             onChanged: (val, isSelected) => setState(
               () => _selectedFilters = _selectedFilters.copyWith(
                 environments: [


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR adds search functionality and pagination for the environments endpoint. It's ultimate goal is to avoid overloading the frontend by retrieving all environments and instead search dynamically according to user keyboard input. I had implemented the same approach for test cases in [PR#392](https://github.com/canonical/test_observer/pull/392).

## Resolved issues
[TO-184](https://warthogs.atlassian.net/browse/TO-184?atlOrigin=eyJpIjoiYzc5ZjZmYWI4YWUxNDMwOGFlNzNmOTlmZDA1Y2NjYjIiLCJwIjoiaiJ9)

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes
Changed simple behavior of `GET v1/environments` from retrieving all environments in the database to searching 50 suggested results based on user input + pagination that supports this operation. 

<img width="1425" height="1105" alt="image" src="https://github.com/user-attachments/assets/690a99c5-67ae-4936-988f-2a22bd483599" />

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->
Pytests are added that ensures the changes in the endpoint work correctly. Moreover, I tested out the frontend by running the application in localhost. 