### PR TITLE
feat: terraform: include service-hostname in nginx config

### DIFF
--- a/terraform/ps6/main.tf
+++ b/terraform/ps6/main.tf
@@ -10,6 +10,7 @@ resource "juju_application" "api_ingress" {
   }
 
   config = {
+    service-hostname       = var.api_hostname
     whitelist-source-range = var.nginx_ingress_integrator_charm_whitelist_source_range
   }
 }
@@ -26,6 +27,7 @@ resource "juju_application" "frontend_ingress" {
   }
 
   config = {
+    service-hostname       = var.frontend_hostname
     whitelist-source-range = var.nginx_ingress_integrator_charm_whitelist_source_range
   }
 }


### PR DESCRIPTION
This should allow proper certificates to be generated through LEGO.