### PR TITLE
Add missing downgrade operations to application table

### DIFF
--- a/backend/migrations/versions/2026_03_31_1410-f0847700d32e_convert_permission_to_enum.py
+++ b/backend/migrations/versions/2026_03_31_1410-f0847700d32e_convert_permission_to_enum.py
@@ -81,6 +81,9 @@ def downgrade() -> None:
     # restore previous default
     op.execute("ALTER TABLE team ALTER COLUMN permissions SET DEFAULT '{}'::character varying[]")
 
+    # drop default
+    op.execute("ALTER TABLE application ALTER COLUMN permissions DROP DEFAULT")
+
     # upgrade application table
     op.alter_column(
         "application",
@@ -90,3 +93,6 @@ def downgrade() -> None:
         existing_nullable=False,
         postgresql_using="permissions::varchar[]",
     )
+
+    # restore previous default
+    op.execute("ALTER TABLE application ALTER COLUMN permissions SET DEFAULT '{}'::character varying[]")

--- a/backend/migrations/versions/2026_03_31_1410-f0847700d32e_convert_permission_to_enum.py
+++ b/backend/migrations/versions/2026_03_31_1410-f0847700d32e_convert_permission_to_enum.py
@@ -36,6 +36,11 @@ PERMISSION_TYPE = postgresql.ARRAY(postgresql.ENUM(name="permission"))
 
 def upgrade() -> None:
     # upgrade application table
+
+    # drop default to prevent casting errors from postgresql
+    op.execute("ALTER TABLE application ALTER COLUMN permissions DROP DEFAULT")
+
+    # change type
     op.alter_column(
         "application",
         "permissions",
@@ -44,6 +49,9 @@ def upgrade() -> None:
         existing_nullable=False,
         postgresql_using="permissions::permission[]",
     )
+
+    # apply new default
+    op.execute("ALTER TABLE application ALTER COLUMN permissions SET DEFAULT '{}'::permission[]")
 
     # upgrade team table
     # drop default to prevent casting errors from postgresql


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

While working on https://github.com/canonical/test_observer/pull/686 to add new permissions, I saw some test failures that came as part of the automatic Alembic downgrades that happen in the `pytest` suite.

The changes in this PR fixed the problems there, but these changes should be merged regardless of whether that PR actually gets merged (we might end up going a different route and closing that PR).

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

This properly adjusts the permissions column on the application table. Without it, the migration is not properly atomic.