### PR TITLE
[Fix] Readd assignee fields

### DIFF
--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -4857,6 +4857,32 @@
             ],
             "title": "Comment"
           },
+          "assignee_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assignee Id",
+            "description": "Legacy field. Mapped to reviewer_ids as a single-element list when reviewer_ids/reviewer_emails are not provided.",
+            "deprecated": true
+          },
+          "assignee_email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assignee Email",
+            "description": "Legacy field. Mapped to reviewer_emails as a single-element list when reviewer_ids/reviewer_emails are not provided.",
+            "deprecated": true
+          },
           "reviewer_ids": {
             "anyOf": [
               {
@@ -4869,7 +4895,8 @@
                 "type": "null"
               }
             ],
-            "title": "Reviewer Ids"
+            "title": "Reviewer Ids",
+            "description": "Reviewer user IDs. Preferred over legacy assignee_id/assignee_email for setting assignees."
           },
           "reviewer_emails": {
             "anyOf": [
@@ -4883,7 +4910,8 @@
                 "type": "null"
               }
             ],
-            "title": "Reviewer Emails"
+            "title": "Reviewer Emails",
+            "description": "Reviewer emails. Preferred over legacy assignee_id/assignee_email for setting assignees."
           }
         },
         "type": "object",
@@ -5001,6 +5029,18 @@
           "completed_environment_reviews_count": {
             "type": "integer",
             "title": "Completed Environment Reviews Count"
+          },
+          "assignee": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ReviewerResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Backward-compatible assignee field. Populated from the first entry in reviewers when present.",
+            "readOnly": true
           }
         },
         "type": "object",
@@ -5029,7 +5069,8 @@
           "created_at",
           "bug_link",
           "all_environment_reviews_count",
-          "completed_environment_reviews_count"
+          "completed_environment_reviews_count",
+          "assignee"
         ],
         "title": "ArtefactResponse"
       },

--- a/backend/test_observer/controllers/artefacts/models.py
+++ b/backend/test_observer/controllers/artefacts/models.py
@@ -25,6 +25,7 @@ from pydantic import (
     HttpUrl,
     computed_field,
     field_validator,
+    model_validator,
 )
 
 from test_observer.controllers.execution_metadata.models import ExecutionMetadata
@@ -77,6 +78,12 @@ class ArtefactResponse(BaseModel):
     bug_link: str
     all_environment_reviews_count: int
     completed_environment_reviews_count: int
+
+    @computed_field(
+        description=("Backward-compatible assignee field. Populated from the first entry in reviewers when present.")
+    )
+    def assignee(self) -> ReviewerResponse | None:
+        return self.reviewers[0] if self.reviewers else None
 
 
 class EnvironmentResponse(BaseModel):
@@ -141,8 +148,46 @@ class ArtefactPatch(BaseModel):
     archived: bool | None = None
     stage: StageName | None = None
     comment: str | None = None
-    reviewer_ids: list[int] | None = None
-    reviewer_emails: list[str] | None = None
+    assignee_id: int | None = Field(
+        default=None,
+        deprecated=True,
+        description=(
+            "Legacy field. Mapped to reviewer_ids as a single-element list when "
+            "reviewer_ids/reviewer_emails are not provided."
+        ),
+    )
+    assignee_email: str | None = Field(
+        default=None,
+        deprecated=True,
+        description=(
+            "Legacy field. Mapped to reviewer_emails as a single-element list "
+            "when reviewer_ids/reviewer_emails are not provided."
+        ),
+    )
+    reviewer_ids: list[int] | None = Field(
+        default=None,
+        description=("Reviewer user IDs. Preferred over legacy assignee_id/assignee_email for setting assignees."),
+    )
+    reviewer_emails: list[str] | None = Field(
+        default=None,
+        description=("Reviewer emails. Preferred over legacy assignee_id/assignee_email for setting assignees."),
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def map_legacy_assignee_fields(cls, data: object) -> object:
+        if not isinstance(data, dict):
+            return data
+
+        # Backwards compatibility: map legacy assignee fields to reviewer fields
+        # only when reviewer fields are not explicitly provided.
+        if "reviewer_ids" not in data and "reviewer_emails" not in data:
+            if "assignee_id" in data:
+                data["reviewer_ids"] = [data["assignee_id"]] if data["assignee_id"] is not None else None
+            if "assignee_email" in data:
+                data["reviewer_emails"] = [data["assignee_email"]] if data["assignee_email"] is not None else None
+
+        return data
 
 
 class ArtefactVersionResponse(BaseModel):

--- a/backend/tests/controllers/artefacts/test_artefacts.py
+++ b/backend/tests/controllers/artefacts/test_artefacts.py
@@ -522,6 +522,22 @@ def test_update_artefact_reviewer(test_client: TestClient, generator: DataGenera
     assert a.reviewers == [u]
 
 
+def test_update_artefact_reviewer_legacy_assignee_id(test_client: TestClient, generator: DataGenerator):
+    a = generator.gen_artefact()
+    u = generator.gen_user()
+
+    response = make_authenticated_request(
+        lambda: test_client.patch(
+            f"/v1/artefacts/{a.id}",
+            json={"assignee_id": u.id},
+        ),
+        Permission.change_artefact,
+    )
+
+    assert response.status_code == 200
+    assert a.reviewers == [u]
+
+
 def test_update_artefact_reviewer_nonexistent_user(test_client: TestClient, generator: DataGenerator):
     a = generator.gen_artefact()
     nonexistent_user_id = 99999
@@ -558,6 +574,22 @@ def test_update_artefact_reviewer_clear(test_client: TestClient, generator: Data
     assert a.reviewers == []
 
 
+def test_update_artefact_reviewer_clear_legacy_assignee_id(test_client: TestClient, generator: DataGenerator):
+    u = generator.gen_user()
+    a = generator.gen_artefact(reviewers=[u])
+
+    response = make_authenticated_request(
+        lambda: test_client.patch(
+            f"/v1/artefacts/{a.id}",
+            json={"assignee_id": None},
+        ),
+        Permission.change_artefact,
+    )
+
+    assert response.status_code == 200
+    assert a.reviewers == []
+
+
 def test_update_artefact_reviewer_by_email(test_client: TestClient, generator: DataGenerator):
     a = generator.gen_artefact()
     u = generator.gen_user()
@@ -566,6 +598,22 @@ def test_update_artefact_reviewer_by_email(test_client: TestClient, generator: D
         lambda: test_client.patch(
             f"/v1/artefacts/{a.id}",
             json={"reviewer_emails": [u.email]},
+        ),
+        Permission.change_artefact,
+    )
+
+    assert response.status_code == 200
+    assert a.reviewers == [u]
+
+
+def test_update_artefact_reviewer_legacy_assignee_email(test_client: TestClient, generator: DataGenerator):
+    a = generator.gen_artefact()
+    u = generator.gen_user()
+
+    response = make_authenticated_request(
+        lambda: test_client.patch(
+            f"/v1/artefacts/{a.id}",
+            json={"assignee_email": u.email},
         ),
         Permission.change_artefact,
     )
@@ -810,6 +858,17 @@ def _assert_get_artefacts_response(response_json: list[dict[str, Any]], artefact
 
 
 def _assert_get_artefact_response(response: dict[str, Any], artefact: Artefact) -> None:
+    assignee = None
+    if artefact.reviewers:
+        first_reviewer = artefact.reviewers[0]
+        assignee = {
+            "id": first_reviewer.id,
+            "email": first_reviewer.email,
+            "launchpad_email": first_reviewer.email,
+            "launchpad_handle": first_reviewer.launchpad_handle,
+            "name": first_reviewer.name,
+        }
+
     expected = {
         "id": artefact.id,
         "name": artefact.name,
@@ -830,6 +889,7 @@ def _assert_get_artefact_response(response: dict[str, Any], artefact: Artefact) 
         "comment": artefact.comment,
         "archived": artefact.archived,
         "family": artefact.family,
+        "assignee": assignee,
         "reviewers": [],
         "due_date": (artefact.due_date.strftime("%Y-%m-%d") if artefact.due_date else None),
         "bug_link": artefact.bug_link,

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -152,6 +152,11 @@ def test_execution_to_pending_rerun(test_execution: TestExecution) -> dict:
             "status": test_execution.artefact_build.artefact.status.name,
             "comment": test_execution.artefact_build.artefact.comment,
             "archived": test_execution.artefact_build.artefact.archived,
+            "assignee": (
+                test_execution.artefact_build.artefact.reviewers[0]
+                if test_execution.artefact_build.artefact.reviewers
+                else None
+            ),
             "reviewers": test_execution.artefact_build.artefact.reviewers,
             "due_date": test_execution.artefact_build.artefact.due_date,
             "bug_link": test_execution.artefact_build.artefact.bug_link,


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

Assignee field should not have been removed when support for multiple reviewers was added as it broke the OpenAPI contract.

See this commit: https://github.com/canonical/test_observer/commit/f1dc3088e3bc814b1d920c97b7ee5a84d56b3a3d#diff-fd5cdf9c35e455a86a51930341b4c795161502963184a76134eb24d76b618ea0

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

Readd assignee field, populated by the first reviewer.

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

Yes. Fields are marked as deprecated.

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

Yes, as documented in the schema. Non-breaking changes (in fact fixing).

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->
Unit tests added.