### PR TITLE
Feat: Shows number of artifacts

### DIFF
--- a/frontend/lib/ui/dashboard/dashboard_header/dashboard_header.dart
+++ b/frontend/lib/ui/dashboard/dashboard_header/dashboard_header.dart
@@ -48,8 +48,8 @@ class DashboardHeader extends ConsumerWidget {
             const SizedBox(width: Spacing.level4),
             Text(
               totalArtefacts.length == filteredCount
-                  ? '$filteredCount artefacts'
-                  : '$filteredCount of ${totalArtefacts.length} artefacts',
+                  ? '$filteredCount artifacts'
+                  : '$filteredCount of ${totalArtefacts.length} artifacts',
               style: Theme.of(context).textTheme.titleMedium?.copyWith(
                     color: Theme.of(context).colorScheme.onSurfaceVariant,
                   ),


### PR DESCRIPTION
**AI Use Disclosure**: This change was authored with assistance from AI. The code was reviewed, tested locally, and validated as much as possible.

## Description

When you're looking at a dashboard with potentially hundreds of artifacts and applying filters, there is no indication of how many items you are looking at or how your filters are narrowing results. This is a small but practical quality-of-life improvement that shows how many artifacts are on the page and how many are filteres.

<img width="1399" height="326" alt="image" src="https://github.com/user-attachments/assets/0a2f0599-4729-4673-91a7-10bf08f5c906" />

This pull request updates the `DashboardHeader` component to display artifact counts. The main changes include converting the widget to a `ConsumerWidget`, integrating providers for artifact data, and conditionally rendering the artifact count in the header.

* Converted `DashboardHeader` from a `StatelessWidget` to a `ConsumerWidget` to enable Riverpod-based state management and data access.
* Integrated `familyArtefactsProvider` and `filteredFamilyArtefactsProvider` to fetch and display the total and filtered artefact counts for the current family, based on the current route.
* Updated the UI to show the artefact count in the header, displaying either the total or the filtered count as appropriate.

## Resolved issues

- resolve issue #550 

## Documentation

So updated screenshots may be required.

## Web service API changes

- no API change

## Tests

- I ran `docker compose exec test-observer-api pytest` locally and it passed
- the PR check seems to be going well too

