### PR TITLE
Fix README to use correct flag with `spread`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To debug the charm integration tests, you can jump into a `spread` provided envi
 
 ```bash
 # open a shell to the execution environment _before_ executing each test task 
-charmcraft.spread -v -shell lxd 
+charmcraft.spread -v -shell-before lxd 
 
 # open a shell to the execution environment _instead of_ executing each test task 
 charmcraft.spread -v -shell lxd


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

The README provides the following snippet

```bash
# open a shell to the execution environment _before_ executing each test task 
charmcraft.spread -v -shell lxd 

# open a shell to the execution environment _instead of_ executing each test task 
charmcraft.spread -v -shell lxd

# open a shell to the execution environment _after_ of executing each test task 
charmcraft.spread -v -shell-after lxd
```

The commands for before and instead of are the same. The output of `charmcraft.spead -help` provides the following

```
  -shell
    	Run shell instead of task scripts
  -shell-after
    	Run shell after task scripts
  -shell-before
    	Run shell before task scripts
```

Based on that output, I have updated the README to use `-shell-before`