### PR TITLE
Add new permission values (Python Enum)

### DIFF
--- a/backend/migrations/versions/2026_04_05_1535-dc384aedc33e_undo_postgresql_permissions_enum.py
+++ b/backend/migrations/versions/2026_04_05_1535-dc384aedc33e_undo_postgresql_permissions_enum.py
@@ -1,0 +1,200 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Undo PostgreSQL Permissions enum.
+This migration should essentially just undo the changes made in these migrations:
+
+* 2026_03_23_1733-c29b4f545a9b_add_permissions_to_amrs.py
+* 2026_03_31_1410-f0847700d32e_convert_permission_to_enum.py
+
+Revision ID: dc384aedc33e
+Revises: f0847700d32e
+Create Date: 2026-04-05 15:35:45.285289+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "dc384aedc33e"
+down_revision = "f0847700d32e"
+branch_labels = None
+depends_on = None
+
+# Copied from 2026_03_23_1733-c29b4f545a9b_add_permissions_to_amrs.py
+PERMISSION_VALUES = (
+    "view_user",
+    "change_user",
+    "view_team",
+    "change_team",
+    "add_application",
+    "change_application",
+    "view_application",
+    "view_permission",
+    "view_issue",
+    "change_issue",
+    "change_issue_attachment",
+    "change_issue_attachment_bulk",
+    "change_attachment_rule",
+    "change_auto_rerun",
+    "view_test",
+    "change_test",
+    "view_rerun",
+    "change_rerun",
+    "change_rerun_bulk",
+    "view_artefact",
+    "change_artefact",
+    "view_environment_review",
+    "change_environment_review",
+    "view_report",
+    "view_test_case_reported_issue",
+    "change_test_case_reported_issue",
+    "view_environment_reported_issue",
+    "change_environment_reported_issue",
+    "view_notification",
+    "change_notification",
+)
+PERMISSION_ENUM = postgresql.ENUM(*PERMISSION_VALUES, name="permission")
+PERMISSION_TYPE = postgresql.ARRAY(PERMISSION_ENUM)
+
+
+def upgrade() -> None:
+    # Drop the permission array default which uses the permission type
+    op.execute("ALTER TABLE team ALTER COLUMN permissions DROP DEFAULT")
+
+    # Convert the type from the PostgreSQL enum back to an array of strings
+    op.alter_column(
+        "team",
+        "permissions",
+        existing_type=PERMISSION_TYPE,
+        type_=postgresql.ARRAY(sa.VARCHAR()),
+        existing_nullable=False,
+        postgresql_using="permissions::varchar[]",
+    )
+
+    # Restore the string array default
+    op.execute("ALTER TABLE team ALTER COLUMN permissions SET DEFAULT '{}'::character varying[]")
+
+    # Convert the type from the PostgreSQL enum back to an array of strings
+    op.alter_column(
+        "application",
+        "permissions",
+        existing_type=PERMISSION_TYPE,
+        type_=postgresql.ARRAY(sa.VARCHAR()),
+        existing_nullable=False,
+        postgresql_using="permissions::varchar[]",
+    )
+
+    # Drop the permission array default which uses the permission type
+    op.execute("ALTER TABLE artefact_matching_rule ALTER COLUMN grant_permissions DROP DEFAULT")
+
+    # Convert the type from the PostgreSQL enum back to an array of strings
+    op.alter_column(
+        "artefact_matching_rule",
+        "grant_permissions",
+        existing_type=PERMISSION_TYPE,
+        type_=postgresql.ARRAY(sa.VARCHAR()),
+        existing_nullable=False,
+        postgresql_using="grant_permissions::varchar[]",
+    )
+
+    # Set a string array default
+    op.execute(
+        "ALTER TABLE artefact_matching_rule ALTER COLUMN grant_permissions SET DEFAULT '{}'::character varying[]"
+    )
+
+    # Drop the PostgreSQL enum type
+    PERMISSION_ENUM.drop(op.get_bind(), checkfirst=True)
+
+
+def downgrade() -> None:
+    _assert_no_unknown_permission_values()
+
+    # Create the permission type
+    PERMISSION_ENUM.create(op.get_bind(), checkfirst=True)
+
+    # Drop the string array default
+    op.execute("ALTER TABLE artefact_matching_rule ALTER COLUMN grant_permissions DROP DEFAULT")
+
+    # Convert the type from an array of strings to the PostgreSQL enum
+    op.alter_column(
+        "artefact_matching_rule",
+        "grant_permissions",
+        existing_type=postgresql.ARRAY(sa.VARCHAR()),
+        type_=PERMISSION_TYPE,
+        existing_nullable=False,
+        postgresql_using="grant_permissions::permission[]",
+    )
+
+    # Restore the PostgreSQL enum array default
+    op.execute("ALTER TABLE artefact_matching_rule ALTER COLUMN grant_permissions SET DEFAULT '{}'::permission[]")
+
+    # Convert the type from an array of strings to the PostgreSQL enum
+    op.alter_column(
+        "application",
+        "permissions",
+        existing_type=postgresql.ARRAY(sa.VARCHAR()),
+        type_=PERMISSION_TYPE,
+        existing_nullable=False,
+        postgresql_using="permissions::permission[]",
+    )
+
+    # Drop the string array default
+    op.execute("ALTER TABLE team ALTER COLUMN permissions DROP DEFAULT")
+
+    # Convert the type from an array of strings to the PostgreSQL enum
+    op.alter_column(
+        "team",
+        "permissions",
+        existing_type=postgresql.ARRAY(sa.VARCHAR()),
+        type_=PERMISSION_TYPE,
+        existing_nullable=False,
+        postgresql_using="permissions::permission[]",
+    )
+
+    # Restore the PostgreSQL enum array default
+    op.execute("ALTER TABLE team ALTER COLUMN permissions SET DEFAULT '{}'::permission[]")
+
+
+def _assert_no_unknown_permission_values() -> None:
+    """Fail downgrade clearly if varchar[] contains values missing from the enum."""
+    bind = op.get_bind()
+    result = bind.execute(
+        sa.text(
+            """
+            WITH all_permissions AS (
+                SELECT unnest(permissions) AS permission_value FROM team
+                UNION ALL
+                SELECT unnest(permissions) AS permission_value FROM application
+                UNION ALL
+                SELECT unnest(grant_permissions) AS permission_value FROM artefact_matching_rule
+            )
+            SELECT DISTINCT permission_value
+            FROM all_permissions
+            WHERE permission_value IS NOT NULL
+              AND permission_value NOT IN :allowed_permissions
+            ORDER BY permission_value
+            """
+        ).bindparams(sa.bindparam("allowed_permissions", expanding=True)),
+        {"allowed_permissions": list(PERMISSION_VALUES)},
+    )
+    unknown_values = [row[0] for row in result]
+    if unknown_values:
+        raise RuntimeError(
+            "Cannot downgrade permissions to PostgreSQL enum. Unknown permission values "
+            f"found in database: {unknown_values}. Remove or map these values before downgrading."
+        )

--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -6960,6 +6960,10 @@
       "Permission": {
         "type": "string",
         "enum": [
+          "view_basic",
+          "view_sentry_debug",
+          "view_docs",
+          "view_self",
           "view_user",
           "change_user",
           "view_team",

--- a/backend/test_observer/common/enums.py
+++ b/backend/test_observer/common/enums.py
@@ -16,6 +16,16 @@ from enum import StrEnum, auto
 
 
 class Permission(StrEnum):
+    # /, /v1/version
+    view_basic = auto()
+    # /sentry-debug, which is intended to be used for testing Sentry integration
+    # and does nothing but raise an exception
+    view_sentry_debug = auto()
+    # Docs (Swagger and OpenAPI schema)
+    view_docs = auto()
+    # /v1/users/me and /v1/applications/me
+    view_self = auto()
+
     # Authentication
     view_user = auto()
     change_user = auto()

--- a/backend/test_observer/common/validation.py
+++ b/backend/test_observer/common/validation.py
@@ -1,0 +1,33 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from typing import Any
+
+from test_observer.common.enums import Permission
+
+
+def validate_permissions(permissions: list[Any]) -> list[Permission]:
+    """
+    Make sure that the provided permissions are valid Permission enum members.
+    """
+
+    validated: list[Permission] = []
+    for permission in permissions:
+        if not isinstance(permission, Permission | str):
+            raise ValueError(f"Invalid permission type: {permission} (type {type(permission)})")
+        if permission not in Permission:
+            raise ValueError(f"Invalid permission: {permission}")
+        validated.append(Permission(permission))
+    return validated

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -42,6 +42,7 @@ from sqlalchemy.orm import (
     foreign,
     mapped_column,
     relationship,
+    validates,
 )
 from sqlalchemy.sql import ColumnElement, func
 
@@ -170,8 +171,18 @@ class Application(Base):
     name: Mapped[str] = mapped_column(unique=True)
     # We use native_enum=False because adding permissions with native enums
     # requires a migration to update the possible values
-    # SQLAlchemy will still do Python-side validation (though only through the ORM)
+    # As a result, we add our own validator as well
     permissions: Mapped[list[Permission]] = mapped_column(ARRAY(Enum(Permission, native_enum=False)), default=list)
+
+    @validates("permissions")
+    def validate_permissions(self, _key: str, value: list[Permission | str]) -> list[Permission]:
+        invalid: list[Permission | str] = []
+        for permission in value:
+            if permission not in Permission:
+                invalid.append(permission)
+        if invalid:
+            raise ValueError(f"Invalid permissions: {', '.join(invalid)}")
+        return value  # type: ignore[return-value]
 
     @staticmethod
     def gen_api_key() -> str:
@@ -195,8 +206,18 @@ class Team(Base):
     name: Mapped[str] = mapped_column(unique=True)
     # We use native_enum=False because adding permissions with native enums
     # requires a migration to update the possible values
-    # SQLAlchemy will still do Python-side validation (though only through the ORM)
+    # As a result, we add our own validator as well
     permissions: Mapped[list[Permission]] = mapped_column(ARRAY(Enum(Permission, native_enum=False)), default=list)
+
+    @validates("permissions")
+    def validate_permissions(self, _key: str, value: list[Permission | str]) -> list[Permission]:
+        invalid: list[Permission | str] = []
+        for permission in value:
+            if permission not in Permission:
+                invalid.append(permission)
+        if invalid:
+            raise ValueError(f"Invalid permissions: {', '.join(invalid)}")
+        return value  # type: ignore[return-value]
 
     members: Mapped[list[User]] = relationship(secondary=team_users_association, back_populates="teams")
     artefact_matching_rules: Mapped[list["ArtefactMatchingRule"]] = relationship(
@@ -229,10 +250,20 @@ class ArtefactMatchingRule(Base):
 
     # We use native_enum=False because adding permissions with native enums
     # requires a migration to update the possible values
-    # SQLAlchemy will still do Python-side validation (though only through the ORM)
+    # As a result, we add our own validator as well
     grant_permissions: Mapped[list[Permission]] = mapped_column(
         ARRAY(Enum(Permission, native_enum=False)), default=list
     )
+
+    @validates("grant_permissions")
+    def validate_grant_permissions(self, _key: str, value: list[Permission | str]) -> list[Permission]:
+        invalid: list[Permission | str] = []
+        for permission in value:
+            if permission not in Permission:
+                invalid.append(permission)
+        if invalid:
+            raise ValueError(f"Invalid permissions: {', '.join(invalid)}")
+        return value  # type: ignore[return-value]
 
     __table_args__ = (UniqueConstraint("name", "family", "stage", "track", "branch"),)
 

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -168,7 +168,10 @@ class Application(Base):
     __tablename__ = "application"
 
     name: Mapped[str] = mapped_column(unique=True)
-    permissions: Mapped[list[Permission]] = mapped_column(ARRAY(Enum(Permission)), default=list)
+    # We use native_enum=False because adding permissions with native enums
+    # requires a migration to update the possible values
+    # SQLAlchemy will still do Python-side validation
+    permissions: Mapped[list[Permission]] = mapped_column(ARRAY(Enum(Permission, native_enum=False)), default=list)
 
     @staticmethod
     def gen_api_key() -> str:
@@ -190,7 +193,10 @@ class Team(Base):
     __tablename__ = "team"
 
     name: Mapped[str] = mapped_column(unique=True)
-    permissions: Mapped[list[Permission]] = mapped_column(ARRAY(Enum(Permission)), default=list)
+    # We use native_enum=False because adding permissions with native enums
+    # requires a migration to update the possible values
+    # SQLAlchemy will still do Python-side validation
+    permissions: Mapped[list[Permission]] = mapped_column(ARRAY(Enum(Permission, native_enum=False)), default=list)
 
     members: Mapped[list[User]] = relationship(secondary=team_users_association, back_populates="teams")
     artefact_matching_rules: Mapped[list["ArtefactMatchingRule"]] = relationship(
@@ -221,7 +227,12 @@ class ArtefactMatchingRule(Base):
         back_populates="artefact_matching_rules",
     )
 
-    grant_permissions: Mapped[list[Permission]] = mapped_column(ARRAY(Enum(Permission)), default=list)
+    # We use native_enum=False because adding permissions with native enums
+    # requires a migration to update the possible values
+    # SQLAlchemy will still do Python-side validation
+    grant_permissions: Mapped[list[Permission]] = mapped_column(
+        ARRAY(Enum(Permission, native_enum=False)), default=list
+    )
 
     __table_args__ = (UniqueConstraint("name", "family", "stage", "track", "branch"),)
 

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -47,6 +47,7 @@ from sqlalchemy.orm import (
 from sqlalchemy.sql import ColumnElement, func
 
 from test_observer.common.enums import Permission
+from test_observer.common.validation import validate_permissions
 from test_observer.data_access.models_enums import (
     ArtefactBuildEnvironmentReviewDecision,
     ArtefactStatus,
@@ -175,14 +176,8 @@ class Application(Base):
     permissions: Mapped[list[Permission]] = mapped_column(ARRAY(Enum(Permission, native_enum=False)), default=list)
 
     @validates("permissions")
-    def validate_permissions(self, _key: str, value: list[Permission | str]) -> list[Permission]:
-        invalid: list[Permission | str] = []
-        for permission in value:
-            if permission not in Permission:
-                invalid.append(permission)
-        if invalid:
-            raise ValueError(f"Invalid permissions: {', '.join(invalid)}")
-        return value  # type: ignore[return-value]
+    def validate_permissions(self, _key: str, values: list[Permission | str]) -> list[Permission]:
+        return validate_permissions(values)
 
     @staticmethod
     def gen_api_key() -> str:
@@ -210,14 +205,8 @@ class Team(Base):
     permissions: Mapped[list[Permission]] = mapped_column(ARRAY(Enum(Permission, native_enum=False)), default=list)
 
     @validates("permissions")
-    def validate_permissions(self, _key: str, value: list[Permission | str]) -> list[Permission]:
-        invalid: list[Permission | str] = []
-        for permission in value:
-            if permission not in Permission:
-                invalid.append(permission)
-        if invalid:
-            raise ValueError(f"Invalid permissions: {', '.join(invalid)}")
-        return value  # type: ignore[return-value]
+    def validate_permissions(self, _key: str, values: list[Permission | str]) -> list[Permission]:
+        return validate_permissions(values)
 
     members: Mapped[list[User]] = relationship(secondary=team_users_association, back_populates="teams")
     artefact_matching_rules: Mapped[list["ArtefactMatchingRule"]] = relationship(
@@ -256,14 +245,8 @@ class ArtefactMatchingRule(Base):
     )
 
     @validates("grant_permissions")
-    def validate_grant_permissions(self, _key: str, value: list[Permission | str]) -> list[Permission]:
-        invalid: list[Permission | str] = []
-        for permission in value:
-            if permission not in Permission:
-                invalid.append(permission)
-        if invalid:
-            raise ValueError(f"Invalid permissions: {', '.join(invalid)}")
-        return value  # type: ignore[return-value]
+    def validate_grant_permissions(self, _key: str, values: list[Permission | str]) -> list[Permission]:
+        return validate_permissions(values)
 
     __table_args__ = (UniqueConstraint("name", "family", "stage", "track", "branch"),)
 

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -170,7 +170,7 @@ class Application(Base):
     name: Mapped[str] = mapped_column(unique=True)
     # We use native_enum=False because adding permissions with native enums
     # requires a migration to update the possible values
-    # SQLAlchemy will still do Python-side validation
+    # SQLAlchemy will still do Python-side validation (though only through the ORM)
     permissions: Mapped[list[Permission]] = mapped_column(ARRAY(Enum(Permission, native_enum=False)), default=list)
 
     @staticmethod
@@ -195,7 +195,7 @@ class Team(Base):
     name: Mapped[str] = mapped_column(unique=True)
     # We use native_enum=False because adding permissions with native enums
     # requires a migration to update the possible values
-    # SQLAlchemy will still do Python-side validation
+    # SQLAlchemy will still do Python-side validation (though only through the ORM)
     permissions: Mapped[list[Permission]] = mapped_column(ARRAY(Enum(Permission, native_enum=False)), default=list)
 
     members: Mapped[list[User]] = relationship(secondary=team_users_association, back_populates="teams")
@@ -229,7 +229,7 @@ class ArtefactMatchingRule(Base):
 
     # We use native_enum=False because adding permissions with native enums
     # requires a migration to update the possible values
-    # SQLAlchemy will still do Python-side validation
+    # SQLAlchemy will still do Python-side validation (though only through the ORM)
     grant_permissions: Mapped[list[Permission]] = mapped_column(
         ARRAY(Enum(Permission, native_enum=False)), default=list
     )

--- a/backend/tests/controllers/applications/test_applications.py
+++ b/backend/tests/controllers/applications/test_applications.py
@@ -171,11 +171,11 @@ def test_update_invalid_permissions_api(test_client: TestClient, generator: Data
 
 
 def test_create_invalid_permissions_orm(generator: DataGenerator):
-    with pytest.raises(ValueError, match="Invalid permissions: invalid_permission"):
+    with pytest.raises(ValueError, match="Invalid permission: invalid_permission"):
         generator.gen_application(permissions=["invalid_permission"])
 
 
 def test_update_invalid_permissions_orm(generator: DataGenerator):
     application = generator.gen_application()
-    with pytest.raises(ValueError, match="Invalid permissions: invalid_permission"):
+    with pytest.raises(ValueError, match="Invalid permission: invalid_permission"):
         application.permissions = ["invalid_permission"]  # type: ignore

--- a/backend/tests/controllers/applications/test_applications.py
+++ b/backend/tests/controllers/applications/test_applications.py
@@ -13,6 +13,7 @@
 # SPDX-FileCopyrightText: Copyright 2025 Canonical Ltd.
 # SPDX-License-Identifier: AGPL-3.0-only
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -141,3 +142,40 @@ def test_clear_application_permissions(test_client: TestClient, generator: DataG
 
     assert response.status_code == 200
     assert response.json()["permissions"] == []
+
+
+def test_create_invalid_permissions_api(test_client: TestClient):
+    response = make_authenticated_request(
+        lambda: test_client.post(
+            "/v1/applications",
+            json={"name": "myscript", "permissions": ["invalid_permission"]},
+        ),
+        Permission.add_application,
+    )
+
+    assert response.status_code == 422
+
+
+def test_update_invalid_permissions_api(test_client: TestClient, generator: DataGenerator):
+    application = generator.gen_application()
+
+    response = make_authenticated_request(
+        lambda: test_client.patch(
+            f"/v1/applications/{application.id}",
+            json={"permissions": ["invalid_permission"]},
+        ),
+        Permission.change_application,
+    )
+
+    assert response.status_code == 422
+
+
+def test_create_invalid_permissions_orm(generator: DataGenerator):
+    with pytest.raises(ValueError, match="Invalid permissions: invalid_permission"):
+        generator.gen_application(permissions=["invalid_permission"])
+
+
+def test_update_invalid_permissions_orm(generator: DataGenerator):
+    application = generator.gen_application()
+    with pytest.raises(ValueError, match="Invalid permissions: invalid_permission"):
+        application.permissions = ["invalid_permission"]  # type: ignore

--- a/backend/tests/controllers/artefact_matching_rules/test_artefact_matching_rules.py
+++ b/backend/tests/controllers/artefact_matching_rules/test_artefact_matching_rules.py
@@ -764,7 +764,7 @@ def test_update_invalid_grant_permissions_api(test_client: TestClient, generator
 def test_create_invalid_grant_permissions_orm(generator: DataGenerator):
     """Test creating a rule with grant_permissions set"""
     team = generator.gen_team(name="test-team")
-    with pytest.raises(ValueError, match="Invalid permissions: invalid_permission"):
+    with pytest.raises(ValueError, match="Invalid permission: invalid_permission"):
         generator.gen_artefact_matching_rule(
             family=FamilyName.snap,
             track="22",
@@ -778,5 +778,5 @@ def test_update_invalid_grant_permissions_orm(generator: DataGenerator):
     team = generator.gen_team(name="test-team")
     rule = generator.gen_artefact_matching_rule(family=FamilyName.snap, track="22", teams=[team])
 
-    with pytest.raises(ValueError, match="Invalid permissions: invalid_permission"):
+    with pytest.raises(ValueError, match="Invalid permission: invalid_permission"):
         rule.grant_permissions = ["invalid_permission"]  # type: ignore

--- a/backend/tests/controllers/artefact_matching_rules/test_artefact_matching_rules.py
+++ b/backend/tests/controllers/artefact_matching_rules/test_artefact_matching_rules.py
@@ -17,6 +17,7 @@
 # SPDX-FileCopyrightText: Copyright 2023 Canonical Ltd.
 # SPDX-License-Identifier: AGPL-3.0-only
 
+import pytest
 from fastapi.testclient import TestClient
 
 from test_observer.common.enums import Permission
@@ -722,3 +723,60 @@ def test_teams_api_returns_empty_grant_permissions_by_default(test_client: TestC
     rules = response.json()["artefact_matching_rules"]
     assert len(rules) == 1
     assert rules[0]["grant_permissions"] == []
+
+
+def test_create_invalid_grant_permissions_api(test_client: TestClient, generator: DataGenerator):
+    """Test creating a rule with grant_permissions set"""
+    team = generator.gen_team(name="test-team")
+
+    response = make_authenticated_request(
+        lambda: test_client.post(
+            "/v1/artefact-matching-rules",
+            json={
+                "family": "snap",
+                "track": "22",
+                "team_ids": [team.id],
+                "grant_permissions": ["invalid_permission"],
+            },
+        ),
+        Permission.change_team,
+    )
+
+    assert response.status_code == 422
+
+
+def test_update_invalid_grant_permissions_api(test_client: TestClient, generator: DataGenerator):
+    """Test patching grant_permissions on an existing rule"""
+    team = generator.gen_team(name="test-team")
+    rule = generator.gen_artefact_matching_rule(family=FamilyName.snap, track="22", teams=[team])
+
+    response = make_authenticated_request(
+        lambda: test_client.patch(
+            f"/v1/artefact-matching-rules/{rule.id}",
+            json={"grant_permissions": ["invalid_permission"]},
+        ),
+        Permission.change_team,
+    )
+
+    assert response.status_code == 422
+
+
+def test_create_invalid_grant_permissions_orm(generator: DataGenerator):
+    """Test creating a rule with grant_permissions set"""
+    team = generator.gen_team(name="test-team")
+    with pytest.raises(ValueError, match="Invalid permissions: invalid_permission"):
+        generator.gen_artefact_matching_rule(
+            family=FamilyName.snap,
+            track="22",
+            teams=[team],
+            grant_permissions=["invalid_permission"],  # type: ignore
+        )
+
+
+def test_update_invalid_grant_permissions_orm(generator: DataGenerator):
+    """Test patching grant_permissions on an existing rule"""
+    team = generator.gen_team(name="test-team")
+    rule = generator.gen_artefact_matching_rule(family=FamilyName.snap, track="22", teams=[team])
+
+    with pytest.raises(ValueError, match="Invalid permissions: invalid_permission"):
+        rule.grant_permissions = ["invalid_permission"]  # type: ignore

--- a/backend/tests/controllers/artefact_matching_rules/test_artefact_matching_rules.py
+++ b/backend/tests/controllers/artefact_matching_rules/test_artefact_matching_rules.py
@@ -726,7 +726,7 @@ def test_teams_api_returns_empty_grant_permissions_by_default(test_client: TestC
 
 
 def test_create_invalid_grant_permissions_api(test_client: TestClient, generator: DataGenerator):
-    """Test creating a rule with grant_permissions set"""
+    """Test creating a rule with invalid grant_permissions set using the API"""
     team = generator.gen_team(name="test-team")
 
     response = make_authenticated_request(
@@ -746,7 +746,7 @@ def test_create_invalid_grant_permissions_api(test_client: TestClient, generator
 
 
 def test_update_invalid_grant_permissions_api(test_client: TestClient, generator: DataGenerator):
-    """Test patching grant_permissions on an existing rule"""
+    """Test patching grant_permissions on an existing rule with invalid permissions using the API"""
     team = generator.gen_team(name="test-team")
     rule = generator.gen_artefact_matching_rule(family=FamilyName.snap, track="22", teams=[team])
 
@@ -762,7 +762,7 @@ def test_update_invalid_grant_permissions_api(test_client: TestClient, generator
 
 
 def test_create_invalid_grant_permissions_orm(generator: DataGenerator):
-    """Test creating a rule with grant_permissions set"""
+    """Test creating a rule with invalid grant_permissions set using the ORM directly"""
     team = generator.gen_team(name="test-team")
     with pytest.raises(ValueError, match="Invalid permission: invalid_permission"):
         generator.gen_artefact_matching_rule(
@@ -774,7 +774,7 @@ def test_create_invalid_grant_permissions_orm(generator: DataGenerator):
 
 
 def test_update_invalid_grant_permissions_orm(generator: DataGenerator):
-    """Test patching grant_permissions on an existing rule"""
+    """Test patching grant_permissions on an existing rule using the ORM directly"""
     team = generator.gen_team(name="test-team")
     rule = generator.gen_artefact_matching_rule(family=FamilyName.snap, track="22", teams=[team])
 

--- a/backend/tests/controllers/teams/test_teams.py
+++ b/backend/tests/controllers/teams/test_teams.py
@@ -13,6 +13,7 @@
 # SPDX-FileCopyrightText: Copyright 2025 Canonical Ltd.
 # SPDX-License-Identifier: AGPL-3.0-only
 
+import pytest
 from fastapi.testclient import TestClient
 
 from test_observer.common.enums import Permission
@@ -68,7 +69,7 @@ def test_create_team_with_permissions_and_matching_rules(test_client: TestClient
     assert data["members"] == []
 
 
-def test_create_team_invalid_permission(test_client: TestClient):
+def test_create_team_invalid_permission_api(test_client: TestClient):
     response = make_authenticated_request(
         lambda: test_client.post(
             "/v1/teams",
@@ -579,3 +580,17 @@ def test_remove_rule_from_team_without_making_it_an_orphan_does_not_remove_rule(
         Permission.view_team,
     )
     assert response.status_code == 200
+
+
+def test_create_team_invalid_permission_orm(generator: DataGenerator):
+    with pytest.raises(ValueError, match="Invalid permissions: invalid_permission"):
+        generator.gen_team(
+            name="test-team",
+            permissions=["invalid_permission"],
+        )
+
+
+def test_update_team_invalid_permission_orm(generator: DataGenerator):
+    team = generator.gen_team(name="test-team")
+    with pytest.raises(ValueError, match="Invalid permissions: invalid_permission"):
+        team.permissions = ["invalid_permission"]  # type: ignore

--- a/backend/tests/controllers/teams/test_teams.py
+++ b/backend/tests/controllers/teams/test_teams.py
@@ -583,7 +583,7 @@ def test_remove_rule_from_team_without_making_it_an_orphan_does_not_remove_rule(
 
 
 def test_create_team_invalid_permission_orm(generator: DataGenerator):
-    with pytest.raises(ValueError, match="Invalid permissions: invalid_permission"):
+    with pytest.raises(ValueError, match="Invalid permission: invalid_permission"):
         generator.gen_team(
             name="test-team",
             permissions=["invalid_permission"],
@@ -592,5 +592,5 @@ def test_create_team_invalid_permission_orm(generator: DataGenerator):
 
 def test_update_team_invalid_permission_orm(generator: DataGenerator):
     team = generator.gen_team(name="test-team")
-    with pytest.raises(ValueError, match="Invalid permissions: invalid_permission"):
+    with pytest.raises(ValueError, match="Invalid permission: invalid_permission"):
         team.permissions = ["invalid_permission"]  # type: ignore


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

As mentioned in https://github.com/canonical/test_observer/pull/674, this is the alternate version of https://github.com/canonical/test_observer/pull/686. This undoes the move to native PostgreSQL enums, since that makes adding new permissions more of a headache. This does add some SQLAlchemy validators so that we can still get some enforcement on the values and adds tests that cover the cases of trying to apply invalid values.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

Part of [Test Observer: Move root and docs behind authentication](https://warthogs.atlassian.net/browse/IQA-3506)

## Tests

Added tests
