### PR TITLE
Add missing linting

### DIFF
--- a/backend/migrations/versions/2026_02_25_1600-a1b2c3d4e5f6_add_auto_rerun_to_issue.py
+++ b/backend/migrations/versions/2026_02_25_1600-a1b2c3d4e5f6_add_auto_rerun_to_issue.py
@@ -22,9 +22,8 @@ Create Date: 2026-02-25 16:00:00.000000+00:00
 
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "a1b2c3d4e5f6"

--- a/backend/test_observer/controllers/issues/attachment_rules_logic.py
+++ b/backend/test_observer/controllers/issues/attachment_rules_logic.py
@@ -28,16 +28,14 @@ from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 
 from test_observer.data_access.models import (
+    Issue,
     IssueTestResultAttachment,
-    TestExecutionRerunRequest,
-    TestResult,
     IssueTestResultAttachmentRule,
     IssueTestResultAttachmentRuleExecutionMetadata,
     TestExecution,
     TestExecutionMetadata,
+    TestExecutionRerunRequest,
     TestResult,
-    IssueTestResultAttachment,
-    Issue,
 )
 
 
@@ -191,7 +189,7 @@ def apply_test_result_attachment_rules(db: Session, test_result: TestResult):
             )
             .select_from(TestExecution)
             .join(
-                TestResult, 
+                TestResult,
                 TestResult.test_execution_id == TestExecution.id,
             )
             .join(

--- a/backend/test_observer/controllers/issues/issues.py
+++ b/backend/test_observer/controllers/issues/issues.py
@@ -16,9 +16,8 @@
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Security
-from sqlalchemy import String, func, select
-from fastapi import HTTPException
 from fastapi.security import SecurityScopes
+from sqlalchemy import String, func, select
 from sqlalchemy.orm import Session, selectinload
 
 from test_observer.common.permissions import Permission, permission_checker
@@ -44,9 +43,6 @@ from .models import (
     IssuesGetResponse,
     MinimalIssueResponse,
 )
-from .issue_url_parser import issue_source_project_key_from_url
-
-from . import issue_attachments, attachment_rules
 
 router = APIRouter(tags=["issues"])
 router.include_router(issue_attachments.router)
@@ -182,9 +178,9 @@ def require_auto_rerun_permission(
     "/{issue_id}",
     response_model=IssueResponse,
     dependencies=[
-        Security(permission_checker, scopes=[Permission.change_issue]), 
-        Security(require_auto_rerun_permission, scopes=[Permission.change_auto_rerun])
-        ],
+        Security(permission_checker, scopes=[Permission.change_issue]),
+        Security(require_auto_rerun_permission, scopes=[Permission.change_auto_rerun]),
+    ],
 )
 def patch_issue(
     issue_id: int,

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -640,9 +640,7 @@ class Issue(Base):
     title: Mapped[str] = mapped_column(default="")
     status: Mapped[IssueStatus] = mapped_column(default=IssueStatus.UNKNOWN)
     last_synced_at = Column(DateTime, nullable=True)
-    labels: Mapped[list[str] | None] = mapped_column(
-        ARRAY(String), nullable=True, default=None
-    )
+    labels: Mapped[list[str] | None] = mapped_column(ARRAY(String), nullable=True, default=None)
     auto_rerun_enabled: Mapped[bool] = mapped_column(default=False)
 
     test_result_attachments: Mapped[list["IssueTestResultAttachment"]] = relationship(

--- a/backend/tests/controllers/issues/test_auto_rerun.py
+++ b/backend/tests/controllers/issues/test_auto_rerun.py
@@ -14,21 +14,20 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 
-import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from tests.conftest import make_authenticated_request
-from tests.data_generator import DataGenerator
 from test_observer.common.permissions import Permission
+from test_observer.controllers.issues.attachment_rules_logic import (
+    apply_test_result_attachment_rules,
+)
 from test_observer.data_access.models import (
     IssueTestResultAttachmentRule,
     TestExecutionRerunRequest,
 )
 from test_observer.data_access.models_enums import FamilyName
-from test_observer.controllers.issues.attachment_rules_logic import (
-    apply_test_result_attachment_rules,
-)
+from tests.conftest import make_authenticated_request
+from tests.data_generator import DataGenerator
 
 
 def test_issue_auto_rerun_enabled_default_false(
@@ -122,14 +121,10 @@ def test_auto_rerun_creates_rerun_request_when_enabled(
     artefact = generator.gen_artefact(family=FamilyName.snap)
     artefact_build = generator.gen_artefact_build(artefact=artefact)
     environment = generator.gen_environment()
-    test_execution = generator.gen_test_execution(
-        artefact_build=artefact_build, environment=environment
-    )
+    test_execution = generator.gen_test_execution(artefact_build=artefact_build, environment=environment)
     test_case = generator.gen_test_case()
-    test_result = generator.gen_test_result(
-        test_case=test_case, test_execution=test_execution
-    )
-    
+    test_result = generator.gen_test_result(test_case=test_case, test_execution=test_execution)
+
     # Create issue with auto_rerun enabled
     issue = generator.gen_issue()
     issue.auto_rerun_enabled = True
@@ -167,14 +162,10 @@ def test_auto_rerun_does_not_create_rerun_request_when_disabled(
     artefact = generator.gen_artefact(family=FamilyName.snap)
     artefact_build = generator.gen_artefact_build(artefact=artefact)
     environment = generator.gen_environment()
-    test_execution = generator.gen_test_execution(
-        artefact_build=artefact_build, environment=environment
-    )
+    test_execution = generator.gen_test_execution(artefact_build=artefact_build, environment=environment)
     test_case = generator.gen_test_case()
-    test_result = generator.gen_test_result(
-        test_case=test_case, test_execution=test_execution
-    )
-    
+    test_result = generator.gen_test_result(test_case=test_case, test_execution=test_execution)
+
     # Create issue with auto_rerun DISABLED (default)
     issue = generator.gen_issue()
     assert issue.auto_rerun_enabled is False
@@ -204,22 +195,18 @@ def test_auto_rerun_multiple_issues_with_different_settings(
     artefact = generator.gen_artefact(family=FamilyName.snap)
     artefact_build = generator.gen_artefact_build(artefact=artefact)
     environment = generator.gen_environment()
-    test_execution = generator.gen_test_execution(
-        artefact_build=artefact_build, environment=environment
-    )
+    test_execution = generator.gen_test_execution(artefact_build=artefact_build, environment=environment)
     test_case = generator.gen_test_case()
-    test_result = generator.gen_test_result(
-        test_case=test_case, test_execution=test_execution
-    )
-    
+    test_result = generator.gen_test_result(test_case=test_case, test_execution=test_execution)
+
     # Create issue 1 with auto_rerun enabled
     issue1 = generator.gen_issue(key="1")
     issue1.auto_rerun_enabled = True
-    
+
     # Create issue 2 with auto_rerun disabled
     issue2 = generator.gen_issue(key="2")
     issue2.auto_rerun_enabled = False
-    
+
     db_session.commit()
 
     # Create attachment rules that match for both issues
@@ -254,18 +241,12 @@ def test_auto_rerun_no_duplicate_rerun_requests(
     artefact = generator.gen_artefact(family=FamilyName.snap)
     artefact_build = generator.gen_artefact_build(artefact=artefact)
     environment = generator.gen_environment()
-    test_execution = generator.gen_test_execution(
-        artefact_build=artefact_build, environment=environment
-    )
+    test_execution = generator.gen_test_execution(artefact_build=artefact_build, environment=environment)
     test_case1 = generator.gen_test_case(name="test1")
     test_case2 = generator.gen_test_case(name="test2")
-    test_result1 = generator.gen_test_result(
-        test_case=test_case1, test_execution=test_execution
-    )
-    test_result2 = generator.gen_test_result(
-        test_case=test_case2, test_execution=test_execution
-    )
-    
+    test_result1 = generator.gen_test_result(test_case=test_case1, test_execution=test_execution)
+    test_result2 = generator.gen_test_result(test_case=test_case2, test_execution=test_execution)
+
     # Create issue with auto_rerun enabled
     issue = generator.gen_issue()
     issue.auto_rerun_enabled = True


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

I discovered we had a linting problem from some of our previous commits, this PR adds the missing linting. 

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->
