### PR TITLE
[TO-234] - Add view filters link to attachment rules on issue page

### DIFF
--- a/frontend/lib/ui/issue_page/attachment_rules.dart
+++ b/frontend/lib/ui/issue_page/attachment_rules.dart
@@ -97,7 +97,7 @@ class AttachmentRuleExpandable extends ConsumerWidget {
                     );
                 context.go(filters.toTestResultsUri().toString());
               },
-              child: const Text('view filter'),
+              child: const Text('view filters'),
             ),
             TextButton(
               child: Text(attachmentRule.enabled ? 'disable' : 'enable'),


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

Resolves https://github.com/canonical/test_observer/issues/461

Each attachment rule on the issue details page now has a "view filters" button that navigates to the Search Test Results page with the rule's filters pre-applied.

The link pre-populates all attachment rule filters (families, environments, test cases, template IDs, execution metadata, test result statuses)

## Resolved issues
[TO-234](https://warthogs.atlassian.net/browse/TO-234)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

<img width="2252" height="1530" alt="image" src="https://github.com/user-attachments/assets/eaf9d0f3-958c-430c-80a0-6c54fb94ebca" />
<img width="2252" height="1530" alt="image" src="https://github.com/user-attachments/assets/a41860ae-6fda-4137-9696-c3b00516f5ad" />



[TO-234]: https://warthogs.atlassian.net/browse/TO-234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ