### PR TITLE
Add view run button in test result's details dialog

### DIFF
--- a/frontend/lib/ui/test_results_page/test_results_details_dialog.dart
+++ b/frontend/lib/ui/test_results_page/test_results_details_dialog.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Canonical Ltd.
+// Copyright (C) 2026 Canonical Ltd.
 //
 // This file is part of Test Observer Frontend.
 //


### PR DESCRIPTION
## Description

Adds a near-copy of the "View Run" button and icon from the test results table to a result's "Details" dialog which will open the run in a new tab.

<img width="1368" height="1057" alt="Screenshot 2026-02-05 at 12 19 15" src="https://github.com/user-attachments/assets/af0c6139-7cfa-414c-a31c-d820cf01a065" />


## Resolved issues

Closes #482 

## Documentation

No changes to the documentation

## Web service API changes

No changes to the API

## Tests

See attached screenshot taken from a local deployment using seed data.
