### PR TITLE
[TO-230] - Change cancel buttons' color from grey to black

### DIFF
--- a/frontend/lib/ui/artefact_page/environment_issues/environment_issue_form.dart
+++ b/frontend/lib/ui/artefact_page/environment_issues/environment_issue_form.dart
@@ -220,7 +220,7 @@ class _EnvironmentIssueFormState extends ConsumerState<_EnvironmentIssueForm> {
                   onPressed: () => context.pop(),
                   child: Text(
                     'cancel',
-                    style: buttonFontStyle?.apply(color: Colors.grey),
+                    style: buttonFontStyle?.apply(color: Colors.black),
                   ),
                 ),
                 const Spacer(),

--- a/frontend/lib/ui/artefact_page/issue_attachments/issue_forms/attach_issue_form.dart
+++ b/frontend/lib/ui/artefact_page/issue_attachments/issue_forms/attach_issue_form.dart
@@ -168,7 +168,7 @@ class _AttachIssueFormState extends ConsumerState<AttachIssueForm> {
                   onPressed: () => context.pop(),
                   child: Text(
                     'cancel',
-                    style: buttonFontStyle?.apply(color: Colors.grey),
+                    style: buttonFontStyle?.apply(color: Colors.black),
                   ),
                 ),
                 const Spacer(),

--- a/frontend/lib/ui/artefact_page/issue_attachments/issue_forms/detach_issue_form.dart
+++ b/frontend/lib/ui/artefact_page/issue_attachments/issue_forms/detach_issue_form.dart
@@ -178,7 +178,7 @@ class _DetachIssueFormState extends ConsumerState<DetachIssueForm> {
                   onPressed: () => context.pop(),
                   child: Text(
                     'cancel',
-                    style: buttonFontStyle?.apply(color: Colors.grey),
+                    style: buttonFontStyle?.apply(color: Colors.black),
                   ),
                 ),
                 const Spacer(),

--- a/frontend/lib/ui/artefact_page/test_issues/test_issue_form.dart
+++ b/frontend/lib/ui/artefact_page/test_issues/test_issue_form.dart
@@ -190,7 +190,7 @@ class _TestIssueFormState extends ConsumerState<_TestIssueForm> {
                   onPressed: () => context.pop(),
                   child: Text(
                     'cancel',
-                    style: buttonFontStyle?.apply(color: Colors.grey),
+                    style: buttonFontStyle?.apply(color: Colors.black),
                   ),
                 ),
                 const Spacer(),

--- a/frontend/lib/ui/issues_page/add_issue_form.dart
+++ b/frontend/lib/ui/issues_page/add_issue_form.dart
@@ -75,7 +75,7 @@ class _AddIssueFormState extends ConsumerState<_AddIssueForm> {
                   onPressed: () => context.pop(),
                   child: Text(
                     'cancel',
-                    style: buttonFontStyle?.apply(color: Colors.grey),
+                    style: buttonFontStyle?.apply(color: Colors.black),
                   ),
                 ),
                 const Spacer(),

--- a/frontend/lib/ui/test_results_page/bulk_operations/bulk_issue_attachment_form.dart
+++ b/frontend/lib/ui/test_results_page/bulk_operations/bulk_issue_attachment_form.dart
@@ -96,7 +96,7 @@ class _BulkIssueAttachmentFormState
                   onPressed: () => Navigator.of(context).pop(),
                   child: Text(
                     'cancel',
-                    style: buttonFontStyle?.apply(color: Colors.grey),
+                    style: buttonFontStyle?.apply(color: Colors.black),
                   ),
                 ),
                 const Spacer(),

--- a/frontend/lib/ui/test_results_page/bulk_operations/bulk_modify_reruns_form.dart
+++ b/frontend/lib/ui/test_results_page/bulk_operations/bulk_modify_reruns_form.dart
@@ -148,7 +148,7 @@ class _BulkModifyRerunsFormState extends ConsumerState<_BulkModifyRerunsForm> {
                   onPressed: () => Navigator.of(context).pop(),
                   child: Text(
                     'cancel',
-                    style: buttonFontStyle?.apply(color: Colors.grey),
+                    style: buttonFontStyle?.apply(color: Colors.black),
                   ),
                 ),
                 const Spacer(),

--- a/frontend/lib/ui/test_results_page/bulk_operations/create_attachment_rule_form.dart
+++ b/frontend/lib/ui/test_results_page/bulk_operations/create_attachment_rule_form.dart
@@ -103,7 +103,7 @@ class _CreateAttachmentRuleFormState
                   onPressed: () => Navigator.of(context).pop(),
                   child: Text(
                     'cancel',
-                    style: buttonFontStyle?.apply(color: Colors.grey),
+                    style: buttonFontStyle?.apply(color: Colors.black),
                   ),
                 ),
                 const Spacer(),


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

Resolves https://github.com/canonical/test_observer/issues/456

This PR changes the cancel buttons' color to from grey to black because grey makes it looks like disabled.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

[TO-230
](https://warthogs.atlassian.net/browse/TO-230)
## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Changed from

<img width="631" height="147" alt="image" src="https://github.com/user-attachments/assets/3cc2cbc5-d883-499c-bccc-b805e15b7353" />

To

<img width="745" height="205" alt="image" src="https://github.com/user-attachments/assets/7ebeed93-78e4-44c8-81b5-3030a0f882c0" />
