### PR TITLE
Dockerfile reworks for reliability and faster rebuilds for non-flutter changes

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -18,7 +18,16 @@ WORKDIR /app
 # Disabling full copy of the immediate directory.  Before the Flutter build, let's *just* copy the files needed for Flutter.
 # This will minimize rebuilding of much of the Flutter code unless there is a true need for it.
 #COPY . /app
-COPY lib assets benchmarks integration_test test test_driver web analysis_options.yaml frontend.iml LICENSE .metadata pubspec.* run_benchmark_tests.dart run_integration_tests.sh .vscode /app/
+COPY lib /app/lib
+COPY assets /app/assets
+COPY benchmarks /app/benchmarks
+COPY integration_test /app/integration_test
+COPY test /app/test
+COPY test_driver /app/test_driver
+COPY web /app/web
+COPY .vscode /app/.vscode
+COPY analysis_options.yaml frontend.iml LICENSE .metadata pubspec.* run_benchmark_tests.dart run_integration_tests.sh /app/
+
 # NOTE: Skipping charm directory, as well as Docker and Git-related files
 
 RUN flutter pub get


### PR DESCRIPTION
## Description

This is a set of fairly small changes that are intended to improve frontend builds and provide a base for other potential improvements.

* The Dockerfile's "apt-get update" and "apt-get install" lines are now linked together as a joint step.  This avoids a podman/docker caching issue where an update to dependencies may require re-running the "apt-get install" line, but the preceding "apt-get update" line isn't reran as well, resulting in apt trying to pull older versions of packages which no longer exist in the repositories.
* To avoid triggering flutter source rebuilds, only the files needed by Flutter - or at least my best guess as to which files those are - are copied.  This results in a more verbose Dockerfile but avoids moving any existing files (as was attempted in #518).  This should allow for updates to the Dockerfile, nginx.conf, or other files which may be added without triggering a full rebuild of the Flutter app's sources via the `COPY . /app` step.

To be clear: yes, I would like to see us move away from Flutter for the UI as I see it having numerous weaknesses, primarily in relation to rendering to canvas rather than the DOM, and this minor restructuring makes it easier for us to do such experimentation.  But even if this were not to happen, I believe this PR's changes still offer some benefit.

## Related issues (not "resolved issues" in this case)

* [Test Observer experimental non-flutter rewrite work](https://warthogs.atlassian.net/browse/IQA-3353)

## Documentation

No changes; changes were restricted purely to the Dockerfile.

## Web service API changes

No changes; changes were restricted purely to the Dockerfile.

## Tests

I ran through `podman compose down` and `podman compose up`; it still works after these changes.