### PR TITLE
Updated docker-compose.yml to work with podman and podman-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
         condition: service_healthy
 
   test-observer-db:
-    image: postgres:15
+    image: docker.io/postgres:15
     environment:
       POSTGRES_USER: test_observer_user
       POSTGRES_PASSWORD: test_observer_password
@@ -55,7 +55,7 @@ services:
       start_period: 30s
 
   saml-idp:
-    image: kristophjunge/test-saml-idp
+    image: docker.io/kristophjunge/test-saml-idp
     ports:
       - "8080:8080"
       - "8443:8443"


### PR DESCRIPTION
## Description

This is a minor tweak so that "podman compose up" will work when using podman and podman-compose instead of docker and docker-compose.

## Resolved issues

N/A

## Documentation

No changes made.  I could update the README to say e.g. docker/podman, but as podman is often used as a drop-in replacement for docker, I'm not sure if the noise is really desired.

## Web service API changes

N/A

## Tests

Ran "podman compose up", verified backend and frontend accessibility in a browser, and cleaned up via "podman compose down".