### PR TITLE
fix script to fetch openapi schema

### DIFF
--- a/backend/scripts/fetch_openapi_schema.sh
+++ b/backend/scripts/fetch_openapi_schema.sh
@@ -6,21 +6,11 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Go to backend directory (parent of scripts)
 cd "$SCRIPT_DIR/.."
 
-for i in {1..5}; do
-    tmpfile=$(mktemp)
-    if curl --silent --fail "http://localhost:30000/openapi.json" -o "$tmpfile"; then
-        jq < "$tmpfile" > schemata/openapi.json
-        echo "OpenAPI schema fetched and written to schemata/openapi.json"
-        success=true
-        rm "$tmpfile"
-        break
-    else
-        rm "$tmpfile"
-        sleep 1
-    fi
-done
-
-if [ -z "$success" ]; then
-    echo "Failed to fetch openapi.json after multiple attempts."
-    exit 1
+tmpfile=$(mktemp)
+if curl --silent --fail "http://localhost:30000/openapi.json" -o "$tmpfile"; then
+    jq < "$tmpfile" > schemata/openapi.json
+    echo "OpenAPI schema fetched and written to schemata/openapi.json"
+else
+    echo "Failed to fetch openapi.json"
 fi
+rm "$tmpfile"


### PR DESCRIPTION
## Description

The `fetch_openapi_schema.sh` script doesn't currently work because of the `--head` argument. Also, it sets up a local server before fetching the schema, and stages the changes in git.

This PR removes the `--head` argument, the setting up of a local server (i.e., assumes the user has the server running local as per `README.md` instructions) and the staging of the changes.