### PR TITLE
Add SQL event listener

### DIFF
--- a/backend/test_observer/data_access/setup.py
+++ b/backend/test_observer/data_access/setup.py
@@ -39,19 +39,21 @@ SessionLocal = sessionmaker(
 
 DBAPIParameters = dict[Any, Any] | tuple[Any] | list[Any] | None
 
+
 # https://docs.sqlalchemy.org/en/20/core/events.html#sqlalchemy.events.ConnectionEvents.before_cursor_execute
 # retval=True is needed to actually modify the statement
 @listens_for(engine, "before_cursor_execute", retval=True)
 def tag_sql_with_origin(
-    conn: Connection,
-    cursor: DBAPICursor,
+    _conn: Connection,
+    _cursor: DBAPICursor,
     statement: str,
     parameters: DBAPIParameters,
-    context: ExecutionContext,
-    executemany: bool
+    _context: ExecutionContext,
+    _executemany: bool,
 ) -> tuple[str, DBAPIParameters]:
     """
-    This event listener tags each SQL statement with a comment containing the stack trace of where the query originated.
+    This event listener tags each SQL statement with a comment
+    containing the stack trace of where the query originated.
     """
 
     stack = traceback.extract_stack()
@@ -71,6 +73,7 @@ def tag_sql_with_origin(
         statement = f"/* Origin: {origin} */ " + statement
 
     return statement, parameters
+
 
 # Dependency
 def get_db():


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR introduces an event listener that tags SQL queries with the file and function they originate from, if the origin is within the Test Observer code, which should help identify where idle transactions are coming from.

This will probably have some performance implications, so we may want to put this behind some sort of feature flag (environment variable) or otherwise expect to revert this after we have identified the source of issues.

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

I tested manually, both by using `echo=True` in the engine creation, and also changing the `docker-compose.yml` file to update the `test-observer-db` service with

```
    command:
      - "postgres"
      - "-c"
      - "log_statement=all" # Log all SQL statements for debugging
```

In production, we don't log all statements, but we do now log long-running ones, so we should still get the benefit. Here is an example Postgres log from local testing, captured with `docker compose logs test-observer-db`

```
test-observer-db-1  | 2026-02-17 21:27:05.861 UTC [1940] LOG:  execute <unnamed>: /* Origin: metrics_initializer.py:_initialize_test_results_metric */ SELECT artefact.family AS artefact_family, artefact.name AS artefact_name, artefact.stage AS artefact_stage, artefact.track AS artefact_track, artefact.series AS artefact_series, artefact.os AS artefact_os, environment.name AS environment_name, test_plan.name AS test_plan, test_case.name AS test_name, test_result.status AS test_result_status, count(*) AS cnt 
test-observer-db-1  | 	FROM test_result JOIN test_execution ON test_result.test_execution_id = test_execution.id JOIN test_case ON test_result.test_case_id = test_case.id JOIN test_plan ON test_execution.test_plan_id = test_plan.id JOIN environment ON test_execution.environment_id = environment.id JOIN artefact_build ON test_execution.artefact_build_id = artefact_build.id JOIN artefact ON artefact_build.artefact_id = artefact.id 
test-observer-db-1  | 	WHERE test_result.created_at > $1::TIMESTAMP WITHOUT TIME ZONE GROUP BY artefact.family, artefact.name, artefact.stage, artefact.track, artefact.series, artefact.os, environment.name, test_plan.name, test_case.name, test_result.status
test-observer-db-1  | 2026-02-17 21:27:05.861 UTC [1940] DETAIL:  parameters: $1 = '2026-01-18 21:27:05.814837'
```