### PR TITLE
Improve get_or_create function

### DIFF
--- a/backend/test_observer/data_access/repository.py
+++ b/backend/test_observer/data_access/repository.py
@@ -22,7 +22,7 @@ from typing import Any
 from pydantic import HttpUrl
 
 from sqlalchemy import and_, func
-from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
 
 from .models import Artefact, ArtefactBuild, DataModel, TestExecutionRelevantLink
@@ -153,15 +153,32 @@ def get_or_create(
     # <timestamp> ERROR:  duplicate key value violates unique constraint "<key>"
     # <timestamp> DETAIL:  Key (<key>)=(<value>) already exists.
 
-    # We now use `.on_conflict_do_nothing()` to avoid the error
-    # in the common case where the instance already exists
-    creation_kwargs = creation_kwargs or {}
-    values = {**filter_kwargs, **creation_kwargs}
-    statement = insert(model).values(**values).on_conflict_do_nothing()
-    db.execute(statement)
-    db.commit()
+    # We now check for the instance first to avoid this
+    instance = db.query(model).filter_by(**filter_kwargs).first()
+    if instance:
+        return instance
 
-    return db.query(model).filter_by(**filter_kwargs).one()
+    creation_kwargs = creation_kwargs or {}
+    instance = model(**filter_kwargs, **creation_kwargs)
+
+    # The instance did not exist when we queried,
+    # but it might have been created by another process before we try to add it.
+    # Thus, we still need to catch the IntegrityError
+    # and query for the instance in that case, but this should be much rarer
+    try:
+        # Attempt to add and commit the new instance
+        # Use a nested transaction to avoid rolling back the entire session
+        with db.begin_nested():
+            db.add(instance)
+            # Ensure the INSERT is executed immediately
+            # to catch IntegrityError here if it occurs
+            db.flush()
+        db.commit()
+    except IntegrityError:
+        # Query and return the existing instance
+        instance = db.query(model).filter_by(**filter_kwargs).one()
+
+    return instance
 
 
 def create_test_execution_relevant_link(

--- a/backend/tests/data_access/test_repository.py
+++ b/backend/tests/data_access/test_repository.py
@@ -17,7 +17,7 @@
 
 """Test services functions"""
 
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Query, Session
 
 from test_observer.data_access.repository import (
     create_test_execution_relevant_link,
@@ -28,6 +28,10 @@ from tests.data_generator import DataGenerator
 from test_observer.data_access.models import TestCase
 
 from pydantic import HttpUrl
+from pytest import MonkeyPatch
+from typing import TypeVar
+
+_T = TypeVar("_T")
 
 
 def test_create_test_execution_relevant_link(
@@ -79,7 +83,6 @@ def test_get_or_create_returns_existing(db_session: Session):
     )
 
     assert test_case.id == result.id
-    assert db_session.query(type(test_case)).count() == 1
 
 
 def test_get_or_create_creates_new(db_session: Session):
@@ -102,4 +105,55 @@ def test_get_or_create_creates_new(db_session: Session):
 
     assert result.id is not None
     assert result.name == test_case.name
-    assert db_session.query(type(test_case)).count() == 1
+
+
+def test_get_or_create_race_condition(
+    db_session: Session,
+    monkeypatch: MonkeyPatch,
+):
+    """
+    Test that get_or_create handles a race condition,
+    where another process creates the instance after we check for its existence
+    but before we try to create it.
+    """
+
+    # Arrange
+
+    # get_or_create calls query.first() to check if the instance exists,
+    # so we mock the first() method to return None,
+    # as if the instance did not exist
+    def mock_first(_: Query[_T]) -> None:
+        return None
+
+    monkeypatch.setattr(Query, "first", mock_first)
+
+    # We add the instance to the database to simulate another process creating it
+    test_case = TestCase(name="new", category="category")
+    db_session.add(test_case)
+    db_session.commit()
+
+    # We want to check that we raise the IntegrityError by checking calls to `one()`,
+    # which only happens in the exception handling
+    calls = {"one": 0}
+    one = Query.one
+
+    def mock_one(self: Query[_T]) -> _T:
+        calls["one"] += 1
+        return one(self)
+
+    monkeypatch.setattr(Query, "one", mock_one)
+
+    # Act
+
+    # Because of the way get_or_create attempts to create an instance,
+    # we must make sure every required field of the model is included
+    # in one of filter_kwargs or creation_kwargs
+    # for the case when the model doesn't exist
+    result = get_or_create(
+        db_session,
+        model=type(test_case),
+        filter_kwargs={"name": test_case.name, "category": test_case.category},
+    )
+
+    assert result.id == test_case.id
+    assert calls["one"] == 1


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

When investigating a database outage last week, I saw that the PostgreSQL logs were filled with noise about keys violating unique constraints. I then happened to notice the `get_or_create` function, which I believe is the source of the logs. If I understand things correctly, every single function call that deals with an existing entry with a unique constraint will hit the `IntegrityError`, and though we catch the error and handle it appropriately, I don't think that stops PostgreSQL from logging the error.

I believe the approach in this PR should vastly reduce the noise in the logs. It might be slightly less performant in the rare cases where an entry is created between the time of the initial query and the time of the attempted insert, but I believe it should be more performant in the much more frequent case that an entry already exists.

## Resolves

https://warthogs.atlassian.net/browse/IQA-3378

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Added unit tests
