### PR TITLE
Add parent epic to jira sync

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -29,7 +29,7 @@ settings:
   sync_comments: true
   
   # (Optional) (Default: None) Parent Epic key to link the issue to
-  # epic_key: "MTC-296"
+  epic_key: "TO-188"
       
   # (Optional) Dictionary mapping GitHub issue labels to Jira issue types. 
   # If label on the issue is not in specified list, this issue will be created as a Bug


### PR DESCRIPTION
Adds [TO-188](https://warthogs.atlassian.net/browse/TO-188) (Test Observer UI Usability Improvements) as the default parent epic for issues here to be filed under.

[TO-188]: https://warthogs.atlassian.net/browse/TO-188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ