### PR TITLE
Eager load TestExecution in Artefact builds

### DIFF
--- a/backend/test_observer/controllers/artefacts/builds.py
+++ b/backend/test_observer/controllers/artefacts/builds.py
@@ -20,11 +20,12 @@ from sqlalchemy.orm import selectinload
 
 from test_observer.common.permissions import Permission, permission_checker
 from test_observer.controllers.artefacts.artefact_retriever import ArtefactRetriever
+from test_observer.controllers.test_executions.test_execution import (
+    TEST_EXECUTION_OPTIONS,
+)
 from test_observer.data_access.models import (
     Artefact,
     ArtefactBuild,
-    TestExecution,
-    TestResult,
 )
 
 from .models import (
@@ -44,14 +45,7 @@ def get_artefact_builds(
         ArtefactRetriever(
             selectinload(Artefact.builds)
             .selectinload(ArtefactBuild.test_executions)
-            .options(
-                selectinload(TestExecution.environment),
-                selectinload(TestExecution.rerun_request),
-                selectinload(TestExecution.relevant_links),
-                selectinload(TestExecution.test_results).selectinload(
-                    TestResult.issue_attachments
-                ),
-            )
+            .options(*TEST_EXECUTION_OPTIONS)
         )
     ),
 ):


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

As a follow-up to https://github.com/canonical/test_observer/pull/577, I saw a few more instances of untagged queries, which I was able to trace to lazy loading in the artefact builds endpoint, so I added the eager loading there as well. 

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Manual tests show that GET requests to `v1/artefacts/{id}/builds` previously resulted in untagged and slow queries. They are now tagged. Automated tests already cover this function