### PR TITLE
Corrected _search to use pagination

### DIFF
--- a/frontend/lib/providers/test_results_search.dart
+++ b/frontend/lib/providers/test_results_search.dart
@@ -86,6 +86,11 @@ class TestResultsSearch extends _$TestResultsSearch {
     if (!filters.hasFilters) {
       return TestResultsSearchResult.empty();
     }
-    return await api.searchTestResults(filters);
+    // Update filters with pagination
+    final updatedFilters = filters.copyWith(
+      limit: limit,
+      offset: offset,
+    );
+    return await api.searchTestResults(updatedFilters);
   }
 }


### PR DESCRIPTION
## Description

In _search (of frontend/lib/providers/test_results_search.dart), the offset and limit fields were passed in as arguments but never merged into the results filter before passing those filters to api.searchTestResults.  This results in no offset/limit being sent as part of the backend API requests, and thus the behavior where we would just repeat the same initial request.

All I did was add the missing parameters in.  Directly assigning them didn't work, but copyWith did allow me to do this.

## Resolved issues

Fixes https://github.com/canonical/test_observer/issues/410 and https://warthogs.atlassian.net/browse/TO-204.

## Documentation

Purely a bug fix; no change in documented behavior.

## Web service API changes

No backend API changes.

## Tests

This was tested locally by:

* Loading sufficient test data so that the search page would need to paginate.  The test data generated from backend/scripts/seed_data.py didn't provide enough C3TestResult objects, but I was able to fix this by tweaking that script and using a list comprehension to generate 200 or so objects.  (For example, find the EndTestExecutionRequest with ci_link of `"http://example2"`, and change the test_results field to use a list comprehension to generate 200 objects with unique names like `f"test{i}"`.)
* Removing any pre-existing podman volumes from previous runs.
* Running `podman compose down` to clean up previous runs.
* Running `podman compose up --build` to build up-to-date containers using the updated code and expanded test data.
* Connecting to [http://localhost:30001/#/test-results?families=snap,deb,charm,image](http://localhost:30001/#/test-results?families=snap,deb,charm,image), opening the network tab of Firefox devtools, and observing that offset/limit are now clearly being used.