### PR TITLE
[TO-237] Fix the integration task in spread

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -3,6 +3,7 @@ kill-timeout: 90m
 workers: 1
 
 environment:
+  CI: "$(HOST: echo $CI)"
   CONCIERGE_JUJU_CHANNEL: 3.6/stable
 
 backends:
@@ -108,7 +109,9 @@ prepare: |
   chown $(id -u):$(id -g) $PWD/frontend/charm/test-observer-frontend_ubuntu-22.04-amd64.charm
 
 restore: |
-  concierge restore --trace
-  apt autoremove -y --purge
-  rm -Rf "$SPREAD_PATH"
-  mkdir -p "$SPREAD_PATH"
+  if [[ -z "${CI:-}" ]]; then
+    concierge restore --trace
+    apt autoremove -y --purge
+    rm -Rf "$SPREAD_PATH"
+    mkdir -p "$SPREAD_PATH"
+  fi

--- a/spread/integration/task.yaml
+++ b/spread/integration/task.yaml
@@ -37,6 +37,8 @@ execute: |
   juju ssh --container postgresql db/leader "PGPASSWORD=$PGPASSWORD PGHOST=$PGHOST PGUSER=$PGUSER PGDATABASE=$PGDATABASE psql -c \"select launchpad_handle from app_user where email='omar.selo@canonical.com'\"" | grep omar-selo
 
 restore: |
-  # The testing model is created by concierge
-  juju destroy-model testing --destroy-storage --force --no-prompt --no-wait
-  juju add-model testing
+  if [[ -z "${CI:-}" ]]; then
+    # The testing model is created by concierge
+    juju destroy-model testing --destroy-storage --force --no-prompt --no-wait
+    juju add-model testing
+  fi


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

The integration test workflow would always fail. An example run is [here](https://github.com/canonical/test_observer/actions/runs/19497062613/job/55802024177).

There were a few issues:

1. The backend/API charm was not being configured with a `sessions_secret`, which is required. 
2. The SQL query was using an incorrect field for the email
3. The Juju snap no longer offers a 3.5/stable channel


## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

[TO-237](https://warthogs.atlassian.net/browse/TO-237)

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

I have run the spread tests locally, and we should see them pass in this PR.

[TO-237]: https://warthogs.atlassian.net/browse/TO-237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ