### PR TITLE
Add new permission values (PostgreSQL Enum)

### DIFF
--- a/backend/migrations/versions/2026_03_31_1410-f0847700d32e_convert_permission_to_enum.py
+++ b/backend/migrations/versions/2026_03_31_1410-f0847700d32e_convert_permission_to_enum.py
@@ -81,6 +81,9 @@ def downgrade() -> None:
     # restore previous default
     op.execute("ALTER TABLE team ALTER COLUMN permissions SET DEFAULT '{}'::character varying[]")
 
+    # drop default
+    op.execute("ALTER TABLE application ALTER COLUMN permissions DROP DEFAULT")
+
     # upgrade application table
     op.alter_column(
         "application",
@@ -90,3 +93,6 @@ def downgrade() -> None:
         existing_nullable=False,
         postgresql_using="permissions::varchar[]",
     )
+
+    # restore previous default
+    op.execute("ALTER TABLE application ALTER COLUMN permissions SET DEFAULT '{}'::character varying[]")

--- a/backend/migrations/versions/2026_03_31_1410-f0847700d32e_convert_permission_to_enum.py
+++ b/backend/migrations/versions/2026_03_31_1410-f0847700d32e_convert_permission_to_enum.py
@@ -36,11 +36,6 @@ PERMISSION_TYPE = postgresql.ARRAY(postgresql.ENUM(name="permission"))
 
 def upgrade() -> None:
     # upgrade application table
-
-    # drop default to prevent casting errors from postgresql
-    op.execute("ALTER TABLE application ALTER COLUMN permissions DROP DEFAULT")
-
-    # change type
     op.alter_column(
         "application",
         "permissions",
@@ -49,9 +44,6 @@ def upgrade() -> None:
         existing_nullable=False,
         postgresql_using="permissions::permission[]",
     )
-
-    # apply new default
-    op.execute("ALTER TABLE application ALTER COLUMN permissions SET DEFAULT '{}'::permission[]")
 
     # upgrade team table
     # drop default to prevent casting errors from postgresql
@@ -89,9 +81,6 @@ def downgrade() -> None:
     # restore previous default
     op.execute("ALTER TABLE team ALTER COLUMN permissions SET DEFAULT '{}'::character varying[]")
 
-    # drop default
-    op.execute("ALTER TABLE application ALTER COLUMN permissions DROP DEFAULT")
-
     # upgrade application table
     op.alter_column(
         "application",
@@ -101,6 +90,3 @@ def downgrade() -> None:
         existing_nullable=False,
         postgresql_using="permissions::varchar[]",
     )
-
-    # restore previous default
-    op.execute("ALTER TABLE application ALTER COLUMN permissions SET DEFAULT '{}'::character varying[]")

--- a/backend/migrations/versions/2026_03_31_1410-f0847700d32e_convert_permission_to_enum.py
+++ b/backend/migrations/versions/2026_03_31_1410-f0847700d32e_convert_permission_to_enum.py
@@ -36,6 +36,11 @@ PERMISSION_TYPE = postgresql.ARRAY(postgresql.ENUM(name="permission"))
 
 def upgrade() -> None:
     # upgrade application table
+
+    # drop default to prevent casting errors from postgresql
+    op.execute("ALTER TABLE application ALTER COLUMN permissions DROP DEFAULT")
+
+    # change type
     op.alter_column(
         "application",
         "permissions",
@@ -44,6 +49,9 @@ def upgrade() -> None:
         existing_nullable=False,
         postgresql_using="permissions::permission[]",
     )
+
+    # apply new default
+    op.execute("ALTER TABLE application ALTER COLUMN permissions SET DEFAULT '{}'::permission[]")
 
     # upgrade team table
     # drop default to prevent casting errors from postgresql

--- a/backend/migrations/versions/2026_04_04_1017-87fbc47c21f4_add_new_permissions.py
+++ b/backend/migrations/versions/2026_04_04_1017-87fbc47c21f4_add_new_permissions.py
@@ -81,7 +81,7 @@ def upgrade() -> None:
     op.execute(f"ALTER TYPE {PERMISSION_ENUM_NAME} RENAME TO {PERMISSION_ENUM_NAME}_old")
 
     # Create the new enum with the same name as the old enum.
-    formatted_options = ", ".join(f"'{p}'" for p in NEW_PERMISSIONS)
+    formatted_options = ", ".join(f"'{p}'" for p in sorted(list(NEW_PERMISSIONS)))
     op.execute(f"CREATE TYPE {PERMISSION_ENUM_NAME} AS ENUM ({formatted_options})")
 
     # artefact_matching_rule comes from this migration:
@@ -149,7 +149,7 @@ def downgrade() -> None:
     op.execute(f"ALTER TYPE {PERMISSION_ENUM_NAME} RENAME TO {PERMISSION_ENUM_NAME}_new")
 
     # Create the old enum with the same name as the current enum.
-    formatted_options = ", ".join(f"'{p}'" for p in OLD_PERMISSIONS)
+    formatted_options = ", ".join(f"'{p}'" for p in sorted(list(OLD_PERMISSIONS)))
     op.execute(f"CREATE TYPE {PERMISSION_ENUM_NAME} AS ENUM ({formatted_options})")
 
     columns_to_update = [
@@ -160,7 +160,7 @@ def downgrade() -> None:
 
     # Update existing table columns to use the new enum type
     # However, on downgrading, we have to remove any values that are not in the old enum
-    to_remove = ", ".join(f"'{p}'" for p in NEW_PERMISSIONS - OLD_PERMISSIONS)
+    to_remove = ", ".join(f"'{p}'" for p in sorted(list(NEW_PERMISSIONS - OLD_PERMISSIONS)))
     for table_name, column_name in columns_to_update:
         has_default = (
             op.get_bind()

--- a/backend/migrations/versions/2026_04_04_1017-87fbc47c21f4_add_new_permissions.py
+++ b/backend/migrations/versions/2026_04_04_1017-87fbc47c21f4_add_new_permissions.py
@@ -81,7 +81,7 @@ def upgrade() -> None:
     op.execute(f"ALTER TYPE {PERMISSION_ENUM_NAME} RENAME TO {PERMISSION_ENUM_NAME}_old")
 
     # Create the new enum with the same name as the old enum.
-    formatted_options = ", ".join(f"'{p}'" for p in sorted(list(NEW_PERMISSIONS)))
+    formatted_options = ", ".join(f"'{p}'" for p in sorted(NEW_PERMISSIONS))
     op.execute(f"CREATE TYPE {PERMISSION_ENUM_NAME} AS ENUM ({formatted_options})")
 
     # artefact_matching_rule comes from this migration:
@@ -149,7 +149,7 @@ def downgrade() -> None:
     op.execute(f"ALTER TYPE {PERMISSION_ENUM_NAME} RENAME TO {PERMISSION_ENUM_NAME}_new")
 
     # Create the old enum with the same name as the current enum.
-    formatted_options = ", ".join(f"'{p}'" for p in sorted(list(OLD_PERMISSIONS)))
+    formatted_options = ", ".join(f"'{p}'" for p in sorted(OLD_PERMISSIONS))
     op.execute(f"CREATE TYPE {PERMISSION_ENUM_NAME} AS ENUM ({formatted_options})")
 
     columns_to_update = [
@@ -160,7 +160,7 @@ def downgrade() -> None:
 
     # Update existing table columns to use the new enum type
     # However, on downgrading, we have to remove any values that are not in the old enum
-    to_remove = ", ".join(f"'{p}'" for p in sorted(list(NEW_PERMISSIONS - OLD_PERMISSIONS)))
+    to_remove = ", ".join(f"'{p}'" for p in sorted(NEW_PERMISSIONS - OLD_PERMISSIONS))
     for table_name, column_name in columns_to_update:
         has_default = (
             op.get_bind()

--- a/backend/migrations/versions/2026_04_04_1017-87fbc47c21f4_add_new_permissions.py
+++ b/backend/migrations/versions/2026_04_04_1017-87fbc47c21f4_add_new_permissions.py
@@ -21,6 +21,7 @@ Create Date: 2026-04-04 10:17:58.679185+00:00
 
 """
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -94,9 +95,23 @@ def upgrade() -> None:
     ]
     # Update existing table columns to use the new enum type
     for table_name, column_name in columns_to_update:
-        # We have to drop the default before altering the column type,
-        # otherwise PostgreSQL will complain about being unable to cast the default value to the new enum type.
-        op.execute(f"ALTER TABLE {table_name} ALTER COLUMN {column_name} DROP DEFAULT")
+        # Check if a default currently exists
+        # This query returns the default expression string if it exists, or None
+        has_default = op.get_bind().execute(
+            sa.text(
+                f"""
+                SELECT column_default 
+                FROM information_schema.columns 
+                WHERE table_name = '{table_name}' 
+                AND column_name = '{column_name}'
+                """
+            )
+        ).scalar()
+
+        if has_default:
+            # We have to drop the default before altering the column type,
+            # otherwise PostgreSQL will complain about being unable to cast the default value to the new enum type.
+            op.execute(f"ALTER TABLE {table_name} ALTER COLUMN {column_name} DROP DEFAULT")
 
         op.execute(
             f"""
@@ -105,8 +120,9 @@ def upgrade() -> None:
             """
         )
 
-        # Reapply the default, which is an empty array of the new enum type.
-        op.execute(f"ALTER TABLE {table_name} ALTER COLUMN {column_name} SET DEFAULT '{{}}'::{PERMISSION_ENUM_NAME}[]")
+        if has_default:
+            # Reapply the default, which is an empty array of the new enum type.
+            op.execute(f"ALTER TABLE {table_name} ALTER COLUMN {column_name} SET DEFAULT '{{}}'::{PERMISSION_ENUM_NAME}[]")
 
     # Drop the old enum type
     # We need to use SQL here, because otherwise the SQLAlchemy Enum object will attempt to drop the new enum,
@@ -140,7 +156,19 @@ def downgrade() -> None:
     # However, on downgrading, we have to remove any values that are not in the old enum
     to_remove = ", ".join(f"'{p}'" for p in NEW_PERMISSIONS - OLD_PERMISSIONS)
     for table_name, column_name in columns_to_update:
-        op.execute(f"ALTER TABLE {table_name} ALTER COLUMN {column_name} DROP DEFAULT")
+        has_default = op.get_bind().execute(
+            sa.text(
+                f"""
+                SELECT column_default 
+                FROM information_schema.columns 
+                WHERE table_name = '{table_name}' 
+                AND column_name = '{column_name}'
+                """
+            )
+        ).scalar()
+
+        if has_default:
+            op.execute(f"ALTER TABLE {table_name} ALTER COLUMN {column_name} DROP DEFAULT")
 
         # We want to remove any values that are not in the old enum
         # That is, if a row has permissions = ["view_user", "change_user", "view_basic", "view_docs"],
@@ -165,6 +193,7 @@ def downgrade() -> None:
             """
         )
 
-        op.execute(f"ALTER TABLE {table_name} ALTER COLUMN {column_name} SET DEFAULT '{{}}'::{PERMISSION_ENUM_NAME}[]")
+        if has_default:
+            op.execute(f"ALTER TABLE {table_name} ALTER COLUMN {column_name} SET DEFAULT '{{}}'::{PERMISSION_ENUM_NAME}[]")
 
     op.execute(f"DROP TYPE {PERMISSION_ENUM_NAME}_new")

--- a/backend/migrations/versions/2026_04_04_1017-87fbc47c21f4_add_new_permissions.py
+++ b/backend/migrations/versions/2026_04_04_1017-87fbc47c21f4_add_new_permissions.py
@@ -97,16 +97,20 @@ def upgrade() -> None:
     for table_name, column_name in columns_to_update:
         # Check if a default currently exists
         # This query returns the default expression string if it exists, or None
-        has_default = op.get_bind().execute(
-            sa.text(
-                f"""
-                SELECT column_default 
-                FROM information_schema.columns 
-                WHERE table_name = '{table_name}' 
-                AND column_name = '{column_name}'
-                """
+        has_default = (
+            op.get_bind()
+            .execute(
+                sa.text(
+                    f"""
+                    SELECT column_default 
+                    FROM information_schema.columns 
+                    WHERE table_name = '{table_name}' 
+                    AND column_name = '{column_name}'
+                    """
+                )
             )
-        ).scalar()
+            .scalar()
+        )
 
         if has_default:
             # We have to drop the default before altering the column type,
@@ -122,7 +126,9 @@ def upgrade() -> None:
 
         if has_default:
             # Reapply the default, which is an empty array of the new enum type.
-            op.execute(f"ALTER TABLE {table_name} ALTER COLUMN {column_name} SET DEFAULT '{{}}'::{PERMISSION_ENUM_NAME}[]")
+            op.execute(
+                f"ALTER TABLE {table_name} ALTER COLUMN {column_name} SET DEFAULT '{{}}'::{PERMISSION_ENUM_NAME}[]"
+            )
 
     # Drop the old enum type
     # We need to use SQL here, because otherwise the SQLAlchemy Enum object will attempt to drop the new enum,
@@ -156,16 +162,20 @@ def downgrade() -> None:
     # However, on downgrading, we have to remove any values that are not in the old enum
     to_remove = ", ".join(f"'{p}'" for p in NEW_PERMISSIONS - OLD_PERMISSIONS)
     for table_name, column_name in columns_to_update:
-        has_default = op.get_bind().execute(
-            sa.text(
-                f"""
-                SELECT column_default 
-                FROM information_schema.columns 
-                WHERE table_name = '{table_name}' 
-                AND column_name = '{column_name}'
-                """
+        has_default = (
+            op.get_bind()
+            .execute(
+                sa.text(
+                    f"""
+                    SELECT column_default 
+                    FROM information_schema.columns 
+                    WHERE table_name = '{table_name}' 
+                    AND column_name = '{column_name}'
+                    """
+                )
             )
-        ).scalar()
+            .scalar()
+        )
 
         if has_default:
             op.execute(f"ALTER TABLE {table_name} ALTER COLUMN {column_name} DROP DEFAULT")
@@ -194,6 +204,8 @@ def downgrade() -> None:
         )
 
         if has_default:
-            op.execute(f"ALTER TABLE {table_name} ALTER COLUMN {column_name} SET DEFAULT '{{}}'::{PERMISSION_ENUM_NAME}[]")
+            op.execute(
+                f"ALTER TABLE {table_name} ALTER COLUMN {column_name} SET DEFAULT '{{}}'::{PERMISSION_ENUM_NAME}[]"
+            )
 
     op.execute(f"DROP TYPE {PERMISSION_ENUM_NAME}_new")

--- a/backend/migrations/versions/2026_04_04_1017-87fbc47c21f4_add_new_permissions.py
+++ b/backend/migrations/versions/2026_04_04_1017-87fbc47c21f4_add_new_permissions.py
@@ -1,0 +1,155 @@
+"""Add new permissions
+
+Revision ID: 87fbc47c21f4
+Revises: f0847700d32e
+Create Date: 2026-04-04 10:17:58.679185+00:00
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "87fbc47c21f4"
+down_revision = "f0847700d32e"
+branch_labels = None
+depends_on = None
+
+PERMISSION_ENUM_NAME = "permission"
+
+# Manually copied from 2026_03_23_1733-c29b4f545a9b_add_permissions_to_amrs.py
+OLD_PERMISSIONS = {
+    "view_user",
+    "change_user",
+    "view_team",
+    "change_team",
+    "add_application",
+    "change_application",
+    "view_application",
+    "view_permission",
+    "view_issue",
+    "change_issue",
+    "change_issue_attachment",
+    "change_issue_attachment_bulk",
+    "change_attachment_rule",
+    "change_auto_rerun",
+    "view_test",
+    "change_test",
+    "view_rerun",
+    "change_rerun",
+    "change_rerun_bulk",
+    "view_artefact",
+    "change_artefact",
+    "view_environment_review",
+    "change_environment_review",
+    "view_report",
+    "view_test_case_reported_issue",
+    "change_test_case_reported_issue",
+    "view_environment_reported_issue",
+    "change_environment_reported_issue",
+    "view_notification",
+    "change_notification",
+}
+
+NEW_PERMISSIONS = OLD_PERMISSIONS.union({"view_basic", "view_sentry_debug", "view_docs", "view_self"})
+
+
+def upgrade() -> None:
+    """
+    Although PostgreSQL does support adding new values to an enum type,
+    it does not support removing values from an enum type,
+    which is what we would need to do in the downgrade.
+    As a result, we take a more symmetric approach to upgrading and downgrading,
+    where we create new enum types in both cases.
+    """
+    # Rename the old enum to a new temporary name, so that we can create the new enum with the same name.
+    op.execute(f"ALTER TYPE {PERMISSION_ENUM_NAME} RENAME TO {PERMISSION_ENUM_NAME}_old")
+
+    # Create the new enum with the same name as the old enum.
+    formatted_options = ", ".join(f"'{p}'" for p in NEW_PERMISSIONS)
+    op.execute(f"CREATE TYPE {PERMISSION_ENUM_NAME} AS ENUM ({formatted_options})")
+
+    # artefact_matching_rule comes from this migration:
+    # 2026_03_23_1733-c29b4f545a9b_add_permissions_to_amrs.py
+    # application and team come from this migration:
+    # 2026_03_31_1410-f0847700d32e_convert_permission_to_enum.py
+    columns_to_update = [
+        ("application", "permissions"),
+        ("artefact_matching_rule", "grant_permissions"),
+        ("team", "permissions"),
+    ]
+    # Update existing table columns to use the new enum type
+    for table_name, column_name in columns_to_update:
+        # We have to drop the default before altering the column type,
+        # otherwise PostgreSQL will complain about being unable to cast the default value to the new enum type.
+        op.execute(f"ALTER TABLE {table_name} ALTER COLUMN {column_name} DROP DEFAULT")
+
+        op.execute(
+            f"""
+            ALTER TABLE {table_name} ALTER COLUMN {column_name} TYPE {PERMISSION_ENUM_NAME}[]
+            USING {column_name}::text[]::{PERMISSION_ENUM_NAME}[]
+            """
+        )
+
+        # Reapply the default, which is an empty array of the new enum type.
+        op.execute(f"ALTER TABLE {table_name} ALTER COLUMN {column_name} SET DEFAULT '{{}}'::{PERMISSION_ENUM_NAME}[]")
+
+    # Drop the old enum type
+    # We need to use SQL here, because otherwise the SQLAlchemy Enum object will attempt to drop the new enum,
+    # since it has the same name as the old enum.
+    # This will fail, since values were updated to point to the new enum.
+    op.execute(f"DROP TYPE {PERMISSION_ENUM_NAME}_old")
+
+
+def downgrade() -> None:
+    """
+    PostgreSQL does not support removing enum values,
+    so one option is to just do nothing in the downgrade.
+    However, for the sake of attempting to create a somewhat reversible process,
+    we will rename the current enum, create the old enum, and convert the columns back to the old enum.
+    """
+
+    # Rename the current enum to a new temporary name, so that we can create the old enum with the same name.
+    op.execute(f"ALTER TYPE {PERMISSION_ENUM_NAME} RENAME TO {PERMISSION_ENUM_NAME}_new")
+
+    # Create the old enum with the same name as the current enum.
+    formatted_options = ", ".join(f"'{p}'" for p in OLD_PERMISSIONS)
+    op.execute(f"CREATE TYPE {PERMISSION_ENUM_NAME} AS ENUM ({formatted_options})")
+
+    columns_to_update = [
+        ("application", "permissions"),
+        ("artefact_matching_rule", "grant_permissions"),
+        ("team", "permissions"),
+    ]
+
+    # Update existing table columns to use the new enum type
+    # However, on downgrading, we have to remove any values that are not in the old enum
+    to_remove = ", ".join(f"'{p}'" for p in NEW_PERMISSIONS - OLD_PERMISSIONS)
+    for table_name, column_name in columns_to_update:
+        op.execute(f"ALTER TABLE {table_name} ALTER COLUMN {column_name} DROP DEFAULT")
+
+        # We want to remove any values that are not in the old enum
+        # That is, if a row has permissions = ["view_user", "change_user", "view_basic", "view_docs"],
+        # we want that row to have its permissions set to ["view_user", "change_user"]
+        op.execute(
+            f"""
+            UPDATE {table_name} SET {column_name} = COALESCE(
+                ARRAY(
+                    SELECT val
+                    FROM unnest({column_name}) AS val
+                    WHERE val::text NOT IN ({to_remove})
+                ),
+                '{{}}'
+            )
+            WHERE {column_name}::text[] && ARRAY[{to_remove}]::text[]
+            """
+        )
+        op.execute(
+            f"""
+            ALTER TABLE {table_name} ALTER COLUMN {column_name} TYPE {PERMISSION_ENUM_NAME}[]
+            USING {column_name}::text[]::{PERMISSION_ENUM_NAME}[]
+            """
+        )
+
+        op.execute(f"ALTER TABLE {table_name} ALTER COLUMN {column_name} SET DEFAULT '{{}}'::{PERMISSION_ENUM_NAME}[]")
+
+    op.execute(f"DROP TYPE {PERMISSION_ENUM_NAME}_new")

--- a/backend/migrations/versions/2026_04_04_1017-87fbc47c21f4_add_new_permissions.py
+++ b/backend/migrations/versions/2026_04_04_1017-87fbc47c21f4_add_new_permissions.py
@@ -1,3 +1,18 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
 """Add new permissions
 
 Revision ID: 87fbc47c21f4

--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -6960,6 +6960,10 @@
       "Permission": {
         "type": "string",
         "enum": [
+          "view_basic",
+          "view_sentry_debug",
+          "view_docs",
+          "view_self",
           "view_user",
           "change_user",
           "view_team",

--- a/backend/scripts/seed_data.py
+++ b/backend/scripts/seed_data.py
@@ -761,6 +761,8 @@ def seed_data(client: TestClient | requests.Session, session: Session | None = N
     application = session.scalar(select(Application).where(Application.name == "seed_data_app"))
     inspector = inspect(session.get_bind())
     permissions = next(e["labels"] for e in inspector.get_enums() if e["name"] == "permission")  # type: ignore
+    if permissions is None:
+        raise RuntimeError("Could not find permissions enum in database")
     if not application:
         application = Application(name="seed_data_app", permissions=permissions)
         session.add(application)

--- a/backend/scripts/seed_data.py
+++ b/backend/scripts/seed_data.py
@@ -23,7 +23,7 @@ from textwrap import dedent
 import requests
 from fastapi.testclient import TestClient
 from pydantic import HttpUrl
-from sqlalchemy import select
+from sqlalchemy import inspect, select
 from sqlalchemy.orm import Session
 
 from test_observer.controllers.environments.models import (
@@ -43,8 +43,6 @@ from test_observer.controllers.issues.models import (
     IssuePutRequest,
     IssueTestResultAttachmentRulePostRequest,
 )
-from test_observer.common.enums import Permission
-
 from test_observer.controllers.artefacts.models import TestExecutionRelevantLinkCreate
 
 from test_observer.data_access.models import Artefact, User, TestResult, Application
@@ -55,7 +53,6 @@ from test_observer.data_access.models_enums import (
     CharmStage,
     ImageStage,
     IssueStatus,
-    IssueSource,
 )
 from test_observer.data_access.setup import SessionLocal
 from test_observer.users.add_user import add_user
@@ -757,9 +754,15 @@ def seed_data(client: TestClient | requests.Session, session: Session | None = N
     certbot.is_admin = True
 
     # Create an application with all permissions
+    # Following the conversion of permissions to be a PostgreSQL enum,
+    # we need to pull the values from the database rather than the Python code.
+    # Otherwise, the code could contain values not present in the database,
+    # which would cause an error when trying to add the application.
     application = session.scalar(select(Application).where(Application.name == "seed_data_app"))
+    inspector = inspect(session.get_bind())
+    permissions = next(e["labels"] for e in inspector.get_enums() if e["name"] == "permission")
     if not application:
-        application = Application(name="seed_data_app", permissions=[p.value for p in Permission])
+        application = Application(name="seed_data_app", permissions=permissions)
         session.add(application)
         session.commit()
         session.refresh(application)

--- a/backend/scripts/seed_data.py
+++ b/backend/scripts/seed_data.py
@@ -760,7 +760,7 @@ def seed_data(client: TestClient | requests.Session, session: Session | None = N
     # which would cause an error when trying to add the application.
     application = session.scalar(select(Application).where(Application.name == "seed_data_app"))
     inspector = inspect(session.get_bind())
-    permissions = next(e["labels"] for e in inspector.get_enums() if e["name"] == "permission")
+    permissions = next(e["labels"] for e in inspector.get_enums() if e["name"] == "permission")  # type: ignore
     if not application:
         application = Application(name="seed_data_app", permissions=permissions)
         session.add(application)

--- a/backend/test_observer/common/enums.py
+++ b/backend/test_observer/common/enums.py
@@ -15,7 +15,21 @@
 from enum import StrEnum, auto
 
 
+# Following the conversion of permissions to be a PostgreSQL enum,
+# any change to the permissions defined here must be accompanied
+# by a new database migration to update the enum values in the database.
+# Alembic does not detect the changes in this case, so the migration must be created manually as well.
 class Permission(StrEnum):
+    # /, /v1/version
+    view_basic = auto()
+    # /sentry-debug, which is intended to be used for testing Sentry integration
+    # and does nothing but raise an exception
+    view_sentry_debug = auto()
+    # Docs (Swagger and OpenAPI schema)
+    view_docs = auto()
+    # /v1/users/me and /v1/applications/me
+    view_self = auto()
+
     # Authentication
     view_user = auto()
     change_user = auto()

--- a/backend/tests/controllers/applications/test_applications.py
+++ b/backend/tests/controllers/applications/test_applications.py
@@ -13,7 +13,9 @@
 # SPDX-FileCopyrightText: Copyright 2025 Canonical Ltd.
 # SPDX-License-Identifier: AGPL-3.0-only
 
+import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.orm import Session
 
 from test_observer.common.enums import Permission
@@ -141,3 +143,34 @@ def test_clear_application_permissions(test_client: TestClient, generator: DataG
 
     assert response.status_code == 200
     assert response.json()["permissions"] == []
+
+
+def test_create_invalid_permissions_api(test_client: TestClient):
+    response = make_authenticated_request(
+        lambda: test_client.post(
+            "/v1/applications",
+            json={"name": "myscript", "permissions": ["invalid_permission"]},
+        ),
+        Permission.add_application,
+    )
+
+    assert response.status_code == 422
+
+
+def test_update_invalid_permissions_api(test_client: TestClient, generator: DataGenerator):
+    application = generator.gen_application()
+
+    response = make_authenticated_request(
+        lambda: test_client.patch(
+            f"/v1/applications/{application.id}",
+            json={"permissions": ["invalid_permission"]},
+        ),
+        Permission.change_application,
+    )
+
+    assert response.status_code == 422
+
+
+def test_create_invalid_permissions_orm(generator: DataGenerator):
+    with pytest.raises(ProgrammingError):
+        generator.gen_application(permissions=["invalid_permission"])

--- a/backend/tests/controllers/artefact_matching_rules/test_artefact_matching_rules.py
+++ b/backend/tests/controllers/artefact_matching_rules/test_artefact_matching_rules.py
@@ -17,7 +17,9 @@
 # SPDX-FileCopyrightText: Copyright 2023 Canonical Ltd.
 # SPDX-License-Identifier: AGPL-3.0-only
 
+import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.exc import ProgrammingError
 
 from test_observer.common.enums import Permission
 from test_observer.data_access.models_enums import FamilyName
@@ -722,3 +724,51 @@ def test_teams_api_returns_empty_grant_permissions_by_default(test_client: TestC
     rules = response.json()["artefact_matching_rules"]
     assert len(rules) == 1
     assert rules[0]["grant_permissions"] == []
+
+
+def test_create_artefact_matching_rule_invalid_grant_permissions_api(test_client: TestClient, generator: DataGenerator):
+    """Test creating a rule with grant_permissions set"""
+    team = generator.gen_team(name="test-team")
+
+    response = make_authenticated_request(
+        lambda: test_client.post(
+            "/v1/artefact-matching-rules",
+            json={
+                "family": "snap",
+                "track": "22",
+                "team_ids": [team.id],
+                "grant_permissions": ["invalid_permission"],
+            },
+        ),
+        Permission.change_team,
+    )
+
+    assert response.status_code == 422
+
+
+def test_update_artefact_matching_rule_invalid_grant_permissions_api(test_client: TestClient, generator: DataGenerator):
+    """Test patching grant_permissions on an existing rule"""
+    team = generator.gen_team(name="test-team")
+    rule = generator.gen_artefact_matching_rule(family=FamilyName.snap, track="22", teams=[team])
+
+    response = make_authenticated_request(
+        lambda: test_client.patch(
+            f"/v1/artefact-matching-rules/{rule.id}",
+            json={"grant_permissions": ["invalid_permission"]},
+        ),
+        Permission.change_team,
+    )
+
+    assert response.status_code == 422
+
+
+def test_create_artefact_matching_rule_invalid_grant_permissions_orm(generator: DataGenerator):
+    """Test creating a rule with grant_permissions set"""
+    team = generator.gen_team(name="test-team")
+    with pytest.raises(ProgrammingError):
+        generator.gen_artefact_matching_rule(
+            family=FamilyName.snap,
+            track="22",
+            teams=[team],
+            grant_permissions=["invalid_permission"],  # type: ignore
+        )

--- a/backend/tests/controllers/teams/test_teams.py
+++ b/backend/tests/controllers/teams/test_teams.py
@@ -13,7 +13,9 @@
 # SPDX-FileCopyrightText: Copyright 2025 Canonical Ltd.
 # SPDX-License-Identifier: AGPL-3.0-only
 
+import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.exc import ProgrammingError
 
 from test_observer.common.enums import Permission
 from test_observer.data_access.models_enums import FamilyName
@@ -68,7 +70,7 @@ def test_create_team_with_permissions_and_matching_rules(test_client: TestClient
     assert data["members"] == []
 
 
-def test_create_team_invalid_permission(test_client: TestClient):
+def test_create_team_invalid_permission_api(test_client: TestClient):
     response = make_authenticated_request(
         lambda: test_client.post(
             "/v1/teams",
@@ -81,6 +83,14 @@ def test_create_team_invalid_permission(test_client: TestClient):
     )
 
     assert response.status_code == 422
+
+
+def test_create_team_invalid_permission_orm(generator: DataGenerator):
+    with pytest.raises(ProgrammingError):
+        generator.gen_team(
+            name="test-team",
+            permissions=["invalid_permission"],
+        )
 
 
 def test_create_team_missing_name(test_client: TestClient):


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR introduces some new permissions, which will ultimately be used by https://github.com/canonical/test_observer/pull/674, but following the move to a PostgreSQL enum for permissions, it becomes more cumbersome to add permissions.

This PR represents what is necessary to add permissions in the current scheme. It can be merged if we decide to stick with it, but I think it also serves as a good indicator that we actually don't want to use a PostgreSQL enum for permissions going forward, and so we probably want to revert that.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

Part of [Test Observer: Move root and docs behind authentication](https://warthogs.atlassian.net/browse/IQA-3506)

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

I can build and run the Docker services locally, and I also executed the downgrade manually as a test. Both directions do seem to work. Checking with the `seed_data_app` that gets populated in the local database with every permission, I can see that it gets the new permissions on upgrade, and it successfully reverts to the old permissions on downgrade.