### PR TITLE
Reduce connection pool size

### DIFF
--- a/backend/test_observer/data_access/setup.py
+++ b/backend/test_observer/data_access/setup.py
@@ -29,7 +29,7 @@ from sqlalchemy.orm import sessionmaker
 DEFAULT_DB_URL = "postgresql+pg8000://postgres:password@test-observer-db:5432/postgres"
 DB_URL = environ.get("DB_URL", DEFAULT_DB_URL)
 
-engine = create_engine(DB_URL, pool_size=45, max_overflow=45)
+engine = create_engine(DB_URL, pool_size=10, max_overflow=20)
 SessionLocal = sessionmaker(
     autocommit=False,
     autoflush=False,


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

The current connection pool size looks targeted for a single unit, but is capable of saturating the default PostgreSQL connection limit of 100 when there are multiple units. With a single unit, it caps at 90 connections, leaving 10 connections reserved. But with three units, where each unit can create up 90 connections, and will happily create and leave up to 45 connections open each, we can attempt to create up to 135 idle connections (and 270 maximum connections), which Postgres will kill with complaints about no available connections.

A pool size of 10 with overflow of 20 will cap at 30 connections, so with three workers, we return to 90 max connections with 10 reserved.