### PR TITLE
Update the license year to 2026

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -4,7 +4,7 @@ header:
     license:
       spdx-id: AGPL-3.0-only
       copyright-owner: Canonical Ltd.
-      copyright-year: 2023
+      copyright-year: 2026
       software-name: Test Observer Backend
       content: |
         Copyright (C) [year] [owner]
@@ -25,7 +25,7 @@ header:
     license:
       spdx-id: GPL-3.0-only
       copyright-owner: Canonical Ltd.
-      copyright-year: 2023
+      copyright-year: 2026
       software-name: Test Observer Frontend
       content: |
         Copyright (C) [year] [owner]
@@ -50,7 +50,7 @@ header:
     license:
       spdx-id: Apache-2.0
       copyright-owner: Canonical Ltd.
-      copyright-year: 2023
+      copyright-year: 2026
       software-name: Test Observer Backend Charm
   - paths:
       - "frontend/charm/src/**/*.py"
@@ -58,5 +58,5 @@ header:
     license:
       spdx-id: Apache-2.0
       copyright-owner: Canonical Ltd.
-      copyright-year: 2023
+      copyright-year: 2026
       software-name: Test Observer Frontend Charm


### PR DESCRIPTION
## Description
Copyright checker was stuck at 2023, moved it to 2026.

## Resolved issues
No specific issue, just an annoyance 

## Documentation

No change in docs

## Web service API changes
No change

## Tests
CI tests run and pass