### PR TITLE
Use context manager in celery tasks

### DIFF
--- a/backend/tasks/celery.py
+++ b/backend/tasks/celery.py
@@ -69,19 +69,24 @@ def setup_periodic_tasks(sender, **kwargs):  # noqa
 
 @app.task
 def integrate_with_kernel_swm():
-    db = SessionLocal()
-    swm_info = get_artefacts_swm_info()
-    update_artefacts_with_tracker_info(db, swm_info)
+    with SessionLocal() as db:
+        swm_info = get_artefacts_swm_info()
+        # update_artefacts_with_tracker_info calls db.commit()
+        update_artefacts_with_tracker_info(db, swm_info)
 
 
 @app.task
 def run_promote_artefacts():
-    promote_artefacts(SessionLocal())
+    with SessionLocal() as db:
+        # The underlying functions called in promoote_artefacts call db.commit()
+        promote_artefacts(db)
 
 
 @app.task
 def clean_user_sessions():
-    delete_expired_user_sessions(SessionLocal())
+    with SessionLocal() as db:
+        # delete_expired_user_sessions calls db.commit()
+        delete_expired_user_sessions(db)
 
 
 # @app.task


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR uses a context manager for the periodic celery tasks, so that database connections are closed. We are currently seeing many connections sit in an `idle` state, which I think may be in large part because of these periodic tasks that don't seem to close their connections.

## Resolved issues

I think this will help reduce database connection exhaustion.