### PR TITLE
frontend: use LP handle for submitting test results

### DIFF
--- a/frontend/lib/ui/artefact_page/test_result_dialog.dart
+++ b/frontend/lib/ui/artefact_page/test_result_dialog.dart
@@ -49,7 +49,7 @@ class _AddTestResultDialogState extends ConsumerState<AddTestResultDialog> {
 
   String _testNamePrefix() {
     final user = ref.read(currentUserProvider).valueOrNull;
-    final username = user?.name.trim() ?? '';
+    final username = user?.launchpadHandle?.trim() ?? '';
     return username.isEmpty ? '' : '$username - ';
   }
 


### PR DESCRIPTION
## Description

LP name is not guaranteed to be unique, and can very easily change over time. LP handle is a way safer way to keep track of who submitted what.

## Resolved issues

N/A, trivial change

## Documentation

N/A, trivial change

## Web service API changes

N/A

## Tests

`docker-compose build && docker-compose up`, then:
<img width="360" height="237" alt="image" src="https://github.com/user-attachments/assets/da6b98d8-21f8-4537-8f2b-f9e95b1a4c71" />
Mind the `certbot` string not being capitalized, because it's now the LP handle, and not the Name.