### PR TITLE
[Fix] Update issues test execution count query

### DIFF
--- a/backend/test_observer/controllers/artefacts/environment_reviews.py
+++ b/backend/test_observer/controllers/artefacts/environment_reviews.py
@@ -50,9 +50,7 @@ def get_environment_reviews(
 @router.patch(
     "/{artefact_id}/environment-reviews",
     response_model=list[ArtefactBuildEnvironmentReviewResponse],
-    dependencies=[
-        Security(permission_checker, scopes=[Permission.change_environment_review])
-    ],
+    dependencies=[Security(permission_checker, scopes=[Permission.change_environment_review])],
 )
 def bulk_update_environment_reviews(
     artefact_id: int,

--- a/backend/test_observer/controllers/issues/issues.py
+++ b/backend/test_observer/controllers/issues/issues.py
@@ -146,15 +146,13 @@ def get_issues(
     # Apply limit and offset
     stmt = stmt.limit(limit).offset(offset)
 
-    runs_count_subq = (
-        select(func.count(func.distinct(TestExecution.id)))
-        .join(TestResult, TestResult.test_execution_id == TestExecution.id)
-        .join(IssueTestResultAttachment, IssueTestResultAttachment.test_result_id == TestResult.id)
-        .where(IssueTestResultAttachment.issue_id == Issue.id)
-        .correlate(Issue)
-        .scalar_subquery()
-    )
-    rows = db.execute(stmt.add_columns(runs_count_subq)).all()
+    rows = db.execute(
+        stmt.outerjoin(IssueTestResultAttachment, IssueTestResultAttachment.issue_id == Issue.id)
+        .outerjoin(TestResult, TestResult.id == IssueTestResultAttachment.test_result_id)
+        .outerjoin(TestExecution, TestExecution.id == TestResult.test_execution_id)
+        .add_columns(func.count(func.distinct(TestExecution.id)))
+        .group_by(Issue.id)
+    ).all()
     return IssuesGetResponse(
         issues=[
             MinimalIssueResponse.model_validate(issue).model_copy(

--- a/backend/tests/controllers/artefacts/test_environment_reviews.py
+++ b/backend/tests/controllers/artefacts/test_environment_reviews.py
@@ -156,9 +156,7 @@ def test_review_an_environment(test_client: TestClient, generator: DataGenerator
     }
 
 
-def test_bulk_review_multiple_environments(
-    test_client: TestClient, generator: DataGenerator
-):
+def test_bulk_review_multiple_environments(test_client: TestClient, generator: DataGenerator):
     """Test bulk reviewing multiple environments at once."""
     a = generator.gen_artefact(StageName.beta)
     ab = generator.gen_artefact_build(a)
@@ -171,16 +169,12 @@ def test_bulk_review_multiple_environments(
         {
             "id": er1.id,
             "review_comment": "Approved env1",
-            "review_decision": [
-                ArtefactBuildEnvironmentReviewDecision.APPROVED_INCONSISTENT_TEST
-            ],
+            "review_decision": [ArtefactBuildEnvironmentReviewDecision.APPROVED_INCONSISTENT_TEST],
         },
         {
             "id": er2.id,
             "review_comment": "Approved env2",
-            "review_decision": [
-                ArtefactBuildEnvironmentReviewDecision.APPROVED_INCONSISTENT_TEST
-            ],
+            "review_decision": [ArtefactBuildEnvironmentReviewDecision.APPROVED_INCONSISTENT_TEST],
         },
     ]
 
@@ -200,19 +194,13 @@ def test_bulk_review_multiple_environments(
     for review in reviews:
         if review["id"] == er1.id:
             assert review["review_comment"] == "Approved env1"
-            assert review["review_decision"] == [
-                ArtefactBuildEnvironmentReviewDecision.APPROVED_INCONSISTENT_TEST
-            ]
+            assert review["review_decision"] == [ArtefactBuildEnvironmentReviewDecision.APPROVED_INCONSISTENT_TEST]
         elif review["id"] == er2.id:
             assert review["review_comment"] == "Approved env2"
-            assert review["review_decision"] == [
-                ArtefactBuildEnvironmentReviewDecision.APPROVED_INCONSISTENT_TEST
-            ]
+            assert review["review_decision"] == [ArtefactBuildEnvironmentReviewDecision.APPROVED_INCONSISTENT_TEST]
 
 
-def test_bulk_review_with_same_comment_and_decision(
-    test_client: TestClient, generator: DataGenerator
-):
+def test_bulk_review_with_same_comment_and_decision(test_client: TestClient, generator: DataGenerator):
     """Test bulk reviewing with same comment and decision for multiple environments."""
     a = generator.gen_artefact(StageName.beta)
     ab = generator.gen_artefact_build(a)
@@ -245,9 +233,7 @@ def test_bulk_review_with_same_comment_and_decision(
         assert review["review_comment"] == "All good"
 
 
-def test_bulk_review_rejects_if_review_belongs_to_different_artefact(
-    test_client: TestClient, generator: DataGenerator
-):
+def test_bulk_review_rejects_if_review_belongs_to_different_artefact(test_client: TestClient, generator: DataGenerator):
     """Test that bulk review silently skips reviews from a different artefact."""
     a1 = generator.gen_artefact(StageName.beta, name="artefact1")
     a2 = generator.gen_artefact(StageName.beta, name="artefact2")


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

The `GET /v1/issues` endpoint was computing the number of linked test executions per issue using a correlated subquery, which the database re-executed once per row (an N+1 problem at the SQL level).

This is replaced with a single flat `LEFT OUTER JOIN` + `GROUP BY` across the three relevant tables, so the aggregation is computed in one query pass regardless of how many issues are returned.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

Cannot load https://test-observer.canonical.com/#/issues

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

N/A

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

N/A

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Refactor, existing tests pass.