### PR TITLE
[TO-271] - Show test results count per issue on issues page

### DIFF
--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -5274,9 +5274,9 @@
             ],
             "title": "Labels"
           },
-          "test_results_count": {
+          "test_executions_count": {
             "type": "integer",
-            "title": "Test Results Count",
+            "title": "Test Executions Count",
             "default": 0
           }
         },

--- a/backend/test_observer/controllers/issues/issues.py
+++ b/backend/test_observer/controllers/issues/issues.py
@@ -157,8 +157,10 @@ def get_issues(
     rows = db.execute(stmt.add_columns(runs_count_subq)).all()
     return IssuesGetResponse(
         issues=[
-            MinimalIssueResponse.model_validate(issue).model_copy(update={"test_results_count": test_results_count})
-            for issue, test_results_count in rows
+            MinimalIssueResponse.model_validate(issue).model_copy(
+                update={"test_executions_count": test_executions_count}
+            )
+            for issue, test_executions_count in rows
         ],
         count=total_count,
         limit=limit,

--- a/backend/test_observer/controllers/issues/shared_models.py
+++ b/backend/test_observer/controllers/issues/shared_models.py
@@ -48,7 +48,7 @@ class MinimalIssueResponse(BaseModel):
     status: IssueStatus
     url: HttpUrl
     labels: list[str] | None = None
-    test_results_count: int = 0
+    test_executions_count: int = 0
 
 
 class MinimalIssueTestResultAttachmentRuleResponse(BaseModel):

--- a/backend/tests/controllers/issues/test_issues.py
+++ b/backend/tests/controllers/issues/test_issues.py
@@ -557,7 +557,7 @@ def test_get_all_filter_by_family(test_client: TestClient, generator: DataGenera
     assert unattached_issue.id not in ids
 
 
-def test_get_all_test_results_count(test_client: TestClient, generator: DataGenerator):
+def test_get_all_test_executions_count(test_client: TestClient, generator: DataGenerator):
     issue = generator.gen_issue(key="RUNS-COUNT-1")
     unrelated_issue = generator.gen_issue(key="RUNS-COUNT-2")
 
@@ -592,5 +592,5 @@ def test_get_all_test_results_count(test_client: TestClient, generator: DataGene
     assert response.status_code == 200
 
     issues_by_id = {i["id"]: i for i in response.json()["issues"]}
-    assert issues_by_id[issue.id]["test_results_count"] == 2
-    assert issues_by_id[unrelated_issue.id]["test_results_count"] == 0
+    assert issues_by_id[issue.id]["test_executions_count"] == 2
+    assert issues_by_id[unrelated_issue.id]["test_executions_count"] == 0

--- a/backend/tests/controllers/test_executions/test_get_test_results.py
+++ b/backend/tests/controllers/test_executions/test_get_test_results.py
@@ -96,7 +96,7 @@ def test_fetch_test_results(test_client: TestClient, generator: DataGenerator):
                 "status": issue.status,
                 "url": issue.url,
                 "labels": issue.labels,
-                "test_results_count": 0,
+                "test_executions_count": 0,
             },
             "attachment_rule": None,
         }
@@ -258,7 +258,7 @@ def test_attachment_rule_listed_in_issue_attachment(
                 "status": issue.status,
                 "url": issue.url,
                 "labels": issue.labels,
-                "test_results_count": 0,
+                "test_executions_count": 0,
             },
             "attachment_rule": {
                 "id": attachment_rule_id,

--- a/frontend/lib/models/issue.dart
+++ b/frontend/lib/models/issue.dart
@@ -33,9 +33,9 @@ abstract class Issue with _$Issue {
     required String url,
     @JsonKey(name: 'auto_rerun_enabled', defaultValue: false)
     required bool autoRerunEnabled,
-    @JsonKey(name: 'test_results_count', defaultValue: 0)
+    @JsonKey(name: 'test_executions_count', defaultValue: 0)
     @Default(0)
-    int testResultsCount,
+    int testExecutionsCount,
   }) = _Issue;
 
   factory Issue.fromJson(Map<String, Object?> json) => _$IssueFromJson(json);

--- a/frontend/lib/ui/issues_page/issues_page_body.dart
+++ b/frontend/lib/ui/issues_page/issues_page_body.dart
@@ -131,8 +131,8 @@ class _IssuesPageBodyState extends ConsumerState<IssuesPageBody> {
                     children: [
                       IssueLinkWidget(issue: issue),
                       IssueStatusWidget(issue: issue),
-                      _TestResultsCountWidget(
-                        count: issue.testResultsCount,
+                      _TestExecutionsCountWidget(
+                        count: issue.testExecutionsCount,
                       ),
                     ],
                   ),
@@ -156,8 +156,8 @@ class _IssuesPageBodyState extends ConsumerState<IssuesPageBody> {
   }
 }
 
-class _TestResultsCountWidget extends StatelessWidget {
-  const _TestResultsCountWidget({required this.count});
+class _TestExecutionsCountWidget extends StatelessWidget {
+  const _TestExecutionsCountWidget({required this.count});
 
   final int count;
 
@@ -173,7 +173,7 @@ class _TestResultsCountWidget extends StatelessWidget {
           color: Theme.of(context).colorScheme.onSurfaceVariant,
         ),
         Text(
-          '$count ${count == 1 ? 'test result' : 'test results'}',
+          '$count ${count == 1 ? 'test execution' : 'test executions'}',
           style: Theme.of(context).textTheme.bodySmall?.copyWith(
                 color: Theme.of(context).colorScheme.onSurfaceVariant,
               ),


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->
Closes https://github.com/canonical/test_observer/issues/526

Each issue in `GET /v1/issues` now includes an `test_executions_count` field, which is the number of distinct test executions attached to that issue. This is displayed alongside the issue status on the issues list page.

The count is computed via a correlated subquery (`COUNT(DISTINCT test_execution_id)`) at query time.  No schema changes required. Note this counts runs (test executions), not individual test results, which is the more meaningful metric: e.g. an issue affecting 4 test cases in the same run counts as 1 affected run.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->
[TO-271](https://warthogs.atlassian.net/browse/TO-271)
## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

- `GET /v1/issues` response now includes `test_executions_count: int` on each issue object (defaults to 0 for issues with no attachments)

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->
Added unit tests and updated relevant tests.

<img width="2496" height="1517" alt="image" src="https://github.com/user-attachments/assets/d36979d8-ade8-4219-b1d4-243b71d4422a" />


<img width="2203" height="1412" alt="image" src="https://github.com/user-attachments/assets/d6594c84-d67b-449a-ad8d-98ed040560a0" />


[TO-271]: https://warthogs.atlassian.net/browse/TO-271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ