### PR TITLE
Add test results artefact filter to test observer

### DIFF
--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -666,6 +666,277 @@
         }
       }
     },
+    "/v1/artefacts": {
+      "get": {
+        "tags": [
+          "artefacts"
+        ],
+        "summary": "Get Artefacts",
+        "description": "Get latest artefacts optionally by family",
+        "operationId": "get_artefacts_v1_artefacts_get",
+        "parameters": [
+          {
+            "name": "family",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/FamilyName"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Family"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ArtefactResponse"
+                  },
+                  "title": "Response Get Artefacts V1 Artefacts Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/artefacts/search": {
+      "get": {
+        "tags": [
+          "artefacts"
+        ],
+        "summary": "Search Artefacts",
+        "description": "Search for artefacts by name with pagination support.\n\nReturns a list of distinct artefact names that match the search query.",
+        "operationId": "search_artefacts_v1_artefacts_search_get",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Search term for artefact names",
+              "title": "Q"
+            },
+            "description": "Search term for artefact names"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "description": "Maximum number of results (defaults to 50 if not specified)",
+              "default": 50,
+              "title": "Limit"
+            },
+            "description": "Maximum number of results (defaults to 50 if not specified)"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Number of results to skip for pagination",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Number of results to skip for pagination"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtefactSearchResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/artefacts/{artefact_id}": {
+      "get": {
+        "tags": [
+          "artefacts"
+        ],
+        "summary": "Get Artefact",
+        "operationId": "get_artefact_v1_artefacts__artefact_id__get",
+        "parameters": [
+          {
+            "name": "artefact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Artefact Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtefactResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "artefacts"
+        ],
+        "summary": "Patch Artefact",
+        "operationId": "patch_artefact_v1_artefacts__artefact_id__patch",
+        "parameters": [
+          {
+            "name": "artefact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Artefact Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ArtefactPatch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtefactResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/artefacts/{artefact_id}/versions": {
+      "get": {
+        "tags": [
+          "artefacts"
+        ],
+        "summary": "Get Artefact Versions",
+        "operationId": "get_artefact_versions_v1_artefacts__artefact_id__versions_get",
+        "parameters": [
+          {
+            "name": "artefact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Artefact Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ArtefactVersionResponse"
+                  },
+                  "title": "Response Get Artefact Versions V1 Artefacts  Artefact Id  Versions Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/artefacts/{artefact_id}/environment-reviews": {
       "get": {
         "tags": [
@@ -806,198 +1077,6 @@
                     "$ref": "#/components/schemas/ArtefactBuildResponse"
                   },
                   "title": "Response Get Artefact Builds V1 Artefacts  Artefact Id  Builds Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/artefacts": {
-      "get": {
-        "tags": [
-          "artefacts"
-        ],
-        "summary": "Get Artefacts",
-        "description": "Get latest artefacts optionally by family",
-        "operationId": "get_artefacts_v1_artefacts_get",
-        "parameters": [
-          {
-            "name": "family",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/FamilyName"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Family"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ArtefactResponse"
-                  },
-                  "title": "Response Get Artefacts V1 Artefacts Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/artefacts/{artefact_id}": {
-      "get": {
-        "tags": [
-          "artefacts"
-        ],
-        "summary": "Get Artefact",
-        "operationId": "get_artefact_v1_artefacts__artefact_id__get",
-        "parameters": [
-          {
-            "name": "artefact_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Artefact Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ArtefactResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "artefacts"
-        ],
-        "summary": "Patch Artefact",
-        "operationId": "patch_artefact_v1_artefacts__artefact_id__patch",
-        "parameters": [
-          {
-            "name": "artefact_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Artefact Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ArtefactPatch"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ArtefactResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/artefacts/{artefact_id}/versions": {
-      "get": {
-        "tags": [
-          "artefacts"
-        ],
-        "summary": "Get Artefact Versions",
-        "operationId": "get_artefact_versions_v1_artefacts__artefact_id__versions_get",
-        "parameters": [
-          {
-            "name": "artefact_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Artefact Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ArtefactVersionResponse"
-                  },
-                  "title": "Response Get Artefact Versions V1 Artefacts  Artefact Id  Versions Get"
                 }
               }
             }
@@ -2147,6 +2226,27 @@
               "title": "Families"
             },
             "description": "Filter by artefact families (e.g., charm,snap)"
+          },
+          {
+            "name": "artefacts",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by artefact names",
+              "title": "Artefacts"
+            },
+            "description": "Filter by artefact names"
           },
           {
             "name": "environments",
@@ -3417,6 +3517,22 @@
           "completed_environment_reviews_count"
         ],
         "title": "ArtefactResponse"
+      },
+      "ArtefactSearchResponse": {
+        "properties": {
+          "artefacts": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Artefacts"
+          }
+        },
+        "type": "object",
+        "required": [
+          "artefacts"
+        ],
+        "title": "ArtefactSearchResponse"
       },
       "ArtefactStatus": {
         "type": "string",
@@ -5307,6 +5423,13 @@
             },
             "type": "array",
             "title": "Families"
+          },
+          "artefacts": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Artefacts"
           },
           "environments": {
             "items": {

--- a/backend/test_observer/controllers/artefacts/models.py
+++ b/backend/test_observer/controllers/artefacts/models.py
@@ -162,6 +162,10 @@ class ArtefactBuildMinimalResponse(BaseModel):
     revision: int | None
 
 
+class ArtefactSearchResponse(BaseModel):
+    artefacts: list[str]
+
+
 class ArtefactBuildEnvironmentReviewResponse(BaseModel):
     id: int
     review_decision: list[ArtefactBuildEnvironmentReviewDecision]

--- a/backend/test_observer/controllers/test_results/filter_test_results.py
+++ b/backend/test_observer/controllers/test_results/filter_test_results.py
@@ -108,6 +108,10 @@ def build_query_filters_and_joins(
         query_filters.append(Artefact.family.in_(filters.families))
         joins_needed.update(["test_execution", "artefact_build", "artefact"])
 
+    if len(filters.artefacts) > 0:
+        query_filters.append(Artefact.name.in_(filters.artefacts))
+        joins_needed.update(["test_execution", "artefact_build", "artefact"])
+
     if len(filters.environments) > 0:
         query_filters.append(Environment.name.in_(filters.environments))
         joins_needed.update(["test_execution", "environment"])

--- a/backend/test_observer/controllers/test_results/models.py
+++ b/backend/test_observer/controllers/test_results/models.py
@@ -55,6 +55,7 @@ class TestResultSearchResponseWithContext(BaseModel):
 
 class TestResultSearchFilters(BaseModel):
     families: list[FamilyName] = Field(default_factory=list)
+    artefacts: list[str] = Field(default_factory=list)
     environments: list[str] = Field(default_factory=list)
     test_cases: list[str] = Field(default_factory=list)
     template_ids: list[str] = Field(default_factory=list)

--- a/backend/test_observer/controllers/test_results/test_results.py
+++ b/backend/test_observer/controllers/test_results/test_results.py
@@ -81,6 +81,10 @@ def search_test_results(
         list[FamilyName] | None,
         Query(description="Filter by artefact families (e.g., charm,snap)"),
     ] = None,
+    artefacts: Annotated[
+        list[str] | None,
+        Query(description="Filter by artefact names"),
+    ] = None,
     environments: Annotated[
         list[str] | None,
         Query(description="Filter by environment names"),
@@ -122,6 +126,7 @@ def search_test_results(
     # Build the filters
     filters = TestResultSearchFilters(
         families=families or [],
+        artefacts=artefacts or [],
         environments=environments or [],
         test_cases=test_cases or [],
         template_ids=template_ids or [],

--- a/backend/tests/controllers/artefacts/test_artefacts_search.py
+++ b/backend/tests/controllers/artefacts/test_artefacts_search.py
@@ -34,7 +34,6 @@ def test_search_artefacts_endpoint_exists(test_client: TestClient):
 
 def test_search_artefacts_no_query(test_client: TestClient, generator: DataGenerator):
     """Test searching without query returns all artefacts"""
-    # Create some artefacts
     unique_marker = uuid.uuid4().hex[:8]
     artefact1 = generator.gen_artefact(name=f"test_artefact_1_{unique_marker}")
     artefact2 = generator.gen_artefact(name=f"test_artefact_2_{unique_marker}")
@@ -45,7 +44,6 @@ def test_search_artefacts_no_query(test_client: TestClient, generator: DataGener
     data = response.json()
     artefacts = data["artefacts"]
 
-    # Should contain our created artefacts
     assert artefact1.name in artefacts
     assert artefact2.name in artefacts
 
@@ -54,7 +52,6 @@ def test_search_artefacts_with_query(test_client: TestClient, generator: DataGen
     """Test searching with query filters results"""
     unique_marker = uuid.uuid4().hex[:8]
 
-    # Create artefacts with specific patterns
     target_artefact = generator.gen_artefact(name=f"special_search_{unique_marker}")
     other_artefact = generator.gen_artefact(name=f"other_artefact_{unique_marker}")
 
@@ -65,7 +62,6 @@ def test_search_artefacts_with_query(test_client: TestClient, generator: DataGen
     data = response.json()
     artefacts = data["artefacts"]
 
-    # Should only find the target artefact
     assert target_artefact.name in artefacts
     assert other_artefact.name not in artefacts
 
@@ -79,7 +75,6 @@ def test_search_artefacts_case_insensitive(
 
     generator.gen_artefact(name=artefact_name)
 
-    # Search with different cases
     for search_term in ["mixedcase", "MIXEDCASE", "MixedCase"]:
         response = test_client.get(f"/v1/artefacts/search?q={search_term}")
         assert response.status_code == 200
@@ -96,7 +91,6 @@ def test_search_artefacts_partial_match(
 
     generator.gen_artefact(name=artefact_name)
 
-    # Search with partial term
     response = test_client.get("/v1/artefacts/search?q=desktop")
 
     assert response.status_code == 200
@@ -109,7 +103,6 @@ def test_search_artefacts_pagination(test_client: TestClient, generator: DataGen
     unique_marker = uuid.uuid4().hex[:8]
     names = []
 
-    # Create 10 artefacts
     for i in range(10):
         name = f"paginated_artefact_{unique_marker}_{i:02d}"
         generator.gen_artefact(name=name)
@@ -171,7 +164,6 @@ def test_search_artefacts_strips_whitespace(
 
     generator.gen_artefact(name=artefact_name)
 
-    # Search with extra whitespace
     response = test_client.get("/v1/artefacts/search?q=  whitespace_test  ")
     assert response.status_code == 200
     artefacts = response.json()["artefacts"]
@@ -184,10 +176,8 @@ def test_search_artefacts_excludes_archived(
     """Test that archived artefacts are excluded from search"""
     unique_marker = uuid.uuid4().hex[:8]
 
-    # Create active artefact
     active_artefact = generator.gen_artefact(name=f"active_artefact_{unique_marker}")
 
-    # Create archived artefact
     archived_artefact = generator.gen_artefact(
         name=f"archived_artefact_{unique_marker}", archived=True
     )
@@ -197,7 +187,6 @@ def test_search_artefacts_excludes_archived(
     assert response.status_code == 200
     artefacts = response.json()["artefacts"]
 
-    # Active should be included, archived should not
     assert active_artefact.name in artefacts
     assert archived_artefact.name not in artefacts
 
@@ -208,7 +197,6 @@ def test_search_artefacts_default_limit(
     """Test that default limit is 50"""
     unique_marker = uuid.uuid4().hex[:8]
 
-    # Create 60 artefacts
     for i in range(60):
         generator.gen_artefact(name=f"limit_test_{unique_marker}_{i:03d}")
 
@@ -217,4 +205,4 @@ def test_search_artefacts_default_limit(
     assert response.status_code == 200
     artefacts = response.json()["artefacts"]
     assert len(artefacts) <= 50
-    assert len(artefacts) == 50  # exactly 50 when >=50 exist
+    assert len(artefacts) == 50

--- a/backend/tests/controllers/artefacts/test_artefacts_search.py
+++ b/backend/tests/controllers/artefacts/test_artefacts_search.py
@@ -1,0 +1,220 @@
+# Copyright (C) 2023 Canonical Ltd.
+#
+# This file is part of Test Observer Backend.
+#
+# Test Observer Backend is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# Test Observer Backend is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import uuid
+from fastapi.testclient import TestClient
+from tests.data_generator import DataGenerator
+
+
+def generate_unique_name(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+def test_search_artefacts_endpoint_exists(test_client: TestClient):
+    """Test that the search endpoint exists and returns proper format"""
+    response = test_client.get("/v1/artefacts/search")
+    assert response.status_code == 200
+    data = response.json()
+    assert "artefacts" in data
+    assert isinstance(data["artefacts"], list)
+
+
+def test_search_artefacts_no_query(test_client: TestClient, generator: DataGenerator):
+    """Test searching without query returns all artefacts"""
+    # Create some artefacts
+    unique_marker = uuid.uuid4().hex[:8]
+    artefact1 = generator.gen_artefact(name=f"test_artefact_1_{unique_marker}")
+    artefact2 = generator.gen_artefact(name=f"test_artefact_2_{unique_marker}")
+
+    response = test_client.get("/v1/artefacts/search")
+
+    assert response.status_code == 200
+    data = response.json()
+    artefacts = data["artefacts"]
+
+    # Should contain our created artefacts
+    assert artefact1.name in artefacts
+    assert artefact2.name in artefacts
+
+
+def test_search_artefacts_with_query(test_client: TestClient, generator: DataGenerator):
+    """Test searching with query filters results"""
+    unique_marker = uuid.uuid4().hex[:8]
+
+    # Create artefacts with specific patterns
+    target_artefact = generator.gen_artefact(name=f"special_search_{unique_marker}")
+    other_artefact = generator.gen_artefact(name=f"other_artefact_{unique_marker}")
+
+    # Search for the specific pattern
+    response = test_client.get("/v1/artefacts/search?q=special_search")
+
+    assert response.status_code == 200
+    data = response.json()
+    artefacts = data["artefacts"]
+
+    # Should only find the target artefact
+    assert target_artefact.name in artefacts
+    assert other_artefact.name not in artefacts
+
+
+def test_search_artefacts_case_insensitive(
+    test_client: TestClient, generator: DataGenerator
+):
+    """Test that search is case-insensitive"""
+    unique_marker = uuid.uuid4().hex[:8]
+    artefact_name = f"MixedCase_Artefact_{unique_marker}"
+
+    generator.gen_artefact(name=artefact_name)
+
+    # Search with different cases
+    for search_term in ["mixedcase", "MIXEDCASE", "MixedCase"]:
+        response = test_client.get(f"/v1/artefacts/search?q={search_term}")
+        assert response.status_code == 200
+        artefacts = response.json()["artefacts"]
+        assert artefact_name in artefacts
+
+
+def test_search_artefacts_partial_match(
+    test_client: TestClient, generator: DataGenerator
+):
+    """Test that search supports partial matching"""
+    unique_marker = uuid.uuid4().hex[:8]
+    artefact_name = f"ubuntu_desktop_{unique_marker}"
+
+    generator.gen_artefact(name=artefact_name)
+
+    # Search with partial term
+    response = test_client.get("/v1/artefacts/search?q=desktop")
+
+    assert response.status_code == 200
+    artefacts = response.json()["artefacts"]
+    assert artefact_name in artefacts
+
+
+def test_search_artefacts_pagination(test_client: TestClient, generator: DataGenerator):
+    """Test that pagination works correctly"""
+    unique_marker = uuid.uuid4().hex[:8]
+    names = []
+
+    # Create 10 artefacts
+    for i in range(10):
+        name = f"paginated_artefact_{unique_marker}_{i:02d}"
+        generator.gen_artefact(name=name)
+        names.append(name)
+
+    expected_sorted = sorted(names)
+
+    # Get first page
+    response = test_client.get(
+        f"/v1/artefacts/search?q=paginated_artefact_{unique_marker}&limit=3&offset=0"
+    )
+    assert response.status_code == 200
+    page1 = response.json()["artefacts"]
+    assert len(page1) == 3
+    assert page1 == expected_sorted[0:3]
+
+    # Get second page
+    response = test_client.get(
+        f"/v1/artefacts/search?q=paginated_artefact_{unique_marker}&limit=3&offset=3"
+    )
+    assert response.status_code == 200
+    page2 = response.json()["artefacts"]
+    assert len(page2) == 3
+    assert page2 == expected_sorted[3:6]
+
+
+def test_search_artefacts_limit_validation(test_client: TestClient):
+    """Test that limit parameter is validated"""
+    # Test maximum limit
+    response = test_client.get("/v1/artefacts/search?limit=1001")
+    assert response.status_code == 422
+
+    # Test minimum limit
+    response = test_client.get("/v1/artefacts/search?limit=0")
+    assert response.status_code == 422
+
+
+def test_search_artefacts_offset_validation(test_client: TestClient):
+    """Test that offset parameter is validated"""
+    # Test negative offset
+    response = test_client.get("/v1/artefacts/search?offset=-1")
+    assert response.status_code == 422
+
+
+def test_search_artefacts_empty_result(test_client: TestClient):
+    """Test that search with no results returns empty list"""
+    response = test_client.get("/v1/artefacts/search?q=nonexistent_artefact_xyz_123")
+
+    assert response.status_code == 200
+    assert response.json()["artefacts"] == []
+
+
+def test_search_artefacts_strips_whitespace(
+    test_client: TestClient, generator: DataGenerator
+):
+    """Test that search query strips leading/trailing whitespace"""
+    unique_marker = uuid.uuid4().hex[:8]
+    artefact_name = f"whitespace_test_{unique_marker}"
+
+    generator.gen_artefact(name=artefact_name)
+
+    # Search with extra whitespace
+    response = test_client.get("/v1/artefacts/search?q=  whitespace_test  ")
+    assert response.status_code == 200
+    artefacts = response.json()["artefacts"]
+    assert artefact_name in artefacts
+
+
+def test_search_artefacts_excludes_archived(
+    test_client: TestClient, generator: DataGenerator
+):
+    """Test that archived artefacts are excluded from search"""
+    unique_marker = uuid.uuid4().hex[:8]
+
+    # Create active artefact
+    active_artefact = generator.gen_artefact(name=f"active_artefact_{unique_marker}")
+
+    # Create archived artefact
+    archived_artefact = generator.gen_artefact(
+        name=f"archived_artefact_{unique_marker}", archived=True
+    )
+
+    response = test_client.get(f"/v1/artefacts/search?q=artefact_{unique_marker}")
+
+    assert response.status_code == 200
+    artefacts = response.json()["artefacts"]
+
+    # Active should be included, archived should not
+    assert active_artefact.name in artefacts
+    assert archived_artefact.name not in artefacts
+
+
+def test_search_artefacts_default_limit(
+    test_client: TestClient, generator: DataGenerator
+):
+    """Test that default limit is 50"""
+    unique_marker = uuid.uuid4().hex[:8]
+
+    # Create 60 artefacts
+    for i in range(60):
+        generator.gen_artefact(name=f"limit_test_{unique_marker}_{i:03d}")
+
+    response = test_client.get(f"/v1/artefacts/search?q=limit_test_{unique_marker}")
+
+    assert response.status_code == 200
+    artefacts = response.json()["artefacts"]
+    assert len(artefacts) <= 50
+    assert len(artefacts) == 50  # exactly 50 when >=50 exist

--- a/frontend/lib/models/test_results_filters.dart
+++ b/frontend/lib/models/test_results_filters.dart
@@ -28,6 +28,7 @@ abstract class TestResultsFilters with _$TestResultsFilters {
   const TestResultsFilters._();
   const factory TestResultsFilters({
     @Default([]) List<String> families,
+    @Default([]) List<String> artefacts,
     @Default([]) List<String> environments,
     @JsonKey(name: 'test_cases') @Default([]) List<String> testCases,
     @JsonKey(name: 'template_ids') @Default([]) List<String> templateIds,
@@ -58,6 +59,7 @@ abstract class TestResultsFilters with _$TestResultsFilters {
     }
 
     final families = parseParam(parameters['families']);
+    final artefacts = parseParam(parameters['artefacts']);
     final environments = parseParam(parameters['environments']);
     final testCases = parseParam(parameters['test_cases']);
     final templateIds = parseParam(parameters['template_ids']);
@@ -83,6 +85,7 @@ abstract class TestResultsFilters with _$TestResultsFilters {
 
     return TestResultsFilters(
       families: families,
+      artefacts: artefacts,
       environments: environments,
       testCases: testCases,
       templateIds: templateIds,
@@ -99,6 +102,9 @@ abstract class TestResultsFilters with _$TestResultsFilters {
     final params = <String, List<String>>{};
     if (families.isNotEmpty) {
       params['families'] = families;
+    }
+    if (artefacts.isNotEmpty) {
+      params['artefacts'] = artefacts;
     }
     if (environments.isNotEmpty) {
       params['environments'] = environments;
@@ -132,6 +138,7 @@ abstract class TestResultsFilters with _$TestResultsFilters {
 
   bool get hasFilters =>
       families.isNotEmpty ||
+      artefacts.isNotEmpty ||
       environments.isNotEmpty ||
       testCases.isNotEmpty ||
       templateIds.isNotEmpty ||

--- a/frontend/lib/providers/test_results_artefacts.dart
+++ b/frontend/lib/providers/test_results_artefacts.dart
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Canonical Ltd.
+//
+// This file is part of Test Observer Frontend.
+//
+// Test Observer Frontend is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+//
+// Test Observer Frontend is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'api.dart';
+
+part 'test_results_artefacts.g.dart';
+
+@riverpod
+Future<List<String>> suggestedArtefacts(Ref ref, String query) async {
+  // Only search if query is long enough
+  if (query.trim().length < 2) {
+    return [];
+  }
+
+  final api = ref.watch(apiProvider);
+  return await api.searchArtefacts(query: query.trim(), limit: 50);
+}

--- a/frontend/lib/repositories/api_repository.dart
+++ b/frontend/lib/repositories/api_repository.dart
@@ -217,6 +217,27 @@ class ApiRepository {
     return EnvironmentReview.fromJson(response.data);
   }
 
+  Future<List<String>> searchArtefacts({
+    String? query,
+    int limit = 50,
+    int offset = 0,
+  }) async {
+    final queryParams = <String, dynamic>{
+      'limit': limit,
+      'offset': offset,
+    };
+
+    if (query != null && query.trim().isNotEmpty) {
+      queryParams['q'] = query.trim();
+    }
+
+    final response =
+        await dio.get('/v1/artefacts/search', queryParameters: queryParams);
+    final Map<String, dynamic> data = response.data;
+    final List<dynamic> artefacts = data['artefacts'] ?? [];
+    return artefacts.cast<String>();
+  }
+
   Future<List<String>> searchEnvironments({
     String? query,
     int limit = 50,

--- a/frontend/lib/ui/issue_page/issue_page_body.dart
+++ b/frontend/lib/ui/issue_page/issue_page_body.dart
@@ -100,6 +100,7 @@ class _IssuePageBodyState extends ConsumerState<IssuePageBody> {
             onApplyFilters: _updateFilters,
             enabledFilters: const {
               FilterType.families,
+              FilterType.artefacts,
               FilterType.environments,
               FilterType.testCases,
               FilterType.dateRange,

--- a/frontend/lib/ui/test_results_page/test_results_filters_view.dart
+++ b/frontend/lib/ui/test_results_page/test_results_filters_view.dart
@@ -25,12 +25,14 @@ import '../../models/test_results_filters.dart';
 import '../../providers/test_results_environments.dart';
 import '../../providers/test_results_test_cases.dart';
 import '../../providers/execution_metadata.dart';
+import '../../providers/test_results_artefacts.dart';
 import '../page_filters/multi_select_combobox.dart';
 import '../page_filters/date_time_selector.dart';
 import '../spacing.dart';
 
 enum FilterType {
   families,
+  artefacts,
   environments,
   testCases,
   templateIds,
@@ -125,6 +127,30 @@ class _TestResultsFiltersViewState
                   _selectedFilters = _selectedFilters.copyWith(
                     families: [
                       ..._selectedFilters.families.where((f) => f != val),
+                      if (isSelected) val,
+                    ],
+                  );
+                  _notifyChanged(_selectedFilters);
+                });
+              },
+            ),
+          ),
+        if (_isFilterEnabled(FilterType.artefacts))
+          _box(
+            MultiSelectCombobox(
+              title: 'Artefact',
+              allOptions: const [],
+              initialSelected: _selectedFilters.artefacts.toSet(),
+              asyncSuggestionsCallback: (pattern) async {
+                return await ref
+                    .read(suggestedArtefactsProvider(pattern).future);
+              },
+              minCharsForAsyncSearch: 2,
+              onChanged: (val, isSelected) {
+                setState(() {
+                  _selectedFilters = _selectedFilters.copyWith(
+                    artefacts: [
+                      ..._selectedFilters.artefacts.where((a) => a != val),
                       if (isSelected) val,
                     ],
                   );


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR adds the artefact filter to the test results page. For the solution I created the artefact search endpoint `GET v1/artefacts/search` and updated `GET v1/test-results` so it accepts artefact filtering. Then, I created the filter's provider and integrated it to the frontend views.

Upon merging this PR, the test results page will have all filters we intended to include so far. 

## Resolved issues
[TO-186](https://warthogs.atlassian.net/browse/TO-186)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes
Added search endpoint with pagination `GET v1/artefacts/search`:

<img width="1672" height="1218" alt="image" src="https://github.com/user-attachments/assets/6b492580-f7a6-4290-872d-6a7237cdf9ab" />

Modified `GET v1/test-results` such that artefacts are now available as a filter option:

<img width="1672" height="1123" alt="image" src="https://github.com/user-attachments/assets/e548944c-a127-4806-816d-630942d43cf3" />

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Backend: I've added pytests that tests the new endpoint and tests that ensure test results are working properly with the new endpoint. 

Frontend: Integration tests + localhost. I advise reviewers to point to this branch and test it out on their local machines as well. 

[TO-186]: https://warthogs.atlassian.net/browse/TO-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ