### PR TITLE
Use eager loading for TestExecutions

### DIFF
--- a/backend/test_observer/controllers/test_executions/test_execution.py
+++ b/backend/test_observer/controllers/test_executions/test_execution.py
@@ -39,7 +39,7 @@ from .models import TestExecutionsPatchRequest
 router = APIRouter()
 
 TEST_EXECUTION_OPTIONS = [
-    # 1. Single-query Joins (Many-to-One)
+    # Single-query Joins (Many-to-One)
     joinedload(TestExecution.environment),
     joinedload(TestExecution.rerun_request),
     joinedload(TestExecution.test_plan),


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR eagerly loads values we know we will need when fetching `TestExecution`s. This prevents Pydantic from needing to lazily load them later, which makes multiple additional queries that are untagged by the event listener added in https://github.com/canonical/test_observer/pull/574. This may have a performance bonus as well, as with one example in the seed data, I see 8 queries get reduced to 5.

The `TestExecutionResponse` model makes no reference to `ArtefactBuild` or `Artefact`, so the patch method was needlessly pulling those in before.

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

I've manually tested that example query results before and after these changes are the same, and I believe unit tests already cover these functions.