### PR TITLE
make entire page scrollable instead of just the table

### DIFF
--- a/frontend/lib/ui/test_results_page/test_results_body.dart
+++ b/frontend/lib/ui/test_results_page/test_results_body.dart
@@ -25,30 +25,36 @@ import '../spacing.dart';
 import 'test_results_table.dart';
 
 class TestResultsBody extends ConsumerStatefulWidget {
-  const TestResultsBody({super.key, required this.filters});
+  const TestResultsBody({
+    super.key,
+    required this.filters,
+    required this.scrollController,
+  });
 
   final TestResultsFilters filters;
+  final ScrollController scrollController;
 
   @override
   ConsumerState<TestResultsBody> createState() => _TestResultsBodyState();
 }
 
 class _TestResultsBodyState extends ConsumerState<TestResultsBody> {
-  final ScrollController _scrollController = ScrollController();
   bool _isLoadingMore = false;
   TestResultsFilters? _lastProcessedFilters;
 
   @override
   void initState() {
     super.initState();
-
-    _scrollController.addListener(_onScroll);
+    widget.scrollController.addListener(_onScroll);
   }
 
   @override
   void didUpdateWidget(TestResultsBody oldWidget) {
     super.didUpdateWidget(oldWidget);
-    // Handle URI changes
+    if (oldWidget.scrollController != widget.scrollController) {
+      oldWidget.scrollController.removeListener(_onScroll);
+      widget.scrollController.addListener(_onScroll);
+    }
     if (oldWidget.filters != widget.filters) {
       _handleFiltersChange();
     }
@@ -56,13 +62,12 @@ class _TestResultsBodyState extends ConsumerState<TestResultsBody> {
 
   @override
   void dispose() {
-    _scrollController.removeListener(_onScroll);
-    _scrollController.dispose();
+    widget.scrollController.removeListener(_onScroll);
     super.dispose();
   }
 
   void _onScroll() {
-    if (_scrollController.position.extentAfter < 800) {
+    if (widget.scrollController.position.extentAfter < 800) {
       _maybeLoadMore();
     }
   }
@@ -185,33 +190,6 @@ class _TestResultsBodyState extends ConsumerState<TestResultsBody> {
     final count = data.count;
     final testResults = data.testResults;
 
-    if (testResults.isEmpty) {
-      return Center(
-        child: Padding(
-          padding: const EdgeInsets.only(
-            bottom: Spacing.level6 * 4,
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const Icon(Icons.search_off, size: 64, color: Colors.grey),
-              const SizedBox(height: Spacing.level4),
-              Text(
-                'No results found',
-                style: Theme.of(context).textTheme.headlineSmall,
-              ),
-              const SizedBox(height: Spacing.level2),
-              const Text(
-                'Try adjusting your filters or search criteria.',
-                textAlign: TextAlign.center,
-              ),
-            ],
-          ),
-        ),
-      );
-    }
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -232,28 +210,7 @@ class _TestResultsBodyState extends ConsumerState<TestResultsBody> {
           ],
         ),
         const SizedBox(height: Spacing.level3),
-        Expanded(
-          child: NotificationListener<ScrollNotification>(
-            onNotification: (ScrollNotification scrollInfo) {
-              final screenHeight = MediaQuery.of(context).size.height;
-              // Load more naturally when the scroll is at the bottom
-              if (scrollInfo.metrics.extentAfter < screenHeight * 0.5) {
-                _maybeLoadMore();
-              }
-              return false;
-            },
-            child: CustomScrollView(
-              controller: _scrollController,
-              slivers: [
-                SliverToBoxAdapter(
-                  child: TestResultsTable(
-                    testResults: testResults,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
+        TestResultsTable(testResults: testResults),
       ],
     );
   }

--- a/frontend/lib/ui/test_results_page/test_results_page.dart
+++ b/frontend/lib/ui/test_results_page/test_results_page.dart
@@ -37,6 +37,13 @@ class _TestResultsPageState extends ConsumerState<TestResultsPage> {
   bool showFilters = true;
   late TestResultsFilters appliedFilters;
   bool filtersModified = false;
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
 
   void _onApplyFilters(TestResultsFilters filters) {
     context.go(filters.toTestResultsUri().toString());
@@ -56,47 +63,51 @@ class _TestResultsPageState extends ConsumerState<TestResultsPage> {
     final uri = AppRoutes.uriFromContext(context);
     appliedFilters = TestResultsFilters.fromQueryParams(uri.queryParametersAll);
 
-    return Padding(
-      padding: const EdgeInsets.only(
-        left: Spacing.pageHorizontalPadding,
-        right: Spacing.pageHorizontalPadding,
-        top: Spacing.level5,
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        spacing: Spacing.level4,
-        children: [
-          Row(
-            children: [
-              Text(
-                'Search Test Results',
-                style: Theme.of(context).textTheme.headlineLarge,
-              ),
-              const Spacer(),
-              YaruOptionButton(
-                child: const Icon(Icons.filter_alt),
-                onPressed: () {
-                  setState(() {
-                    showFilters = !showFilters;
-                  });
-                },
-              ),
-            ],
-          ),
-          if (showFilters)
-            TestResultsFiltersView(
-              initialFilters: appliedFilters,
-              onApplyFilters: _onApplyFilters,
-              onChanged: _onFiltersChanged,
+    return SingleChildScrollView(
+      controller: _scrollController,
+      child: Padding(
+        padding: const EdgeInsets.only(
+          left: Spacing.pageHorizontalPadding,
+          right: Spacing.pageHorizontalPadding,
+          top: Spacing.level5,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          spacing: Spacing.level4,
+          children: [
+            Row(
+              children: [
+                Text(
+                  'Search Test Results',
+                  style: Theme.of(context).textTheme.headlineLarge,
+                ),
+                const Spacer(),
+                YaruOptionButton(
+                  child: const Icon(Icons.filter_alt),
+                  onPressed: () {
+                    setState(() {
+                      showFilters = !showFilters;
+                    });
+                  },
+                ),
+              ],
             ),
-          BulkOperationsButtons(
-            filters: appliedFilters,
-            disabled: filtersModified,
-          ),
-          Expanded(
-            child: TestResultsBody(filters: appliedFilters),
-          ),
-        ],
+            if (showFilters)
+              TestResultsFiltersView(
+                initialFilters: appliedFilters,
+                onApplyFilters: _onApplyFilters,
+                onChanged: _onFiltersChanged,
+              ),
+            BulkOperationsButtons(
+              filters: appliedFilters,
+              disabled: filtersModified,
+            ),
+            TestResultsBody(
+              filters: appliedFilters,
+              scrollController: _scrollController,
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR addresses the issue https://github.com/canonical/test_observer/issues/458

When multiple filters were expanded on the test results page, the table area shrank because it was wrapped in Expanded inside a Column. The more space the filters took, the less space the table got.
Changes:

- Replaced the page-level `Padding` + `Column` + `Expanded` layout in `test_results_page.dart` with a `SingleChildScrollView`, making the entire page scrollable as one unit.
- Removed `Expanded` + `CustomScrollView` from `test_results_body.dart` since scrolling is now handled at the page level.
- Passed the page-level `ScrollController` down to `TestResultsBody` so infinite loading still triggers correctly when scrolling near the bottom.

## Resolved issues
[TO-231](https://warthogs.atlassian.net/browse/TO-231?atlOrigin=eyJpIjoiNTRiNGU0ZGU5NDk0NDBkN2IyZWFlYWE5ZTdjNmI5NDgiLCJwIjoiaiJ9)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

https://github.com/user-attachments/assets/54d6db86-32b2-4697-bee2-3f42b68dedea

[TO-231]: https://warthogs.atlassian.net/browse/TO-231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ