### PR TITLE
[TO-251, GH-509] Add Test Execution IDs to search results

### DIFF
--- a/frontend/lib/ui/test_results_page/test_results_table.dart
+++ b/frontend/lib/ui/test_results_page/test_results_table.dart
@@ -147,8 +147,9 @@ class _TableDataRow extends StatelessWidget {
           Expanded(flex: 3, child: _ArtefactCell(artefact: artefact)),
           Expanded(flex: 4, child: _TestCaseCell(testResult: testResult)),
           Expanded(
-              flex: 3,
-              child: _TestExecutionIDCell(testExecutionID: testExecution.id)),
+            flex: 3,
+            child: _TestExecutionIDCell(testExecutionID: testExecution.id),
+          ),
           Expanded(flex: 2, child: _StatusCell(status: testResult.status)),
           Expanded(flex: 2, child: _TrackCell(artefact: artefact)),
           Expanded(flex: 3, child: _VersionCell(artefact: artefact)),


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

I updated the search results table to Test Execution IDs, which helps with keeping track of which results you have viewed.

Here is a screenshot before the change:
<img width="3302" height="1962" alt="test-observer-before-row-number" src="https://github.com/user-attachments/assets/ab12cd62-c667-44ef-a92c-b11365bc7b39" />

And here is a screenshot after the change:
<img width="3302" height="1962" alt="test-observer-after" src="https://github.com/user-attachments/assets/06562902-708f-4d9d-b39c-979f8f3ae4c4" />


## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

https://github.com/canonical/test_observer/issues/509
https://warthogs.atlassian.net/browse/TO-251

