### PR TITLE
Fix failing mypy checks

### DIFF
--- a/backend/scripts/show_testcase_history.py
+++ b/backend/scripts/show_testcase_history.py
@@ -71,7 +71,7 @@ def get_previous_jenkins_submission_json_urls(url: str, count: int) -> list[str]
 
 
 def extract_build_number_from_jenkins_submission_json_url(url: str) -> int:
-    pattern = ".+/(\\d+)/artifact/artifacts/submission\\.json"
+    pattern = r".+/(\d+)/artifact/artifacts/submission\.json"
     match = re.match(pattern, url)
     if match is None:
         raise ValueError(f"Provided url {url} is not a valid jenkins submission url")
@@ -79,7 +79,7 @@ def extract_build_number_from_jenkins_submission_json_url(url: str) -> int:
 
 
 def extract_build_url_prefix_from_jenkins_submission_json_url(url: str) -> str:
-    pattern = "(.+/)\\d+/artifact/artifacts/submission\\.json"
+    pattern = r"(.+/)\d+/artifact/artifacts/submission\.json"
     match = re.match(pattern, url)
     if match is None:
         raise ValueError(f"Provided url {url} is not a valid jenkins submission url")

--- a/backend/test_observer/external_apis/archive.py
+++ b/backend/test_observer/external_apis/archive.py
@@ -78,7 +78,7 @@ class ArchiveManager:
 
         # Names of deb packages could have swapped '.' with '_'
         # So this regex is to allow such scenarios
-        name_regex = f"^{debname}$".replace("_", "[_\\.]")
+        name_regex = f"^{debname}$".replace("_", r"[_\.]")
 
         pkg_list = pkg_data.split("\n\n")
         for pkg in pkg_list:


### PR DESCRIPTION
## Description

The mypy checks for the backend always give warnings due to 3 regex strings without proper escape characters.

This PR solves the issue by making them into raw strings.

## Tests

Tested with `pytest` to ensure that no tests started to fail.
