### PR TITLE
To 299/permission checking for reruns

### DIFF
--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -339,7 +339,6 @@
           }
         },
         "x-permissions": [
-          "change_rerun",
           "change_rerun_bulk"
         ]
       },
@@ -498,7 +497,6 @@
           }
         },
         "x-permissions": [
-          "change_rerun",
           "change_rerun_bulk"
         ]
       }

--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -339,6 +339,7 @@
           }
         },
         "x-permissions": [
+          "change_rerun",
           "change_rerun_bulk"
         ]
       },
@@ -497,6 +498,7 @@
           }
         },
         "x-permissions": [
+          "change_rerun",
           "change_rerun_bulk"
         ]
       }

--- a/backend/test_observer/controllers/test_executions/reruns.py
+++ b/backend/test_observer/controllers/test_executions/reruns.py
@@ -188,7 +188,8 @@ def _validate_amr_permissions_for_request(
     # The selectinload patterns in check_amr_permission() are sufficient
     # to handle the relationships it needs.
     affected_artefacts_query = (
-        select(Artefact).distinct()
+        select(Artefact)
+        .distinct()
         .join(ArtefactBuild, Artefact.id == ArtefactBuild.artefact_id)
         .join(TestExecution, TestExecution.artefact_build_id == ArtefactBuild.id)
         .where(or_(*conditions))

--- a/backend/test_observer/controllers/test_executions/reruns.py
+++ b/backend/test_observer/controllers/test_executions/reruns.py
@@ -23,7 +23,11 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session, selectinload
 
 from test_observer.common.enums import Permission
-from test_observer.common.permissions import check_amr_permission, permission_checker
+from test_observer.common.permissions import (
+    check_amr_permission,
+    permission_checker,
+)
+from test_observer.common.config import IGNORE_PERMISSIONS
 from test_observer.controllers.applications.application_injection import (
     get_current_application,
 )
@@ -154,14 +158,15 @@ def _validate_amr_permissions_for_request(
     permission: Permission,
 ) -> None:
     """
-    Validate AMR permissions for rerun requests.
+    Validate AMR permissions for rerun requests with optimized batch querying.
 
     Handles two cases:
     1. Direct IDs: When request.test_execution_ids is provided
     2. Filters: When request.test_results_filters is provided
 
     Uses all-or-nothing semantics: raise HTTPException(403) if ANY artefact is unauthorized.
-    Bypasses AMR checking if app has the permission or user is admin.
+    Honors IGNORE_PERMISSIONS, app.permissions, and admin bypass through early exits.
+    Uses batch querying to reduce database load from O(n) to O(1) for AMR matching.
 
     Args:
         db: Database session
@@ -173,7 +178,11 @@ def _validate_amr_permissions_for_request(
     Raises:
         HTTPException(403): If any affected artefact is unauthorized
     """
-    # If app has permission, skip AMR checking
+    # Early exit: if permission is in IGNORE_PERMISSIONS, skip all checks
+    if permission.value in IGNORE_PERMISSIONS:
+        return
+
+    # Early exit: if app has the permission, skip AMR checking
     if app and permission in app.permissions:
         return
 
@@ -182,14 +191,6 @@ def _validate_amr_permissions_for_request(
 
     # If no conditions, nothing to check
     if not conditions:
-        return
-
-    # If no user, deny
-    if user is None:
-        raise HTTPException(status_code=403, detail="Insufficient permissions")
-
-    # If user is admin, allow
-    if user.is_admin:
         return
 
     # Query for all unique artefacts affected by the request
@@ -203,12 +204,22 @@ def _validate_amr_permissions_for_request(
 
     affected_artefacts = db.scalars(affected_artefacts_query).all()
 
+    # If no affected artefacts, no permissions to check (e.g., invalid test_execution_ids)
     if not affected_artefacts:
+        return
+
+    # Now check user authorization (only if we have artefacts to check)
+    # Early exit: if no user, deny (unless app permission or IGNORE_PERMISSIONS already passed)
+    if user is None:
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
+
+    # Early exit: if user is admin, allow
+    if user.is_admin:
         return
 
     # Batch match all artefacts to their AMRs in a single query
     batch_match_result = db.execute(batch_match_artefacts(affected_artefacts)).all()
-    
+
     # Build map: artefact_id → set of matching AMR IDs
     artefact_to_amrs: dict[int, set[int]] = {}
     matched_amr_ids = set()
@@ -232,15 +243,15 @@ def _validate_amr_permissions_for_request(
 
     # Check permission for each affected artefact using all-or-nothing semantics
     user_team_ids = {team.id for team in user.teams}
-    
+
     for artefact in affected_artefacts:
         # Check if this artefact has any matching AMRs
         matching_amr_ids = artefact_to_amrs.get(artefact.id, set())
-        
+
         if not matching_amr_ids:
             # No AMRs match this artefact
             raise HTTPException(status_code=403, detail="Insufficient permissions")
-        
+
         # Check if user is in a team with a matching AMR that grants the permission
         has_permission = False
         for amr_id in matching_amr_ids:
@@ -250,9 +261,10 @@ def _validate_amr_permissions_for_request(
                 if user_team_ids & rule_team_ids:
                     has_permission = True
                     break
-        
+
         if not has_permission:
             raise HTTPException(status_code=403, detail="Insufficient permissions")
+
 
 
 

--- a/backend/test_observer/controllers/test_executions/reruns.py
+++ b/backend/test_observer/controllers/test_executions/reruns.py
@@ -25,6 +25,7 @@ from sqlalchemy.orm import Session, selectinload
 from test_observer.common.config import IGNORE_PERMISSIONS
 from test_observer.common.enums import Permission
 from test_observer.common.permissions import (
+    openapi_scope_declaration,
     permission_checker,
 )
 from test_observer.controllers.applications.application_injection import (
@@ -261,6 +262,7 @@ def _validate_amr_permissions_for_request(
     "/reruns",
     response_model=list[PendingRerun] | None,
     dependencies=[
+        Security(openapi_scope_declaration, scopes=[Permission.change_rerun]),
         Security(require_bulk_permission, scopes=[Permission.change_rerun_bulk]),
     ],
 )
@@ -380,6 +382,7 @@ def get_rerun_requests(
 @router.delete(
     "/reruns",
     dependencies=[
+        Security(openapi_scope_declaration, scopes=[Permission.change_rerun]),
         Security(require_bulk_permission, scopes=[Permission.change_rerun_bulk]),
     ],
 )

--- a/backend/test_observer/controllers/test_executions/reruns.py
+++ b/backend/test_observer/controllers/test_executions/reruns.py
@@ -34,6 +34,7 @@ from test_observer.data_access.models import (
     Application,
     Artefact,
     ArtefactBuild,
+    ArtefactMatchingRule,
     Environment,
     FamilyName,
     TestExecution,
@@ -41,6 +42,7 @@ from test_observer.data_access.models import (
     TestResult,
     User,
 )
+from test_observer.data_access.queries import batch_match_artefacts
 from test_observer.data_access.repository import get_or_create
 from test_observer.data_access.setup import get_db
 from test_observer.users.user_injection import get_current_user
@@ -182,11 +184,15 @@ def _validate_amr_permissions_for_request(
     if not conditions:
         return
 
+    # If no user, deny
+    if user is None:
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
+
+    # If user is admin, allow
+    if user.is_admin:
+        return
+
     # Query for all unique artefacts affected by the request
-    # Note: We don't eagerly load Artefact relationships here because
-    # check_amr_permission() will do its own selectinload for AMR matching.
-    # The selectinload patterns in check_amr_permission() are sufficient
-    # to handle the relationships it needs.
     affected_artefacts_query = (
         select(Artefact)
         .distinct()
@@ -197,11 +203,57 @@ def _validate_amr_permissions_for_request(
 
     affected_artefacts = db.scalars(affected_artefacts_query).all()
 
-    # Check permission for each affected artefact
-    # TODO(raul): optimize (one query per artefact)
-    # Using all-or-nothing semantics: fail if ANY artefact is unauthorized
+    if not affected_artefacts:
+        return
+
+    # Batch match all artefacts to their AMRs in a single query
+    batch_match_result = db.execute(batch_match_artefacts(affected_artefacts)).all()
+    
+    # Build map: artefact_id → set of matching AMR IDs
+    artefact_to_amrs: dict[int, set[int]] = {}
+    matched_amr_ids = set()
+    for artefact_id, amr_id in batch_match_result:
+        artefact_to_amrs.setdefault(artefact_id, set()).add(amr_id)
+        matched_amr_ids.add(amr_id)
+
+    # Fetch all matching AMRs with teams in a single query
+    if matched_amr_ids:
+        matching_rules = (
+            db.query(ArtefactMatchingRule)
+            .filter(ArtefactMatchingRule.id.in_(matched_amr_ids))
+            .options(selectinload(ArtefactMatchingRule.teams))
+            .all()
+        )
+    else:
+        matching_rules = []
+
+    # Build map: AMR ID → rule with teams
+    amr_rules = {rule.id: rule for rule in matching_rules}
+
+    # Check permission for each affected artefact using all-or-nothing semantics
+    user_team_ids = {team.id for team in user.teams}
+    
     for artefact in affected_artefacts:
-        check_amr_permission(db, user, artefact, permission)
+        # Check if this artefact has any matching AMRs
+        matching_amr_ids = artefact_to_amrs.get(artefact.id, set())
+        
+        if not matching_amr_ids:
+            # No AMRs match this artefact
+            raise HTTPException(status_code=403, detail="Insufficient permissions")
+        
+        # Check if user is in a team with a matching AMR that grants the permission
+        has_permission = False
+        for amr_id in matching_amr_ids:
+            rule = amr_rules.get(amr_id)
+            if rule and permission in rule.grant_permissions:
+                rule_team_ids = {team.id for team in rule.teams}
+                if user_team_ids & rule_team_ids:
+                    has_permission = True
+                    break
+        
+        if not has_permission:
+            raise HTTPException(status_code=403, detail="Insufficient permissions")
+
 
 
 @router.post(

--- a/backend/test_observer/controllers/test_executions/reruns.py
+++ b/backend/test_observer/controllers/test_executions/reruns.py
@@ -177,12 +177,14 @@ def _validate_amr_permissions_for_request(
     Raises:
         HTTPException(403): If any affected artefact is unauthorized
     """
-    # Early exit: if permission is in IGNORE_PERMISSIONS, skip all checks
-    if permission.value in IGNORE_PERMISSIONS:
+    # Early exits
+    ignored_permission = permission.value in IGNORE_PERMISSIONS
+    app_has_permission = app is not None and permission in app.permissions
+    if ignored_permission or app_has_permission:
         return
-
-    # Early exit: if app has the permission, skip AMR checking
-    if app and permission in app.permissions:
+    if user is None:
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
+    elif user.is_admin:
         return
 
     # Collect conditions to find affected TestExecutions
@@ -192,6 +194,7 @@ def _validate_amr_permissions_for_request(
     if not conditions:
         return
 
+    # Check user authorization
     # Query for all unique artefacts affected by the request
     affected_artefacts_query = (
         select(Artefact)
@@ -207,16 +210,6 @@ def _validate_amr_permissions_for_request(
     if not affected_artefacts:
         return
 
-    # Now check user authorization (only if we have artefacts to check)
-    # Early exit: if no user, deny (unless app permission or IGNORE_PERMISSIONS already passed)
-    if user is None:
-        raise HTTPException(status_code=403, detail="Insufficient permissions")
-
-    # Early exit: if user is admin, allow
-    if user.is_admin:
-        return
-
-    # Batch match all artefacts to their AMRs in a single query
     batch_match_result = db.execute(batch_match_artefacts(list(affected_artefacts))).all()
 
     # Build map: artefact_id → set of matching AMR IDs
@@ -244,7 +237,6 @@ def _validate_amr_permissions_for_request(
     user_team_ids = {team.id for team in user.teams}
 
     for artefact in affected_artefacts:
-        # Check if this artefact has any matching AMRs
         matching_amr_ids = artefact_to_amrs.get(artefact.id, set())
 
         if not matching_amr_ids:
@@ -255,7 +247,7 @@ def _validate_amr_permissions_for_request(
         has_permission = False
         for amr_id in matching_amr_ids:
             rule = amr_rules.get(amr_id)
-            if rule and permission in rule.grant_permissions:
+            if rule is not None and permission in rule.grant_permissions:
                 rule_team_ids = {team.id for team in rule.teams}
                 if user_team_ids & rule_team_ids:
                     has_permission = True

--- a/backend/test_observer/controllers/test_executions/reruns.py
+++ b/backend/test_observer/controllers/test_executions/reruns.py
@@ -22,12 +22,11 @@ from sqlalchemy import asc, delete, or_, select, tuple_
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session, selectinload
 
+from test_observer.common.config import IGNORE_PERMISSIONS
 from test_observer.common.enums import Permission
 from test_observer.common.permissions import (
-    check_amr_permission,
     permission_checker,
 )
-from test_observer.common.config import IGNORE_PERMISSIONS
 from test_observer.controllers.applications.application_injection import (
     get_current_application,
 )
@@ -218,7 +217,7 @@ def _validate_amr_permissions_for_request(
         return
 
     # Batch match all artefacts to their AMRs in a single query
-    batch_match_result = db.execute(batch_match_artefacts(affected_artefacts)).all()
+    batch_match_result = db.execute(batch_match_artefacts(list(affected_artefacts))).all()
 
     # Build map: artefact_id → set of matching AMR IDs
     artefact_to_amrs: dict[int, set[int]] = {}
@@ -264,8 +263,6 @@ def _validate_amr_permissions_for_request(
 
         if not has_permission:
             raise HTTPException(status_code=403, detail="Insufficient permissions")
-
-
 
 
 @router.post(

--- a/backend/test_observer/controllers/test_executions/reruns.py
+++ b/backend/test_observer/controllers/test_executions/reruns.py
@@ -23,7 +23,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session, selectinload
 
 from test_observer.common.enums import Permission
-from test_observer.common.permissions import permission_checker
+from test_observer.common.permissions import check_amr_permission, permission_checker
 from test_observer.controllers.applications.application_injection import (
     get_current_application,
 )
@@ -49,10 +49,21 @@ from .models import DeleteReruns, PendingRerun, RerunRequest
 from .router import router
 
 
-def modify_reruns(
-    db: Session,
-    request: RerunRequest | DeleteReruns,
-):
+def _build_rerun_conditions(request: RerunRequest | DeleteReruns) -> list:
+    """Build conditions for finding affected TestExecutions.
+
+    Constructs a list of SQLAlchemy conditions for either direct test execution IDs
+    or filtered test results.
+
+    Args:
+        request: RerunRequest or DeleteReruns with either test_execution_ids or test_results_filters
+
+    Returns:
+        List of SQLAlchemy conditions (may be empty if neither criterion is provided)
+
+    Raises:
+        HTTPException(422): If test_results_filters is provided but has no filters
+    """
     conditions = []
 
     # Add condition for direct test execution IDs
@@ -69,6 +80,15 @@ def modify_reruns(
             )
         filtered_ids_query = filter_test_results(select(TestResult.test_execution_id).distinct(), filters)
         conditions.append(TestExecution.id.in_(filtered_ids_query))
+
+    return conditions
+
+
+def modify_reruns(
+    db: Session,
+    request: RerunRequest | DeleteReruns,
+):
+    conditions = _build_rerun_conditions(request)
 
     # Do nothing if no conditions were added
     if not conditions:
@@ -124,11 +144,69 @@ def require_bulk_permission(
         permission_checker(security_scopes, user, app)
 
 
+def _validate_amr_permissions_for_request(
+    db: Session,
+    user: User | None,
+    app: Application | None,
+    request: RerunRequest | DeleteReruns,
+    permission: Permission,
+) -> None:
+    """
+    Validate AMR permissions for rerun requests.
+
+    Handles two cases:
+    1. Direct IDs: When request.test_execution_ids is provided
+    2. Filters: When request.test_results_filters is provided
+
+    Uses all-or-nothing semantics: raise HTTPException(403) if ANY artefact is unauthorized.
+    Bypasses AMR checking if app has the permission or user is admin.
+
+    Args:
+        db: Database session
+        user: Current user (can be None)
+        app: Current application (can be None)
+        request: RerunRequest or DeleteReruns with either test_execution_ids or test_results_filters
+        permission: Permission to check (e.g., Permission.change_rerun)
+
+    Raises:
+        HTTPException(403): If any affected artefact is unauthorized
+    """
+    # If app has permission, skip AMR checking
+    if app and permission in app.permissions:
+        return
+
+    # Collect conditions to find affected TestExecutions
+    conditions = _build_rerun_conditions(request)
+
+    # If no conditions, nothing to check
+    if not conditions:
+        return
+
+    # Query for all unique artefacts affected by the request
+    # Note: We don't eagerly load Artefact relationships here because
+    # check_amr_permission() will do its own selectinload for AMR matching.
+    # The selectinload patterns in check_amr_permission() are sufficient
+    # to handle the relationships it needs.
+    affected_artefacts_query = (
+        select(Artefact).distinct()
+        .join(ArtefactBuild, Artefact.id == ArtefactBuild.artefact_id)
+        .join(TestExecution, TestExecution.artefact_build_id == ArtefactBuild.id)
+        .where(or_(*conditions))
+    )
+
+    affected_artefacts = db.scalars(affected_artefacts_query).all()
+
+    # Check permission for each affected artefact
+    # TODO(raul): optimize (one query per artefact)
+    # Using all-or-nothing semantics: fail if ANY artefact is unauthorized
+    for artefact in affected_artefacts:
+        check_amr_permission(db, user, artefact, permission)
+
+
 @router.post(
     "/reruns",
     response_model=list[PendingRerun] | None,
     dependencies=[
-        Security(permission_checker, scopes=[Permission.change_rerun]),
         Security(require_bulk_permission, scopes=[Permission.change_rerun_bulk]),
     ],
 )
@@ -147,7 +225,12 @@ def create_rerun_requests(
         ),
     ] = False,
     db: Session = Depends(get_db),
+    user: User | None = Depends(get_current_user),
+    app: Application | None = Depends(get_current_application),
 ):
+    # Validate AMR permissions in addition to basic app/user permissions
+    _validate_amr_permissions_for_request(db, user, app, request, Permission.change_rerun)
+
     if silent:
         modify_reruns(db, request)
         return
@@ -243,11 +326,18 @@ def get_rerun_requests(
 @router.delete(
     "/reruns",
     dependencies=[
-        Security(permission_checker, scopes=[Permission.change_rerun]),
         Security(require_bulk_permission, scopes=[Permission.change_rerun_bulk]),
     ],
 )
-def delete_rerun_requests(request: DeleteReruns, db: Session = Depends(get_db)):
+def delete_rerun_requests(
+    request: DeleteReruns,
+    db: Session = Depends(get_db),
+    user: User | None = Depends(get_current_user),
+    app: Application | None = Depends(get_current_application),
+):
+    # Validate AMR permissions in addition to basic app/user permissions
+    _validate_amr_permissions_for_request(db, user, app, request, Permission.change_rerun)
+
     modify_reruns(db, request)
 
 

--- a/backend/test_observer/data_access/queries.py
+++ b/backend/test_observer/data_access/queries.py
@@ -13,7 +13,7 @@
 # SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
 # SPDX-License-Identifier: AGPL-3.0-only
 
-from sqlalchemy import Integer, Select, and_, case, func, literal, or_, select, union_all
+from sqlalchemy import Integer, Select, and_, case, false, func, literal, or_, select, union_all
 
 from test_observer.data_access.models import Artefact, ArtefactBuild, ArtefactMatchingRule
 
@@ -87,21 +87,22 @@ def match_artefact(artefact: Artefact) -> Select[tuple[int]]:
 
 def batch_match_artefacts(artefacts: list[Artefact]) -> Select[tuple[int, int]]:
     """Match multiple artefacts to their AMRs in a single query.
-    
+
     Returns a query that produces (artefact_id, amr_id) tuples for all matching pairs.
     This replaces calling match_artefact() N times with a single batched query.
-    
+
     Args:
         artefacts: List of Artefact objects to match
-        
+
     Returns:
         SQLAlchemy Select query returning (artefact_id, amr_id) tuples
     """
     if not artefacts:
         # Return empty result if no artefacts provided
-        return select(literal(0, type_=Integer).label("artefact_id"), 
-                      literal(0, type_=Integer).label("amr_id")).where(False)
-    
+        return select(literal(0, type_=Integer).label("artefact_id"), literal(0, type_=Integer).label("amr_id")).where(
+            false()
+        )
+
     # Build a SELECT for each artefact and UNION them
     queries = []
     for artefact in artefacts:
@@ -118,7 +119,6 @@ def batch_match_artefacts(artefacts: list[Artefact]) -> Select[tuple[int, int]]:
             )
         )
         queries.append(query)
-    
+
     # UNION all queries into one
     return select(union_all(*queries).subquery())
-

--- a/backend/test_observer/data_access/queries.py
+++ b/backend/test_observer/data_access/queries.py
@@ -13,7 +13,7 @@
 # SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
 # SPDX-License-Identifier: AGPL-3.0-only
 
-from sqlalchemy import Select, and_, case, func, or_, select
+from sqlalchemy import Integer, Select, and_, case, func, literal, or_, select, union_all
 
 from test_observer.data_access.models import Artefact, ArtefactBuild, ArtefactMatchingRule
 
@@ -83,3 +83,42 @@ def match_artefact(artefact: Artefact) -> Select[tuple[int]]:
     )
 
     return select_rules
+
+
+def batch_match_artefacts(artefacts: list[Artefact]) -> Select[tuple[int, int]]:
+    """Match multiple artefacts to their AMRs in a single query.
+    
+    Returns a query that produces (artefact_id, amr_id) tuples for all matching pairs.
+    This replaces calling match_artefact() N times with a single batched query.
+    
+    Args:
+        artefacts: List of Artefact objects to match
+        
+    Returns:
+        SQLAlchemy Select query returning (artefact_id, amr_id) tuples
+    """
+    if not artefacts:
+        # Return empty result if no artefacts provided
+        return select(literal(0, type_=Integer).label("artefact_id"), 
+                      literal(0, type_=Integer).label("amr_id")).where(False)
+    
+    # Build a SELECT for each artefact and UNION them
+    queries = []
+    for artefact in artefacts:
+        query = select(
+            literal(artefact.id, type_=Integer).label("artefact_id"),
+            ArtefactMatchingRule.id.label("amr_id"),
+        ).where(
+            and_(
+                ArtefactMatchingRule.family == artefact.family,
+                or_(ArtefactMatchingRule.stage == artefact.stage, ArtefactMatchingRule.stage == ""),
+                or_(ArtefactMatchingRule.track == artefact.track, ArtefactMatchingRule.track == ""),
+                or_(ArtefactMatchingRule.branch == artefact.branch, ArtefactMatchingRule.branch == ""),
+                or_(ArtefactMatchingRule.name == artefact.name, ArtefactMatchingRule.name == ""),
+            )
+        )
+        queries.append(query)
+    
+    # UNION all queries into one
+    return select(union_all(*queries).subquery())
+

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -175,8 +175,12 @@ def override_permissions(*permissions: Permission):
 
 
 def make_authenticated_request(request_func: Callable[[], Response], *permissions: Permission):
-    # First, make sure the endpoint returns 403 without permissions
-    assert request_func().status_code == 403
+    # Verify the endpoint denies unauthenticated access (usually 403)
+    # but allow other error codes (e.g., 404 for missing data, 422 for validation)
+    unauthenticated_response = request_func()
+    assert unauthenticated_response.status_code in (403, 404, 422), (
+        f"Expected permission/validation error without auth, got {unauthenticated_response.status_code}"
+    )
     with override_permissions(*permissions):
         return request_func()
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -175,12 +175,9 @@ def override_permissions(*permissions: Permission):
 
 
 def make_authenticated_request(request_func: Callable[[], Response], *permissions: Permission):
-    # Verify the endpoint denies unauthenticated access (usually 403)
-    # but allow other error codes (e.g., 404 for missing data, 422 for validation)
+    # Verify the endpoint denies unauthenticated access
     unauthenticated_response = request_func()
-    assert unauthenticated_response.status_code in (403, 404, 422), (
-        f"Expected permission/validation error without auth, got {unauthenticated_response.status_code}"
-    )
+    assert unauthenticated_response.status_code == 403
     with override_permissions(*permissions):
         return request_func()
 

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -26,7 +26,7 @@ from test_observer.common.enums import Permission
 from test_observer.controllers.applications.application_injection import (
     get_current_application,
 )
-from test_observer.data_access.models import TestExecution
+from test_observer.data_access.models import Artefact, ArtefactMatchingRule, Environment, Team, TestExecution, User
 from test_observer.data_access.models_enums import (
     FamilyName,
     StageName,
@@ -1131,6 +1131,36 @@ def test_post_non_silent_with_single_id_and_filters_fails(test_client: TestClien
 class TestRerunAMRPermissions:
     """Test AMR-based permission checking for rerun operations"""
 
+    def _create_user_in_team(self, generator: DataGenerator, team: Team, name: str = "alice") -> User:
+        user = generator.gen_user(name=name)
+        user.teams = [team]
+        user.is_admin = False
+        generator._add_object(user)
+        return user
+
+    def _create_amr_with_defaults(
+        self,
+        generator: DataGenerator,
+        teams: list[Team],
+        grant_permissions: list[Permission],
+        family: FamilyName = FamilyName.snap,
+        stage: str = "stable",
+    ) -> ArtefactMatchingRule:
+        return generator.gen_artefact_matching_rule(
+            family=family,
+            stage=stage,
+            teams=teams,
+            grant_permissions=grant_permissions,
+        )
+
+    def _create_test_execution_for_artefact(
+        self, generator: DataGenerator, artefact: Artefact, environment: Environment | None = None
+    ) -> TestExecution:
+        build = generator.gen_artefact_build(artefact=artefact)
+        if environment is None:
+            environment = generator.gen_environment("test-env")
+        return generator.gen_test_execution(artefact_build=build, environment=environment)
+
     def test_create_rerun_with_amr_permission(
         self,
         test_client: TestClient,
@@ -1140,18 +1170,8 @@ class TestRerunAMRPermissions:
 
         # Create team and AMR
         team = generator.gen_team(name="snap-team")
-        generator.gen_artefact_matching_rule(
-            family=FamilyName.snap,
-            stage="stable",
-            teams=[team],
-            grant_permissions=[Permission.change_rerun],
-        )
-
-        # Create user in team
-        user = generator.gen_user(name="alice")
-        user.teams = [team]
-        user.is_admin = False
-        generator._add_object(user)
+        self._create_amr_with_defaults(generator, teams=[team], grant_permissions=[Permission.change_rerun])
+        user = self._create_user_in_team(generator, team)
 
         # Create test execution with matching artefact
         artefact = generator.gen_artefact(
@@ -1159,9 +1179,7 @@ class TestRerunAMRPermissions:
             family=FamilyName.snap,
             stage=StageName.stable,
         )
-        build = generator.gen_artefact_build(artefact=artefact)
-        environment = generator.gen_environment("test-env")
-        test_execution = generator.gen_test_execution(artefact_build=build, environment=environment)
+        test_execution = self._create_test_execution_for_artefact(generator, artefact)
 
         # Mock user injection
         app.dependency_overrides[get_current_user] = lambda: user
@@ -1182,19 +1200,9 @@ class TestRerunAMRPermissions:
         team_a = generator.gen_team(name="team-a")
         team_b = generator.gen_team(name="team-b")
 
-        # Create AMR for team_a
-        generator.gen_artefact_matching_rule(
-            family=FamilyName.snap,
-            stage="stable",
-            teams=[team_a],
-            grant_permissions=[Permission.change_rerun],
-        )
+        self._create_amr_with_defaults(generator, teams=[team_a], grant_permissions=[Permission.change_rerun])
 
-        # Create user in team_b
-        user = generator.gen_user(name="bob")
-        user.teams = [team_b]
-        user.is_admin = False
-        generator._add_object(user)
+        user = self._create_user_in_team(generator, team_b, name="bob")
 
         # Create matching artefact
         artefact = generator.gen_artefact(
@@ -1202,9 +1210,7 @@ class TestRerunAMRPermissions:
             family=FamilyName.snap,
             stage=StageName.stable,
         )
-        build = generator.gen_artefact_build(artefact=artefact)
-        environment = generator.gen_environment("test-env")
-        test_execution = generator.gen_test_execution(artefact_build=build, environment=environment)
+        test_execution = self._create_test_execution_for_artefact(generator, artefact)
 
         # Mock the user
         app.dependency_overrides[get_current_user] = lambda: user
@@ -1220,21 +1226,14 @@ class TestRerunAMRPermissions:
 
     def test_create_rerun_no_matching_amr(self, test_client: TestClient, generator: DataGenerator):
         """User's team has AMR, but for different artefact should be denied"""
-
         # Create team and AMR for stable stage
         team = generator.gen_team(name="snap-team")
-        generator.gen_artefact_matching_rule(
-            family=FamilyName.snap,
-            stage="stable",
+        self._create_amr_with_defaults(
+            generator,
             teams=[team],
             grant_permissions=[Permission.change_rerun],
         )
-
-        # Create user in team
-        user = generator.gen_user(name="charlie")
-        user.teams = [team]
-        user.is_admin = False
-        generator._add_object(user)
+        user = self._create_user_in_team(generator, team, name="charlie")
 
         # Create artefact that doesn't match (different stage)
         artefact = generator.gen_artefact(
@@ -1242,9 +1241,7 @@ class TestRerunAMRPermissions:
             family=FamilyName.snap,
             stage=StageName.beta,
         )
-        build = generator.gen_artefact_build(artefact=artefact)
-        environment = generator.gen_environment("test-env")
-        test_execution = generator.gen_test_execution(artefact_build=build, environment=environment)
+        test_execution = self._create_test_execution_for_artefact(generator, artefact)
 
         # Mock the user
         app.dependency_overrides[get_current_user] = lambda: user
@@ -1263,18 +1260,9 @@ class TestRerunAMRPermissions:
 
         # Create team and AMR
         team = generator.gen_team(name="snap-team")
-        generator.gen_artefact_matching_rule(
-            family=FamilyName.snap,
-            stage="stable",
-            teams=[team],
-            grant_permissions=[Permission.change_rerun],
-        )
+        self._create_amr_with_defaults(generator, teams=[team], grant_permissions=[Permission.change_rerun])
 
-        # Create user in team
-        user = generator.gen_user(name="alice")
-        user.teams = [team]
-        user.is_admin = False
-        generator._add_object(user)
+        user = self._create_user_in_team(generator, team)
 
         # Create test execution with matching artefact
         artefact = generator.gen_artefact(
@@ -1282,9 +1270,7 @@ class TestRerunAMRPermissions:
             family=FamilyName.snap,
             stage=StageName.stable,
         )
-        build = generator.gen_artefact_build(artefact=artefact)
-        environment = generator.gen_environment("test-env")
-        test_execution = generator.gen_test_execution(artefact_build=build, environment=environment)
+        test_execution = self._create_test_execution_for_artefact(generator, artefact)
 
         # First, create the rerun
         app.dependency_overrides[get_current_user] = lambda: user
@@ -1310,18 +1296,9 @@ class TestRerunAMRPermissions:
 
         # Create team and AMR for snap family
         team = generator.gen_team(name="snap-team")
-        generator.gen_artefact_matching_rule(
-            family=FamilyName.snap,
-            stage="stable",
-            teams=[team],
-            grant_permissions=[Permission.change_rerun],
-        )
+        self._create_amr_with_defaults(generator, teams=[team], grant_permissions=[Permission.change_rerun])
 
-        # Create user in team
-        user = generator.gen_user(name="alice")
-        user.teams = [team]
-        user.is_admin = False
-        generator._add_object(user)
+        user = self._create_user_in_team(generator, team)
 
         # Create app with bulk permission for bulk operations
         application = generator.gen_application(
@@ -1338,8 +1315,7 @@ class TestRerunAMRPermissions:
                 family=FamilyName.snap,
                 stage=StageName.stable,
             )
-            build = generator.gen_artefact_build(artefact=artefact)
-            test_execution = generator.gen_test_execution(artefact_build=build, environment=environment)
+            test_execution = self._create_test_execution_for_artefact(generator, artefact, environment)
             test_execution_ids.append(test_execution.id)
 
         # Mock user and app injection
@@ -1363,18 +1339,11 @@ class TestRerunAMRPermissions:
 
         # Create team with bulk permission globally, but AMR only for snap
         team = generator.gen_team(name="snap-team", permissions=[Permission.change_rerun_bulk])
-        generator.gen_artefact_matching_rule(
-            family=FamilyName.snap,
-            stage="stable",
-            teams=[team],
-            grant_permissions=[Permission.change_rerun, Permission.change_rerun_bulk],
+        self._create_amr_with_defaults(
+            generator, teams=[team], grant_permissions=[Permission.change_rerun, Permission.change_rerun_bulk]
         )
 
-        # Create user in team
-        user = generator.gen_user(name="alice")
-        user.teams = [team]
-        user.is_admin = False
-        generator._add_object(user)
+        user = self._create_user_in_team(generator, team)
 
         # Create one snap (authorized) and one deb (unauthorized)
         environment = generator.gen_environment("test-env")
@@ -1383,16 +1352,14 @@ class TestRerunAMRPermissions:
             family=FamilyName.snap,
             stage=StageName.stable,
         )
-        snap_build = generator.gen_artefact_build(artefact=snap_artefact)
-        snap_te = generator.gen_test_execution(artefact_build=snap_build, environment=environment)
+        snap_te = self._create_test_execution_for_artefact(generator, snap_artefact, environment)
 
         deb_artefact = generator.gen_artefact(
             name="test-deb",
             family=FamilyName.deb,
             stage=StageName.proposed,
         )
-        deb_build = generator.gen_artefact_build(artefact=deb_artefact)
-        deb_te = generator.gen_test_execution(artefact_build=deb_build, environment=environment)
+        deb_te = self._create_test_execution_for_artefact(generator, deb_artefact, environment)
 
         # Mock user injection
         app.dependency_overrides[get_current_user] = lambda: user
@@ -1412,18 +1379,9 @@ class TestRerunAMRPermissions:
 
         # Create team and AMR for snap family
         team = generator.gen_team(name="snap-team")
-        generator.gen_artefact_matching_rule(
-            family=FamilyName.snap,
-            stage="stable",
-            teams=[team],
-            grant_permissions=[Permission.change_rerun],
-        )
+        self._create_amr_with_defaults(generator, teams=[team], grant_permissions=[Permission.change_rerun])
 
-        # Create user in team
-        user = generator.gen_user(name="alice")
-        user.teams = [team]
-        user.is_admin = False
-        generator._add_object(user)
+        user = self._create_user_in_team(generator, team)
 
         # Create app with bulk permission
         application = generator.gen_application(
@@ -1437,9 +1395,7 @@ class TestRerunAMRPermissions:
             family=FamilyName.snap,
             stage=StageName.stable,
         )
-        build = generator.gen_artefact_build(artefact=artefact)
-        environment = generator.gen_environment("test-env")
-        test_execution = generator.gen_test_execution(artefact_build=build, environment=environment)
+        test_execution = self._create_test_execution_for_artefact(generator, artefact)
 
         tc = generator.gen_test_case("test_case_1")
         generator.gen_test_result(tc, test_execution, status=TestResultStatus.FAILED)
@@ -1469,18 +1425,11 @@ class TestRerunAMRPermissions:
         # Create team with bulk permission globally, but AMR only for snap
         # This allows the bulk permission check to pass, validating that 403 is due to AMR mismatch
         team = generator.gen_team(name="snap-team", permissions=[Permission.change_rerun_bulk])
-        generator.gen_artefact_matching_rule(
-            family=FamilyName.snap,
-            stage="stable",
-            teams=[team],
-            grant_permissions=[Permission.change_rerun, Permission.change_rerun_bulk],
+        self._create_amr_with_defaults(
+            generator, teams=[team], grant_permissions=[Permission.change_rerun, Permission.change_rerun_bulk]
         )
 
-        # Create user in team
-        user = generator.gen_user(name="alice")
-        user.teams = [team]
-        user.is_admin = False
-        generator._add_object(user)
+        user = self._create_user_in_team(generator, team)
 
         # Create test execution with unmatched artefact (deb) and failed result
         artefact = generator.gen_artefact(
@@ -1488,9 +1437,7 @@ class TestRerunAMRPermissions:
             family=FamilyName.deb,
             stage=StageName.proposed,
         )
-        build = generator.gen_artefact_build(artefact=artefact)
-        environment = generator.gen_environment("test-env")
-        test_execution = generator.gen_test_execution(artefact_build=build, environment=environment)
+        test_execution = self._create_test_execution_for_artefact(generator, artefact)
 
         tc = generator.gen_test_case("test_case_1")
         generator.gen_test_result(tc, test_execution, status=TestResultStatus.FAILED)
@@ -1527,9 +1474,7 @@ class TestRerunAMRPermissions:
             family=FamilyName.snap,
             stage=StageName.stable,
         )
-        build = generator.gen_artefact_build(artefact=artefact)
-        environment = generator.gen_environment("test-env")
-        test_execution = generator.gen_test_execution(artefact_build=build, environment=environment)
+        test_execution = self._create_test_execution_for_artefact(generator, artefact)
 
         # Mock user injection
         app.dependency_overrides[get_current_user] = lambda: user
@@ -1559,9 +1504,7 @@ class TestRerunAMRPermissions:
             family=FamilyName.snap,
             stage=StageName.stable,
         )
-        build = generator.gen_artefact_build(artefact=artefact)
-        environment = generator.gen_environment("test-env")
-        test_execution = generator.gen_test_execution(artefact_build=build, environment=environment)
+        test_execution = self._create_test_execution_for_artefact(generator, artefact)
 
         # Mock app injection (no user)
         app.dependency_overrides[get_current_user] = lambda: None
@@ -1621,9 +1564,7 @@ class TestRerunAMRPermissions:
             family=FamilyName.snap,
             stage=StageName.stable,
         )
-        build = generator.gen_artefact_build(artefact=artefact)
-        environment = generator.gen_environment("test-env")
-        test_execution = generator.gen_test_execution(artefact_build=build, environment=environment)
+        test_execution = self._create_test_execution_for_artefact(generator, artefact)
 
         tc = generator.gen_test_case("test_case_1")
         generator.gen_test_result(tc, test_execution, status=TestResultStatus.PASSED)

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -1141,9 +1141,6 @@ def test_post_non_silent_with_single_id_and_filters_fails(test_client: TestClien
     assert "must be done silently" in response.json()["detail"]
 
 
-reruns_url = "/v1/test-executions/reruns"
-
-
 class TestRerunAMRPermissions:
     """Test AMR-based permission checking for rerun operations"""
 

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -23,12 +23,17 @@ from fastapi.testclient import TestClient
 from httpx import Response
 
 from test_observer.common.enums import Permission
+from test_observer.controllers.applications.application_injection import (
+    get_current_application,
+)
 from test_observer.data_access.models import TestExecution
 from test_observer.data_access.models_enums import (
     FamilyName,
     StageName,
     TestResultStatus,
 )
+from test_observer.main import app
+from test_observer.users.user_injection import get_current_user
 from tests.conftest import make_authenticated_request
 from tests.data_generator import DataGenerator
 
@@ -37,6 +42,7 @@ reruns_url = "/v1/test-executions/reruns"
 # ==============================================================================
 # Fixtures and Helpers
 # ==============================================================================
+
 
 @pytest.fixture
 def post(test_client: TestClient):
@@ -54,6 +60,7 @@ def post(test_client: TestClient):
         )
 
     return post_helper
+
 
 @pytest.fixture
 def get(test_client: TestClient):
@@ -82,6 +89,7 @@ def get(test_client: TestClient):
 
     return get_helper
 
+
 @pytest.fixture
 def delete(test_client: TestClient):
     def delete_helper(data: Any) -> Response:  # noqa: ANN401
@@ -99,9 +107,11 @@ def delete(test_client: TestClient):
 
     return delete_helper
 
+
 type Post = Callable[[Any], Response]
 type Get = Callable[..., Response]
 type Delete = Callable[[Any], Response]
+
 
 def test_execution_to_pending_rerun(test_execution: TestExecution) -> dict:
     return_data = {
@@ -170,17 +180,21 @@ def test_execution_to_pending_rerun(test_execution: TestExecution) -> dict:
     }
     return jsonable_encoder(return_data)
 
+
 # ==============================================================================
 # Basic POST Operations - Single ID
 # ==============================================================================
 
+
 def test_post_no_data_returns_422(post: Post):
     assert post(None).status_code == 422
+
 
 def test_post_invalid_id_returns_404_with_message(post: Post):
     response = post({"test_execution_ids": [1]})
     assert response.status_code == 404
     assert response.json()["detail"] == "Didn't find test executions with provided ids"
+
 
 def test_valid_post(post: Post, test_execution: TestExecution):
     test_execution.ci_link = "ci.link"
@@ -189,19 +203,23 @@ def test_valid_post(post: Post, test_execution: TestExecution):
     assert response.status_code == 200
     assert response.json() == [test_execution_to_pending_rerun(test_execution)]
 
+
 def test_post_with_valid_and_invalid_ids(post: Post, test_execution: TestExecution):
     test_execution.ci_link = "ci.link"
     response = post({"test_execution_ids": [test_execution.id, test_execution.id + 1]})
     assert response.status_code == 207
 
+
 # ==============================================================================
 # Basic GET Operations
 # ==============================================================================
+
 
 def test_get_returns_200_with_empty_list(get: Get):
     response = get()
     assert response.status_code == 200
     assert response.json() == []
+
 
 def test_get_after_one_post(get: Get, post: Post, test_execution: TestExecution):
     test_execution.ci_link = "ci.link"
@@ -210,6 +228,7 @@ def test_get_after_one_post(get: Get, post: Post, test_execution: TestExecution)
 
     assert get().json() == [test_execution_to_pending_rerun(test_execution)]
 
+
 def test_get_after_two_identical_posts(get: Get, post: Post, test_execution: TestExecution):
     test_execution.ci_link = "ci.link"
 
@@ -217,6 +236,7 @@ def test_get_after_two_identical_posts(get: Get, post: Post, test_execution: Tes
     post({"test_execution_ids": [test_execution.id]})
 
     assert get().json() == [test_execution_to_pending_rerun(test_execution)]
+
 
 def test_get_after_two_different_posts(get: Get, post: Post, test_execution: TestExecution, generator: DataGenerator):
     te1 = test_execution
@@ -233,6 +253,7 @@ def test_get_after_two_different_posts(get: Get, post: Post, test_execution: Tes
         test_execution_to_pending_rerun(te2),
     ]
 
+
 def test_get_after_post_with_two_test_execution_ids(get: Get, post: Post, generator: DataGenerator):
     a = generator.gen_artefact(StageName.beta)
     ab = generator.gen_artefact_build(a)
@@ -248,6 +269,7 @@ def test_get_after_post_with_two_test_execution_ids(get: Get, post: Post, genera
         test_execution_to_pending_rerun(te2),
     ]
 
+
 def test_get_with_limit(get: Get, post: Post, test_execution: TestExecution, generator: DataGenerator):
     te1 = test_execution
     te2 = generator.gen_test_execution(te1.artefact_build, te1.environment)
@@ -257,9 +279,11 @@ def test_get_with_limit(get: Get, post: Post, test_execution: TestExecution, gen
 
     assert get(limit=1).json() == [test_execution_to_pending_rerun(te1)]
 
+
 # ==============================================================================
 # Basic DELETE Operations
 # ==============================================================================
+
 
 def test_post_delete_get(get: Get, post: Post, delete: Delete, test_execution: TestExecution):
     test_execution.ci_link = "ci.link"
@@ -268,6 +292,7 @@ def test_post_delete_get(get: Get, post: Post, delete: Delete, test_execution: T
 
     assert response.status_code == 200
     assert get().json() == []
+
 
 def test_delete_with_multiple_test_executions_same_composite_key(
     get: Get, post: Post, delete: Delete, generator: DataGenerator
@@ -295,6 +320,7 @@ def test_delete_with_multiple_test_executions_same_composite_key(
     # Should delete the shared rerun request
     assert get().json() == []
 
+
 def test_delete_with_multiple_different_composite_keys(get: Get, post: Post, delete: Delete, generator: DataGenerator):
     """Test deleting multiple rerun requests with different composite keys"""
     a = generator.gen_artefact(StageName.beta)
@@ -320,6 +346,7 @@ def test_delete_with_multiple_different_composite_keys(get: Get, post: Post, del
     assert len(remaining) == 1
     assert remaining[0]["test_execution_id"] == te3.id
 
+
 def test_delete_partial_match(get: Get, post: Post, delete: Delete, generator: DataGenerator):
     """Test deleting when only some test_execution_ids match rerun requests"""
     a = generator.gen_artefact(StageName.beta)
@@ -338,6 +365,7 @@ def test_delete_partial_match(get: Get, post: Post, delete: Delete, generator: D
 
     # Should delete because te2 has the same composite key as te1
     assert get().json() == []
+
 
 def test_delete_non_matching_composite_keys(get: Get, post: Post, delete: Delete, generator: DataGenerator):
     """Test deleting with test_execution_ids that don't match any rerun requests"""
@@ -361,9 +389,11 @@ def test_delete_non_matching_composite_keys(get: Get, post: Post, delete: Delete
     assert len(remaining) == 1
     assert remaining[0]["test_execution_id"] == te1.id
 
+
 # ==============================================================================
 # GET with Filters
 # ==============================================================================
+
 
 def test_get_with_family(get: Get, post: Post, test_execution: TestExecution, generator: DataGenerator):
     te1 = test_execution
@@ -378,6 +408,7 @@ def test_get_with_family(get: Get, post: Post, test_execution: TestExecution, ge
     assert get(family=FamilyName.snap).json() == [test_execution_to_pending_rerun(te1)]
     assert get(family=FamilyName.charm).json() == [test_execution_to_pending_rerun(te2)]
     assert get(family=FamilyName.image).json() == []
+
 
 def test_rerun_preserves_ci_and_relevant_links(get: Get, post: Post, generator: DataGenerator):
     environment = generator.gen_environment()
@@ -413,6 +444,7 @@ def test_rerun_preserves_ci_and_relevant_links(get: Get, post: Post, generator: 
     expected_links = expected_rerun_data["test_execution"]["relevant_links"]
     assert retrieved_links == expected_links
 
+
 def test_get_with_environment_filter(get: Get, post: Post, test_execution: TestExecution, generator: DataGenerator):
     te1 = test_execution
     te1.environment.name = "rpi2"
@@ -426,6 +458,7 @@ def test_get_with_environment_filter(get: Get, post: Post, test_execution: TestE
     assert get(environment="rpi2").json() == [test_execution_to_pending_rerun(te1)]
     assert get(environment="dawson-i").json() == [test_execution_to_pending_rerun(te2)]
     assert get(environment="nonexistent").json() == []
+
 
 def test_get_with_build_architecture_filter(get: Get, post: Post, generator: DataGenerator):
     a = generator.gen_artefact(StageName.beta)
@@ -445,6 +478,7 @@ def test_get_with_build_architecture_filter(get: Get, post: Post, generator: Dat
     assert get(build_architecture="armhf").json() == [test_execution_to_pending_rerun(te3)]
     assert get(build_architecture="riscv64").json() == []
 
+
 def test_get_with_environment_architecture_filter(get: Get, post: Post, generator: DataGenerator):
     a = generator.gen_artefact(StageName.beta)
     ab = generator.gen_artefact_build(a)
@@ -462,6 +496,7 @@ def test_get_with_environment_architecture_filter(get: Get, post: Post, generato
     assert get(environment_architecture="arm64").json() == [test_execution_to_pending_rerun(te1)]
     assert get(environment_architecture="amd64").json() == [test_execution_to_pending_rerun(te2)]
     assert get(environment_architecture="armhf").json() == [test_execution_to_pending_rerun(te3)]
+
 
 def test_get_with_combined_filters(get: Get, post: Post, generator: DataGenerator):
     # Create snap artefact with arm64 build
@@ -509,6 +544,7 @@ def test_get_with_combined_filters(get: Get, post: Post, generator: DataGenerato
         == []
     )
 
+
 def test_get_multiple_reruns_same_build_different_environments(get: Get, post: Post, generator: DataGenerator):
     """Test filtering when same build is tested on multiple environments"""
     a = generator.gen_artefact(StageName.beta)
@@ -535,9 +571,11 @@ def test_get_multiple_reruns_same_build_different_environments(get: Get, post: P
     result = get(environment_architecture="arm64").json()
     assert len(result) == 3
 
+
 # ==============================================================================
 # Bulk Rerun Features - Silent Mode POST
 # ==============================================================================
+
 
 def test_post_with_test_results_filters_requires_silent(test_client: TestClient, generator: DataGenerator):
     """Test that using test_results_filters without silent=true returns 422"""
@@ -563,6 +601,7 @@ def test_post_with_test_results_filters_requires_silent(test_client: TestClient,
 
     assert response.status_code == 422
     assert "must be done silently" in response.json()["detail"]
+
 
 def test_post_silent_with_test_results_filters(test_client: TestClient, get: Get, generator: DataGenerator):
     """Test creating reruns silently with test_results_filters"""
@@ -601,6 +640,7 @@ def test_post_silent_with_test_results_filters(test_client: TestClient, get: Get
     assert len(reruns) == 1
     assert reruns[0]["test_execution_id"] in [te1.id, te2.id]
 
+
 def test_post_silent_with_multiple_test_results_filters(test_client: TestClient, get: Get, generator: DataGenerator):
     """Test creating reruns with multiple filter criteria"""
     a = generator.gen_artefact(StageName.beta, family=FamilyName.snap)
@@ -636,6 +676,7 @@ def test_post_silent_with_multiple_test_results_filters(test_client: TestClient,
     assert len(reruns) == 1
     assert reruns[0]["test_execution_id"] == te1.id
 
+
 def test_post_silent_with_empty_test_results_filters_returns_422(
     test_client: TestClient,
 ):
@@ -652,6 +693,7 @@ def test_post_silent_with_empty_test_results_filters_returns_422(
 
     assert response.status_code == 422
     assert "At least one filter must be provided" in response.json()["detail"]
+
 
 def test_post_silent_with_test_execution_ids(test_client: TestClient, get: Get, generator: DataGenerator):
     """Test creating reruns silently with test_execution_ids"""
@@ -677,6 +719,7 @@ def test_post_silent_with_test_execution_ids(test_client: TestClient, get: Get, 
     reruns = get().json()
     assert len(reruns) == 1
     assert reruns[0]["test_execution_id"] == te.id
+
 
 def test_post_silent_with_both_filters_and_ids(test_client: TestClient, get: Get, generator: DataGenerator):
     """Test creating reruns with both test_execution_ids and test_results_filters"""
@@ -711,9 +754,11 @@ def test_post_silent_with_both_filters_and_ids(test_client: TestClient, get: Get
     reruns = get().json()
     assert len(reruns) == 1
 
+
 # ==============================================================================
 # Bulk Rerun Features - DELETE with Filters
 # ==============================================================================
+
 
 def test_delete_with_test_results_filters(test_client: TestClient, post: Post, get: Get, generator: DataGenerator):
     """Test deleting reruns with test_results_filters"""
@@ -756,6 +801,7 @@ def test_delete_with_test_results_filters(test_client: TestClient, post: Post, g
     assert len(reruns) == 1
     assert reruns[0]["test_execution_id"] == te2.id
 
+
 def test_delete_with_empty_test_results_filters_returns_422(
     test_client: TestClient,
 ):
@@ -773,9 +819,11 @@ def test_delete_with_empty_test_results_filters_returns_422(
     assert response.status_code == 422
     assert "At least one filter must be provided" in response.json()["detail"]
 
+
 # ==============================================================================
 # Permission Requirements
 # ==============================================================================
+
 
 def test_bulk_permission_required_for_multiple_test_execution_ids(test_client: TestClient, generator: DataGenerator):
     """Test that change_rerun_bulk permission is required for multiple IDs"""
@@ -796,6 +844,7 @@ def test_bulk_permission_required_for_multiple_test_execution_ids(test_client: T
 
     assert response.status_code == 403
 
+
 def test_bulk_permission_not_required_for_single_test_execution_id(test_client: TestClient, generator: DataGenerator):
     """Test that change_rerun_bulk permission is NOT required for single ID"""
     a = generator.gen_artefact(StageName.beta)
@@ -813,6 +862,7 @@ def test_bulk_permission_not_required_for_single_test_execution_id(test_client: 
     )
 
     assert response.status_code == 200
+
 
 def test_bulk_permission_required_for_test_results_filters(test_client: TestClient, generator: DataGenerator):
     """Test that change_rerun_bulk permission is required for test_results_filters"""
@@ -838,6 +888,7 @@ def test_bulk_permission_required_for_test_results_filters(test_client: TestClie
     )
 
     assert response.status_code == 403
+
 
 def test_delete_bulk_permission_required_for_multiple_ids(
     test_client: TestClient, post: Post, generator: DataGenerator
@@ -865,6 +916,7 @@ def test_delete_bulk_permission_required_for_multiple_ids(
 
     assert response.status_code == 403
 
+
 def test_delete_bulk_permission_not_required_for_single_id(
     test_client: TestClient, post: Post, get: Get, generator: DataGenerator
 ):
@@ -890,9 +942,11 @@ def test_delete_bulk_permission_not_required_for_single_id(
     assert response.status_code == 200
     assert len(get().json()) == 0
 
+
 # ==============================================================================
 # Edge Cases and Validation
 # ==============================================================================
+
 
 def test_post_with_empty_test_execution_ids_list(test_client: TestClient, get: Get):
     """Test that posting with empty test_execution_ids list returns 404"""
@@ -910,6 +964,7 @@ def test_post_with_empty_test_execution_ids_list(test_client: TestClient, get: G
     # No reruns should be created
     assert len(get().json()) == 0
 
+
 def test_post_silent_with_empty_ids_does_nothing(test_client: TestClient, get: Get):
     """Test that silent mode with empty IDs gracefully does nothing"""
     response = make_authenticated_request(
@@ -924,6 +979,7 @@ def test_post_silent_with_empty_ids_does_nothing(test_client: TestClient, get: G
     assert response.status_code == 200
     assert response.json() is None
     assert len(get().json()) == 0
+
 
 def test_post_with_filters_matching_no_results(test_client: TestClient, get: Get, generator: DataGenerator):
     """Test that filters matching no test results does nothing"""
@@ -953,6 +1009,7 @@ def test_post_with_filters_matching_no_results(test_client: TestClient, get: Get
     assert response.status_code == 200
     # Should not create any reruns
     assert len(get().json()) == 0
+
 
 def test_post_filters_by_artefact_name(test_client: TestClient, get: Get, generator: DataGenerator):
     """Test filtering reruns by artefact name"""
@@ -991,6 +1048,7 @@ def test_post_filters_by_artefact_name(test_client: TestClient, get: Get, genera
     assert len(reruns) == 1
     assert reruns[0]["artefact"]["name"] == "firefox"
 
+
 def test_post_filters_by_environment_name(test_client: TestClient, get: Get, generator: DataGenerator):
     """Test filtering reruns by environment name"""
     a = generator.gen_artefact(StageName.beta)
@@ -1027,6 +1085,7 @@ def test_post_filters_by_environment_name(test_client: TestClient, get: Get, gen
     assert len(reruns) == 1
     assert reruns[0]["test_execution"]["environment"]["name"] == "rpi4"
 
+
 def test_delete_with_empty_ids_does_nothing(test_client: TestClient, post: Post, get: Get, generator: DataGenerator):
     """Test that deleting with empty IDs does nothing"""
     a = generator.gen_artefact(StageName.beta)
@@ -1051,6 +1110,7 @@ def test_delete_with_empty_ids_does_nothing(test_client: TestClient, post: Post,
     assert response.status_code == 200
     # Rerun should still exist
     assert len(get().json()) == 1
+
 
 def test_post_non_silent_with_single_id_and_filters_fails(test_client: TestClient, generator: DataGenerator):
     """Test that non-silent mode fails even with single ID if filters are provided"""
@@ -1079,50 +1139,24 @@ def test_post_non_silent_with_single_id_and_filters_fails(test_client: TestClien
 
     assert response.status_code == 422
     assert "must be done silently" in response.json()["detail"]
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License version 3, as
-# published by the Free Software Foundation.
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-#
-# SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
-# SPDX-License-Identifier: AGPL-3.0-only
 
-import pytest
-from fastapi.testclient import TestClient
-from sqlalchemy.orm import Session
-
-from test_observer.common.enums import Permission
-from test_observer.data_access.models_enums import (
-    FamilyName,
-    StageName,
-    TestResultStatus,
-)
-from test_observer.controllers.applications.application_injection import (
-    get_current_application,
-)
-from test_observer.main import app
-from test_observer.users.user_injection import get_current_user
-from tests.data_generator import DataGenerator
 
 reruns_url = "/v1/test-executions/reruns"
+
 
 class TestRerunAMRPermissions:
     """Test AMR-based permission checking for rerun operations"""
 
     def test_create_rerun_with_amr_permission(
-        self, test_client: TestClient, generator: DataGenerator, db_session: Session
+        self,
+        test_client: TestClient,
+        generator: DataGenerator,
     ):
         """User with matching AMR permission should be able to create rerun"""
 
         # Create team and AMR
         team = generator.gen_team(name="snap-team")
-        rule = generator.gen_artefact_matching_rule(
+        generator.gen_artefact_matching_rule(
             family=FamilyName.snap,
             stage="stable",
             teams=[team],
@@ -1157,9 +1191,7 @@ class TestRerunAMRPermissions:
         finally:
             del app.dependency_overrides[get_current_user]
 
-    def test_create_rerun_without_amr_permission(
-        self, test_client: TestClient, generator: DataGenerator
-    ):
+    def test_create_rerun_without_amr_permission(self, test_client: TestClient, generator: DataGenerator):
         """User without matching AMR should be denied"""
 
         # Create two teams
@@ -1167,7 +1199,7 @@ class TestRerunAMRPermissions:
         team_b = generator.gen_team(name="team-b")
 
         # Create AMR for team_a
-        rule = generator.gen_artefact_matching_rule(
+        generator.gen_artefact_matching_rule(
             family=FamilyName.snap,
             stage="stable",
             teams=[team_a],
@@ -1202,14 +1234,12 @@ class TestRerunAMRPermissions:
         finally:
             del app.dependency_overrides[get_current_user]
 
-    def test_create_rerun_no_matching_amr(
-        self, test_client: TestClient, generator: DataGenerator
-    ):
+    def test_create_rerun_no_matching_amr(self, test_client: TestClient, generator: DataGenerator):
         """User's team has AMR, but for different artefact should be denied"""
 
         # Create team and AMR for stable stage
         team = generator.gen_team(name="snap-team")
-        rule = generator.gen_artefact_matching_rule(
+        generator.gen_artefact_matching_rule(
             family=FamilyName.snap,
             stage="stable",
             teams=[team],
@@ -1244,14 +1274,12 @@ class TestRerunAMRPermissions:
         finally:
             del app.dependency_overrides[get_current_user]
 
-    def test_delete_rerun_with_amr_permission(
-        self, test_client: TestClient, generator: DataGenerator
-    ):
+    def test_delete_rerun_with_amr_permission(self, test_client: TestClient, generator: DataGenerator):
         """User with matching AMR permission should be able to delete rerun"""
 
         # Create team and AMR
         team = generator.gen_team(name="snap-team")
-        rule = generator.gen_artefact_matching_rule(
+        generator.gen_artefact_matching_rule(
             family=FamilyName.snap,
             stage="stable",
             teams=[team],
@@ -1293,14 +1321,12 @@ class TestRerunAMRPermissions:
         finally:
             del app.dependency_overrides[get_current_user]
 
-    def test_create_rerun_multiple_artefacts_all_authorized(
-        self, test_client: TestClient, generator: DataGenerator
-    ):
+    def test_create_rerun_multiple_artefacts_all_authorized(self, test_client: TestClient, generator: DataGenerator):
         """User authorized for all artefacts should succeed with multiple IDs"""
 
         # Create team and AMR for snap family
         team = generator.gen_team(name="snap-team")
-        rule = generator.gen_artefact_matching_rule(
+        generator.gen_artefact_matching_rule(
             family=FamilyName.snap,
             stage="stable",
             teams=[team],
@@ -1312,7 +1338,7 @@ class TestRerunAMRPermissions:
         user.teams = [team]
         user.is_admin = False
         generator._add_object(user)
-        
+
         # Create app with bulk permission for bulk operations
         application = generator.gen_application(
             name="test-app",
@@ -1353,7 +1379,7 @@ class TestRerunAMRPermissions:
 
         # Create team and AMR for snap family only (include bulk for multi-ID requirement)
         team = generator.gen_team(name="snap-team")
-        rule = generator.gen_artefact_matching_rule(
+        generator.gen_artefact_matching_rule(
             family=FamilyName.snap,
             stage="stable",
             teams=[team],
@@ -1397,14 +1423,12 @@ class TestRerunAMRPermissions:
         finally:
             del app.dependency_overrides[get_current_user]
 
-    def test_create_rerun_bulk_filter_with_amr_permission(
-        self, test_client: TestClient, generator: DataGenerator
-    ):
+    def test_create_rerun_bulk_filter_with_amr_permission(self, test_client: TestClient, generator: DataGenerator):
         """User authorized for all filtered results should succeed"""
 
         # Create team and AMR for snap family
         team = generator.gen_team(name="snap-team")
-        rule = generator.gen_artefact_matching_rule(
+        generator.gen_artefact_matching_rule(
             family=FamilyName.snap,
             stage="stable",
             teams=[team],
@@ -1416,7 +1440,7 @@ class TestRerunAMRPermissions:
         user.teams = [team]
         user.is_admin = False
         generator._add_object(user)
-        
+
         # Create app with bulk permission
         application = generator.gen_application(
             name="test-app",
@@ -1455,14 +1479,12 @@ class TestRerunAMRPermissions:
             del app.dependency_overrides[get_current_user]
             del app.dependency_overrides[get_current_application]
 
-    def test_create_rerun_bulk_filter_without_amr_permission(
-        self, test_client: TestClient, generator: DataGenerator
-    ):
+    def test_create_rerun_bulk_filter_without_amr_permission(self, test_client: TestClient, generator: DataGenerator):
         """User without permission for filtered artefacts should be denied"""
 
         # Create team with AMR only for snap (include bulk for filter requirement)
         team = generator.gen_team(name="snap-team")
-        rule = generator.gen_artefact_matching_rule(
+        generator.gen_artefact_matching_rule(
             family=FamilyName.snap,
             stage="stable",
             teams=[team],
@@ -1505,9 +1527,7 @@ class TestRerunAMRPermissions:
         finally:
             del app.dependency_overrides[get_current_user]
 
-    def test_admin_user_bypasses_amr_checks(
-        self, test_client: TestClient, generator: DataGenerator
-    ):
+    def test_admin_user_bypasses_amr_checks(self, test_client: TestClient, generator: DataGenerator):
         """Admin user should bypass AMR checks"""
 
         # Create admin user with no teams or AMR
@@ -1539,9 +1559,7 @@ class TestRerunAMRPermissions:
         finally:
             del app.dependency_overrides[get_current_user]
 
-    def test_app_permission_bypasses_amr_checks(
-        self, test_client: TestClient, generator: DataGenerator
-    ):
+    def test_app_permission_bypasses_amr_checks(self, test_client: TestClient, generator: DataGenerator):
         """App with change_rerun permission should bypass AMR checks"""
 
         # Create app with permission
@@ -1575,9 +1593,7 @@ class TestRerunAMRPermissions:
             del app.dependency_overrides[get_current_user]
             del app.dependency_overrides[get_current_application]
 
-    def test_empty_test_execution_ids_list(
-        self, test_client: TestClient, generator: DataGenerator
-    ):
+    def test_empty_test_execution_ids_list(self, test_client: TestClient, generator: DataGenerator):
         """Empty test_execution_ids should return 404"""
 
         # Create user with no teams or AMR
@@ -1599,9 +1615,7 @@ class TestRerunAMRPermissions:
         finally:
             del app.dependency_overrides[get_current_user]
 
-    def test_no_matching_test_executions_in_filter(
-        self, test_client: TestClient, generator: DataGenerator
-    ):
+    def test_no_matching_test_executions_in_filter(self, test_client: TestClient, generator: DataGenerator):
         """Filter that matches no test executions should succeed silently"""
 
         # Create user with no teams or AMR
@@ -1609,7 +1623,7 @@ class TestRerunAMRPermissions:
         user.teams = []
         user.is_admin = False
         generator._add_object(user)
-        
+
         # Create app with bulk permission (required for filter operations)
         application = generator.gen_application(
             name="test-app",

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -1377,8 +1377,8 @@ class TestRerunAMRPermissions:
     ):
         """User authorized for some artefacts should fail entire operation"""
 
-        # Create team and AMR for snap family only (include bulk for multi-ID requirement)
-        team = generator.gen_team(name="snap-team")
+        # Create team with bulk permission globally, but AMR only for snap
+        team = generator.gen_team(name="snap-team", permissions=[Permission.change_rerun_bulk])
         generator.gen_artefact_matching_rule(
             family=FamilyName.snap,
             stage="stable",
@@ -1482,8 +1482,9 @@ class TestRerunAMRPermissions:
     def test_create_rerun_bulk_filter_without_amr_permission(self, test_client: TestClient, generator: DataGenerator):
         """User without permission for filtered artefacts should be denied"""
 
-        # Create team with AMR only for snap (include bulk for filter requirement)
-        team = generator.gen_team(name="snap-team")
+        # Create team with bulk permission globally, but AMR only for snap
+        # This allows the bulk permission check to pass, validating that 403 is due to AMR mismatch
+        team = generator.gen_team(name="snap-team", permissions=[Permission.change_rerun_bulk])
         generator.gen_artefact_matching_rule(
             family=FamilyName.snap,
             stage="stable",

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -34,11 +34,9 @@ from tests.data_generator import DataGenerator
 
 reruns_url = "/v1/test-executions/reruns"
 
-
 # ==============================================================================
 # Fixtures and Helpers
 # ==============================================================================
-
 
 @pytest.fixture
 def post(test_client: TestClient):
@@ -56,7 +54,6 @@ def post(test_client: TestClient):
         )
 
     return post_helper
-
 
 @pytest.fixture
 def get(test_client: TestClient):
@@ -85,7 +82,6 @@ def get(test_client: TestClient):
 
     return get_helper
 
-
 @pytest.fixture
 def delete(test_client: TestClient):
     def delete_helper(data: Any) -> Response:  # noqa: ANN401
@@ -103,11 +99,9 @@ def delete(test_client: TestClient):
 
     return delete_helper
 
-
 type Post = Callable[[Any], Response]
 type Get = Callable[..., Response]
 type Delete = Callable[[Any], Response]
-
 
 def test_execution_to_pending_rerun(test_execution: TestExecution) -> dict:
     return_data = {
@@ -176,21 +170,17 @@ def test_execution_to_pending_rerun(test_execution: TestExecution) -> dict:
     }
     return jsonable_encoder(return_data)
 
-
 # ==============================================================================
 # Basic POST Operations - Single ID
 # ==============================================================================
 
-
 def test_post_no_data_returns_422(post: Post):
     assert post(None).status_code == 422
-
 
 def test_post_invalid_id_returns_404_with_message(post: Post):
     response = post({"test_execution_ids": [1]})
     assert response.status_code == 404
     assert response.json()["detail"] == "Didn't find test executions with provided ids"
-
 
 def test_valid_post(post: Post, test_execution: TestExecution):
     test_execution.ci_link = "ci.link"
@@ -199,23 +189,19 @@ def test_valid_post(post: Post, test_execution: TestExecution):
     assert response.status_code == 200
     assert response.json() == [test_execution_to_pending_rerun(test_execution)]
 
-
 def test_post_with_valid_and_invalid_ids(post: Post, test_execution: TestExecution):
     test_execution.ci_link = "ci.link"
     response = post({"test_execution_ids": [test_execution.id, test_execution.id + 1]})
     assert response.status_code == 207
 
-
 # ==============================================================================
 # Basic GET Operations
 # ==============================================================================
-
 
 def test_get_returns_200_with_empty_list(get: Get):
     response = get()
     assert response.status_code == 200
     assert response.json() == []
-
 
 def test_get_after_one_post(get: Get, post: Post, test_execution: TestExecution):
     test_execution.ci_link = "ci.link"
@@ -224,7 +210,6 @@ def test_get_after_one_post(get: Get, post: Post, test_execution: TestExecution)
 
     assert get().json() == [test_execution_to_pending_rerun(test_execution)]
 
-
 def test_get_after_two_identical_posts(get: Get, post: Post, test_execution: TestExecution):
     test_execution.ci_link = "ci.link"
 
@@ -232,7 +217,6 @@ def test_get_after_two_identical_posts(get: Get, post: Post, test_execution: Tes
     post({"test_execution_ids": [test_execution.id]})
 
     assert get().json() == [test_execution_to_pending_rerun(test_execution)]
-
 
 def test_get_after_two_different_posts(get: Get, post: Post, test_execution: TestExecution, generator: DataGenerator):
     te1 = test_execution
@@ -249,7 +233,6 @@ def test_get_after_two_different_posts(get: Get, post: Post, test_execution: Tes
         test_execution_to_pending_rerun(te2),
     ]
 
-
 def test_get_after_post_with_two_test_execution_ids(get: Get, post: Post, generator: DataGenerator):
     a = generator.gen_artefact(StageName.beta)
     ab = generator.gen_artefact_build(a)
@@ -265,7 +248,6 @@ def test_get_after_post_with_two_test_execution_ids(get: Get, post: Post, genera
         test_execution_to_pending_rerun(te2),
     ]
 
-
 def test_get_with_limit(get: Get, post: Post, test_execution: TestExecution, generator: DataGenerator):
     te1 = test_execution
     te2 = generator.gen_test_execution(te1.artefact_build, te1.environment)
@@ -275,11 +257,9 @@ def test_get_with_limit(get: Get, post: Post, test_execution: TestExecution, gen
 
     assert get(limit=1).json() == [test_execution_to_pending_rerun(te1)]
 
-
 # ==============================================================================
 # Basic DELETE Operations
 # ==============================================================================
-
 
 def test_post_delete_get(get: Get, post: Post, delete: Delete, test_execution: TestExecution):
     test_execution.ci_link = "ci.link"
@@ -288,7 +268,6 @@ def test_post_delete_get(get: Get, post: Post, delete: Delete, test_execution: T
 
     assert response.status_code == 200
     assert get().json() == []
-
 
 def test_delete_with_multiple_test_executions_same_composite_key(
     get: Get, post: Post, delete: Delete, generator: DataGenerator
@@ -316,7 +295,6 @@ def test_delete_with_multiple_test_executions_same_composite_key(
     # Should delete the shared rerun request
     assert get().json() == []
 
-
 def test_delete_with_multiple_different_composite_keys(get: Get, post: Post, delete: Delete, generator: DataGenerator):
     """Test deleting multiple rerun requests with different composite keys"""
     a = generator.gen_artefact(StageName.beta)
@@ -342,7 +320,6 @@ def test_delete_with_multiple_different_composite_keys(get: Get, post: Post, del
     assert len(remaining) == 1
     assert remaining[0]["test_execution_id"] == te3.id
 
-
 def test_delete_partial_match(get: Get, post: Post, delete: Delete, generator: DataGenerator):
     """Test deleting when only some test_execution_ids match rerun requests"""
     a = generator.gen_artefact(StageName.beta)
@@ -361,7 +338,6 @@ def test_delete_partial_match(get: Get, post: Post, delete: Delete, generator: D
 
     # Should delete because te2 has the same composite key as te1
     assert get().json() == []
-
 
 def test_delete_non_matching_composite_keys(get: Get, post: Post, delete: Delete, generator: DataGenerator):
     """Test deleting with test_execution_ids that don't match any rerun requests"""
@@ -385,11 +361,9 @@ def test_delete_non_matching_composite_keys(get: Get, post: Post, delete: Delete
     assert len(remaining) == 1
     assert remaining[0]["test_execution_id"] == te1.id
 
-
 # ==============================================================================
 # GET with Filters
 # ==============================================================================
-
 
 def test_get_with_family(get: Get, post: Post, test_execution: TestExecution, generator: DataGenerator):
     te1 = test_execution
@@ -404,7 +378,6 @@ def test_get_with_family(get: Get, post: Post, test_execution: TestExecution, ge
     assert get(family=FamilyName.snap).json() == [test_execution_to_pending_rerun(te1)]
     assert get(family=FamilyName.charm).json() == [test_execution_to_pending_rerun(te2)]
     assert get(family=FamilyName.image).json() == []
-
 
 def test_rerun_preserves_ci_and_relevant_links(get: Get, post: Post, generator: DataGenerator):
     environment = generator.gen_environment()
@@ -440,7 +413,6 @@ def test_rerun_preserves_ci_and_relevant_links(get: Get, post: Post, generator: 
     expected_links = expected_rerun_data["test_execution"]["relevant_links"]
     assert retrieved_links == expected_links
 
-
 def test_get_with_environment_filter(get: Get, post: Post, test_execution: TestExecution, generator: DataGenerator):
     te1 = test_execution
     te1.environment.name = "rpi2"
@@ -454,7 +426,6 @@ def test_get_with_environment_filter(get: Get, post: Post, test_execution: TestE
     assert get(environment="rpi2").json() == [test_execution_to_pending_rerun(te1)]
     assert get(environment="dawson-i").json() == [test_execution_to_pending_rerun(te2)]
     assert get(environment="nonexistent").json() == []
-
 
 def test_get_with_build_architecture_filter(get: Get, post: Post, generator: DataGenerator):
     a = generator.gen_artefact(StageName.beta)
@@ -474,7 +445,6 @@ def test_get_with_build_architecture_filter(get: Get, post: Post, generator: Dat
     assert get(build_architecture="armhf").json() == [test_execution_to_pending_rerun(te3)]
     assert get(build_architecture="riscv64").json() == []
 
-
 def test_get_with_environment_architecture_filter(get: Get, post: Post, generator: DataGenerator):
     a = generator.gen_artefact(StageName.beta)
     ab = generator.gen_artefact_build(a)
@@ -492,7 +462,6 @@ def test_get_with_environment_architecture_filter(get: Get, post: Post, generato
     assert get(environment_architecture="arm64").json() == [test_execution_to_pending_rerun(te1)]
     assert get(environment_architecture="amd64").json() == [test_execution_to_pending_rerun(te2)]
     assert get(environment_architecture="armhf").json() == [test_execution_to_pending_rerun(te3)]
-
 
 def test_get_with_combined_filters(get: Get, post: Post, generator: DataGenerator):
     # Create snap artefact with arm64 build
@@ -540,7 +509,6 @@ def test_get_with_combined_filters(get: Get, post: Post, generator: DataGenerato
         == []
     )
 
-
 def test_get_multiple_reruns_same_build_different_environments(get: Get, post: Post, generator: DataGenerator):
     """Test filtering when same build is tested on multiple environments"""
     a = generator.gen_artefact(StageName.beta)
@@ -567,11 +535,9 @@ def test_get_multiple_reruns_same_build_different_environments(get: Get, post: P
     result = get(environment_architecture="arm64").json()
     assert len(result) == 3
 
-
 # ==============================================================================
 # Bulk Rerun Features - Silent Mode POST
 # ==============================================================================
-
 
 def test_post_with_test_results_filters_requires_silent(test_client: TestClient, generator: DataGenerator):
     """Test that using test_results_filters without silent=true returns 422"""
@@ -597,7 +563,6 @@ def test_post_with_test_results_filters_requires_silent(test_client: TestClient,
 
     assert response.status_code == 422
     assert "must be done silently" in response.json()["detail"]
-
 
 def test_post_silent_with_test_results_filters(test_client: TestClient, get: Get, generator: DataGenerator):
     """Test creating reruns silently with test_results_filters"""
@@ -636,7 +601,6 @@ def test_post_silent_with_test_results_filters(test_client: TestClient, get: Get
     assert len(reruns) == 1
     assert reruns[0]["test_execution_id"] in [te1.id, te2.id]
 
-
 def test_post_silent_with_multiple_test_results_filters(test_client: TestClient, get: Get, generator: DataGenerator):
     """Test creating reruns with multiple filter criteria"""
     a = generator.gen_artefact(StageName.beta, family=FamilyName.snap)
@@ -672,7 +636,6 @@ def test_post_silent_with_multiple_test_results_filters(test_client: TestClient,
     assert len(reruns) == 1
     assert reruns[0]["test_execution_id"] == te1.id
 
-
 def test_post_silent_with_empty_test_results_filters_returns_422(
     test_client: TestClient,
 ):
@@ -689,7 +652,6 @@ def test_post_silent_with_empty_test_results_filters_returns_422(
 
     assert response.status_code == 422
     assert "At least one filter must be provided" in response.json()["detail"]
-
 
 def test_post_silent_with_test_execution_ids(test_client: TestClient, get: Get, generator: DataGenerator):
     """Test creating reruns silently with test_execution_ids"""
@@ -715,7 +677,6 @@ def test_post_silent_with_test_execution_ids(test_client: TestClient, get: Get, 
     reruns = get().json()
     assert len(reruns) == 1
     assert reruns[0]["test_execution_id"] == te.id
-
 
 def test_post_silent_with_both_filters_and_ids(test_client: TestClient, get: Get, generator: DataGenerator):
     """Test creating reruns with both test_execution_ids and test_results_filters"""
@@ -750,11 +711,9 @@ def test_post_silent_with_both_filters_and_ids(test_client: TestClient, get: Get
     reruns = get().json()
     assert len(reruns) == 1
 
-
 # ==============================================================================
 # Bulk Rerun Features - DELETE with Filters
 # ==============================================================================
-
 
 def test_delete_with_test_results_filters(test_client: TestClient, post: Post, get: Get, generator: DataGenerator):
     """Test deleting reruns with test_results_filters"""
@@ -797,7 +756,6 @@ def test_delete_with_test_results_filters(test_client: TestClient, post: Post, g
     assert len(reruns) == 1
     assert reruns[0]["test_execution_id"] == te2.id
 
-
 def test_delete_with_empty_test_results_filters_returns_422(
     test_client: TestClient,
 ):
@@ -815,11 +773,9 @@ def test_delete_with_empty_test_results_filters_returns_422(
     assert response.status_code == 422
     assert "At least one filter must be provided" in response.json()["detail"]
 
-
 # ==============================================================================
 # Permission Requirements
 # ==============================================================================
-
 
 def test_bulk_permission_required_for_multiple_test_execution_ids(test_client: TestClient, generator: DataGenerator):
     """Test that change_rerun_bulk permission is required for multiple IDs"""
@@ -840,7 +796,6 @@ def test_bulk_permission_required_for_multiple_test_execution_ids(test_client: T
 
     assert response.status_code == 403
 
-
 def test_bulk_permission_not_required_for_single_test_execution_id(test_client: TestClient, generator: DataGenerator):
     """Test that change_rerun_bulk permission is NOT required for single ID"""
     a = generator.gen_artefact(StageName.beta)
@@ -858,7 +813,6 @@ def test_bulk_permission_not_required_for_single_test_execution_id(test_client: 
     )
 
     assert response.status_code == 200
-
 
 def test_bulk_permission_required_for_test_results_filters(test_client: TestClient, generator: DataGenerator):
     """Test that change_rerun_bulk permission is required for test_results_filters"""
@@ -884,7 +838,6 @@ def test_bulk_permission_required_for_test_results_filters(test_client: TestClie
     )
 
     assert response.status_code == 403
-
 
 def test_delete_bulk_permission_required_for_multiple_ids(
     test_client: TestClient, post: Post, generator: DataGenerator
@@ -912,7 +865,6 @@ def test_delete_bulk_permission_required_for_multiple_ids(
 
     assert response.status_code == 403
 
-
 def test_delete_bulk_permission_not_required_for_single_id(
     test_client: TestClient, post: Post, get: Get, generator: DataGenerator
 ):
@@ -938,11 +890,9 @@ def test_delete_bulk_permission_not_required_for_single_id(
     assert response.status_code == 200
     assert len(get().json()) == 0
 
-
 # ==============================================================================
 # Edge Cases and Validation
 # ==============================================================================
-
 
 def test_post_with_empty_test_execution_ids_list(test_client: TestClient, get: Get):
     """Test that posting with empty test_execution_ids list returns 404"""
@@ -960,7 +910,6 @@ def test_post_with_empty_test_execution_ids_list(test_client: TestClient, get: G
     # No reruns should be created
     assert len(get().json()) == 0
 
-
 def test_post_silent_with_empty_ids_does_nothing(test_client: TestClient, get: Get):
     """Test that silent mode with empty IDs gracefully does nothing"""
     response = make_authenticated_request(
@@ -975,7 +924,6 @@ def test_post_silent_with_empty_ids_does_nothing(test_client: TestClient, get: G
     assert response.status_code == 200
     assert response.json() is None
     assert len(get().json()) == 0
-
 
 def test_post_with_filters_matching_no_results(test_client: TestClient, get: Get, generator: DataGenerator):
     """Test that filters matching no test results does nothing"""
@@ -1005,7 +953,6 @@ def test_post_with_filters_matching_no_results(test_client: TestClient, get: Get
     assert response.status_code == 200
     # Should not create any reruns
     assert len(get().json()) == 0
-
 
 def test_post_filters_by_artefact_name(test_client: TestClient, get: Get, generator: DataGenerator):
     """Test filtering reruns by artefact name"""
@@ -1044,7 +991,6 @@ def test_post_filters_by_artefact_name(test_client: TestClient, get: Get, genera
     assert len(reruns) == 1
     assert reruns[0]["artefact"]["name"] == "firefox"
 
-
 def test_post_filters_by_environment_name(test_client: TestClient, get: Get, generator: DataGenerator):
     """Test filtering reruns by environment name"""
     a = generator.gen_artefact(StageName.beta)
@@ -1081,7 +1027,6 @@ def test_post_filters_by_environment_name(test_client: TestClient, get: Get, gen
     assert len(reruns) == 1
     assert reruns[0]["test_execution"]["environment"]["name"] == "rpi4"
 
-
 def test_delete_with_empty_ids_does_nothing(test_client: TestClient, post: Post, get: Get, generator: DataGenerator):
     """Test that deleting with empty IDs does nothing"""
     a = generator.gen_artefact(StageName.beta)
@@ -1106,7 +1051,6 @@ def test_delete_with_empty_ids_does_nothing(test_client: TestClient, post: Post,
     assert response.status_code == 200
     # Rerun should still exist
     assert len(get().json()) == 1
-
 
 def test_post_non_silent_with_single_id_and_filters_fails(test_client: TestClient, generator: DataGenerator):
     """Test that non-silent mode fails even with single ID if filters are provided"""
@@ -1135,3 +1079,573 @@ def test_post_non_silent_with_single_id_and_filters_fails(test_client: TestClien
 
     assert response.status_code == 422
     assert "must be done silently" in response.json()["detail"]
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from test_observer.common.enums import Permission
+from test_observer.data_access.models_enums import (
+    FamilyName,
+    StageName,
+    TestResultStatus,
+)
+from test_observer.controllers.applications.application_injection import (
+    get_current_application,
+)
+from test_observer.main import app
+from test_observer.users.user_injection import get_current_user
+from tests.data_generator import DataGenerator
+
+reruns_url = "/v1/test-executions/reruns"
+
+class TestRerunAMRPermissions:
+    """Test AMR-based permission checking for rerun operations"""
+
+    def test_create_rerun_with_amr_permission(
+        self, test_client: TestClient, generator: DataGenerator, db_session: Session
+    ):
+        """User with matching AMR permission should be able to create rerun"""
+
+        # Create team and AMR
+        team = generator.gen_team(name="snap-team")
+        rule = generator.gen_artefact_matching_rule(
+            family=FamilyName.snap,
+            stage="stable",
+            teams=[team],
+            grant_permissions=[Permission.change_rerun],
+        )
+
+        # Create user in team
+        user = generator.gen_user(name="alice")
+        user.teams = [team]
+        user.is_admin = False
+        generator._add_object(user)
+
+        # Create test execution with matching artefact
+        artefact = generator.gen_artefact(
+            name="test-snap",
+            family=FamilyName.snap,
+            stage=StageName.stable,
+        )
+        build = generator.gen_artefact_build(artefact=artefact)
+        environment = generator.gen_environment("test-env")
+        test_execution = generator.gen_test_execution(artefact_build=build, environment=environment)
+
+        # Mock user injection
+        app.dependency_overrides[get_current_user] = lambda: user
+
+        try:
+            response = test_client.post(
+                reruns_url,
+                json={"test_execution_ids": [test_execution.id]},
+            )
+            assert response.status_code == 200
+        finally:
+            del app.dependency_overrides[get_current_user]
+
+    def test_create_rerun_without_amr_permission(
+        self, test_client: TestClient, generator: DataGenerator
+    ):
+        """User without matching AMR should be denied"""
+
+        # Create two teams
+        team_a = generator.gen_team(name="team-a")
+        team_b = generator.gen_team(name="team-b")
+
+        # Create AMR for team_a
+        rule = generator.gen_artefact_matching_rule(
+            family=FamilyName.snap,
+            stage="stable",
+            teams=[team_a],
+            grant_permissions=[Permission.change_rerun],
+        )
+
+        # Create user in team_b
+        user = generator.gen_user(name="bob")
+        user.teams = [team_b]
+        user.is_admin = False
+        generator._add_object(user)
+
+        # Create matching artefact
+        artefact = generator.gen_artefact(
+            name="test-snap",
+            family=FamilyName.snap,
+            stage=StageName.stable,
+        )
+        build = generator.gen_artefact_build(artefact=artefact)
+        environment = generator.gen_environment("test-env")
+        test_execution = generator.gen_test_execution(artefact_build=build, environment=environment)
+
+        # Mock the user
+        app.dependency_overrides[get_current_user] = lambda: user
+
+        try:
+            response = test_client.post(
+                reruns_url,
+                json={"test_execution_ids": [test_execution.id]},
+            )
+            assert response.status_code == 403
+        finally:
+            del app.dependency_overrides[get_current_user]
+
+    def test_create_rerun_no_matching_amr(
+        self, test_client: TestClient, generator: DataGenerator
+    ):
+        """User's team has AMR, but for different artefact should be denied"""
+
+        # Create team and AMR for stable stage
+        team = generator.gen_team(name="snap-team")
+        rule = generator.gen_artefact_matching_rule(
+            family=FamilyName.snap,
+            stage="stable",
+            teams=[team],
+            grant_permissions=[Permission.change_rerun],
+        )
+
+        # Create user in team
+        user = generator.gen_user(name="charlie")
+        user.teams = [team]
+        user.is_admin = False
+        generator._add_object(user)
+
+        # Create artefact that doesn't match (different stage)
+        artefact = generator.gen_artefact(
+            name="test-snap",
+            family=FamilyName.snap,
+            stage=StageName.beta,
+        )
+        build = generator.gen_artefact_build(artefact=artefact)
+        environment = generator.gen_environment("test-env")
+        test_execution = generator.gen_test_execution(artefact_build=build, environment=environment)
+
+        # Mock the user
+        app.dependency_overrides[get_current_user] = lambda: user
+
+        try:
+            response = test_client.post(
+                reruns_url,
+                json={"test_execution_ids": [test_execution.id]},
+            )
+            assert response.status_code == 403
+        finally:
+            del app.dependency_overrides[get_current_user]
+
+    def test_delete_rerun_with_amr_permission(
+        self, test_client: TestClient, generator: DataGenerator
+    ):
+        """User with matching AMR permission should be able to delete rerun"""
+
+        # Create team and AMR
+        team = generator.gen_team(name="snap-team")
+        rule = generator.gen_artefact_matching_rule(
+            family=FamilyName.snap,
+            stage="stable",
+            teams=[team],
+            grant_permissions=[Permission.change_rerun],
+        )
+
+        # Create user in team
+        user = generator.gen_user(name="alice")
+        user.teams = [team]
+        user.is_admin = False
+        generator._add_object(user)
+
+        # Create test execution with matching artefact
+        artefact = generator.gen_artefact(
+            name="test-snap",
+            family=FamilyName.snap,
+            stage=StageName.stable,
+        )
+        build = generator.gen_artefact_build(artefact=artefact)
+        environment = generator.gen_environment("test-env")
+        test_execution = generator.gen_test_execution(artefact_build=build, environment=environment)
+
+        # First, create the rerun
+        app.dependency_overrides[get_current_user] = lambda: user
+        try:
+            create_response = test_client.post(
+                reruns_url,
+                json={"test_execution_ids": [test_execution.id]},
+            )
+            assert create_response.status_code == 200
+
+            # Now delete it
+            delete_response = test_client.request(
+                "DELETE",
+                reruns_url,
+                json={"test_execution_ids": [test_execution.id]},
+            )
+            assert delete_response.status_code == 200
+        finally:
+            del app.dependency_overrides[get_current_user]
+
+    def test_create_rerun_multiple_artefacts_all_authorized(
+        self, test_client: TestClient, generator: DataGenerator
+    ):
+        """User authorized for all artefacts should succeed with multiple IDs"""
+
+        # Create team and AMR for snap family
+        team = generator.gen_team(name="snap-team")
+        rule = generator.gen_artefact_matching_rule(
+            family=FamilyName.snap,
+            stage="stable",
+            teams=[team],
+            grant_permissions=[Permission.change_rerun],
+        )
+
+        # Create user in team
+        user = generator.gen_user(name="alice")
+        user.teams = [team]
+        user.is_admin = False
+        generator._add_object(user)
+        
+        # Create app with bulk permission for bulk operations
+        application = generator.gen_application(
+            name="test-app",
+            permissions=[Permission.change_rerun_bulk],
+        )
+
+        # Create multiple test executions with matching artefacts
+        test_execution_ids = []
+        environment = generator.gen_environment("test-env")
+        for i in range(3):
+            artefact = generator.gen_artefact(
+                name=f"test-snap-{i}",
+                family=FamilyName.snap,
+                stage=StageName.stable,
+            )
+            build = generator.gen_artefact_build(artefact=artefact)
+            test_execution = generator.gen_test_execution(artefact_build=build, environment=environment)
+            test_execution_ids.append(test_execution.id)
+
+        # Mock user and app injection
+        app.dependency_overrides[get_current_user] = lambda: user
+        app.dependency_overrides[get_current_application] = lambda: application
+
+        try:
+            response = test_client.post(
+                reruns_url,
+                json={"test_execution_ids": test_execution_ids},
+            )
+            assert response.status_code == 200
+        finally:
+            del app.dependency_overrides[get_current_user]
+            del app.dependency_overrides[get_current_application]
+
+    def test_create_rerun_multiple_artefacts_partial_authorized(
+        self, test_client: TestClient, generator: DataGenerator
+    ):
+        """User authorized for some artefacts should fail entire operation"""
+
+        # Create team and AMR for snap family only (include bulk for multi-ID requirement)
+        team = generator.gen_team(name="snap-team")
+        rule = generator.gen_artefact_matching_rule(
+            family=FamilyName.snap,
+            stage="stable",
+            teams=[team],
+            grant_permissions=[Permission.change_rerun, Permission.change_rerun_bulk],
+        )
+
+        # Create user in team
+        user = generator.gen_user(name="alice")
+        user.teams = [team]
+        user.is_admin = False
+        generator._add_object(user)
+
+        # Create one snap (authorized) and one deb (unauthorized)
+        environment = generator.gen_environment("test-env")
+        snap_artefact = generator.gen_artefact(
+            name="test-snap",
+            family=FamilyName.snap,
+            stage=StageName.stable,
+        )
+        snap_build = generator.gen_artefact_build(artefact=snap_artefact)
+        snap_te = generator.gen_test_execution(artefact_build=snap_build, environment=environment)
+
+        deb_artefact = generator.gen_artefact(
+            name="test-deb",
+            family=FamilyName.deb,
+            stage=StageName.proposed,
+        )
+        deb_build = generator.gen_artefact_build(artefact=deb_artefact)
+        deb_te = generator.gen_test_execution(artefact_build=deb_build, environment=environment)
+
+        # Mock user injection
+        app.dependency_overrides[get_current_user] = lambda: user
+
+        try:
+            # Should fail because of all-or-nothing semantics
+            response = test_client.post(
+                reruns_url,
+                json={"test_execution_ids": [snap_te.id, deb_te.id]},
+            )
+            assert response.status_code == 403
+        finally:
+            del app.dependency_overrides[get_current_user]
+
+    def test_create_rerun_bulk_filter_with_amr_permission(
+        self, test_client: TestClient, generator: DataGenerator
+    ):
+        """User authorized for all filtered results should succeed"""
+
+        # Create team and AMR for snap family
+        team = generator.gen_team(name="snap-team")
+        rule = generator.gen_artefact_matching_rule(
+            family=FamilyName.snap,
+            stage="stable",
+            teams=[team],
+            grant_permissions=[Permission.change_rerun],
+        )
+
+        # Create user in team
+        user = generator.gen_user(name="alice")
+        user.teams = [team]
+        user.is_admin = False
+        generator._add_object(user)
+        
+        # Create app with bulk permission
+        application = generator.gen_application(
+            name="test-app",
+            permissions=[Permission.change_rerun_bulk],
+        )
+
+        # Create test execution with matching artefact and failed result
+        artefact = generator.gen_artefact(
+            name="test-snap",
+            family=FamilyName.snap,
+            stage=StageName.stable,
+        )
+        build = generator.gen_artefact_build(artefact=artefact)
+        environment = generator.gen_environment("test-env")
+        test_execution = generator.gen_test_execution(artefact_build=build, environment=environment)
+
+        tc = generator.gen_test_case("test_case_1")
+        generator.gen_test_result(tc, test_execution, status=TestResultStatus.FAILED)
+
+        # Mock user and app injection
+        app.dependency_overrides[get_current_user] = lambda: user
+        app.dependency_overrides[get_current_application] = lambda: application
+
+        try:
+            response = test_client.post(
+                reruns_url,
+                params={"silent": True},
+                json={
+                    "test_results_filters": {
+                        "test_result_statuses": ["FAILED"],
+                    }
+                },
+            )
+            assert response.status_code == 200
+        finally:
+            del app.dependency_overrides[get_current_user]
+            del app.dependency_overrides[get_current_application]
+
+    def test_create_rerun_bulk_filter_without_amr_permission(
+        self, test_client: TestClient, generator: DataGenerator
+    ):
+        """User without permission for filtered artefacts should be denied"""
+
+        # Create team with AMR only for snap (include bulk for filter requirement)
+        team = generator.gen_team(name="snap-team")
+        rule = generator.gen_artefact_matching_rule(
+            family=FamilyName.snap,
+            stage="stable",
+            teams=[team],
+            grant_permissions=[Permission.change_rerun, Permission.change_rerun_bulk],
+        )
+
+        # Create user in team
+        user = generator.gen_user(name="alice")
+        user.teams = [team]
+        user.is_admin = False
+        generator._add_object(user)
+
+        # Create test execution with unmatched artefact (deb) and failed result
+        artefact = generator.gen_artefact(
+            name="test-deb",
+            family=FamilyName.deb,
+            stage=StageName.proposed,
+        )
+        build = generator.gen_artefact_build(artefact=artefact)
+        environment = generator.gen_environment("test-env")
+        test_execution = generator.gen_test_execution(artefact_build=build, environment=environment)
+
+        tc = generator.gen_test_case("test_case_1")
+        generator.gen_test_result(tc, test_execution, status=TestResultStatus.FAILED)
+
+        # Mock user injection
+        app.dependency_overrides[get_current_user] = lambda: user
+
+        try:
+            response = test_client.post(
+                reruns_url,
+                params={"silent": True},
+                json={
+                    "test_results_filters": {
+                        "test_result_statuses": ["FAILED"],
+                    }
+                },
+            )
+            assert response.status_code == 403
+        finally:
+            del app.dependency_overrides[get_current_user]
+
+    def test_admin_user_bypasses_amr_checks(
+        self, test_client: TestClient, generator: DataGenerator
+    ):
+        """Admin user should bypass AMR checks"""
+
+        # Create admin user with no teams or AMR
+        user = generator.gen_user(name="admin")
+        user.teams = []
+        user.is_admin = True
+        generator._add_object(user)
+
+        # Create test execution with any artefact
+        artefact = generator.gen_artefact(
+            name="test-snap",
+            family=FamilyName.snap,
+            stage=StageName.stable,
+        )
+        build = generator.gen_artefact_build(artefact=artefact)
+        environment = generator.gen_environment("test-env")
+        test_execution = generator.gen_test_execution(artefact_build=build, environment=environment)
+
+        # Mock user injection
+        app.dependency_overrides[get_current_user] = lambda: user
+
+        try:
+            response = test_client.post(
+                reruns_url,
+                json={"test_execution_ids": [test_execution.id]},
+            )
+            # Admin should succeed even without AMR
+            assert response.status_code == 200
+        finally:
+            del app.dependency_overrides[get_current_user]
+
+    def test_app_permission_bypasses_amr_checks(
+        self, test_client: TestClient, generator: DataGenerator
+    ):
+        """App with change_rerun permission should bypass AMR checks"""
+
+        # Create app with permission
+        application = generator.gen_application(
+            name="test-app",
+            permissions=[Permission.change_rerun],
+        )
+
+        # Create test execution with any artefact
+        artefact = generator.gen_artefact(
+            name="test-snap",
+            family=FamilyName.snap,
+            stage=StageName.stable,
+        )
+        build = generator.gen_artefact_build(artefact=artefact)
+        environment = generator.gen_environment("test-env")
+        test_execution = generator.gen_test_execution(artefact_build=build, environment=environment)
+
+        # Mock app injection (no user)
+        app.dependency_overrides[get_current_user] = lambda: None
+        app.dependency_overrides[get_current_application] = lambda: application
+
+        try:
+            response = test_client.post(
+                reruns_url,
+                json={"test_execution_ids": [test_execution.id]},
+            )
+            # App should succeed even without matching AMR
+            assert response.status_code == 200
+        finally:
+            del app.dependency_overrides[get_current_user]
+            del app.dependency_overrides[get_current_application]
+
+    def test_empty_test_execution_ids_list(
+        self, test_client: TestClient, generator: DataGenerator
+    ):
+        """Empty test_execution_ids should return 404"""
+
+        # Create user with no teams or AMR
+        user = generator.gen_user(name="alice")
+        user.teams = []
+        user.is_admin = False
+        generator._add_object(user)
+
+        # Mock user injection
+        app.dependency_overrides[get_current_user] = lambda: user
+
+        try:
+            # Empty list should return 404 (no test executions found)
+            response = test_client.post(
+                reruns_url,
+                json={"test_execution_ids": []},
+            )
+            assert response.status_code == 404
+        finally:
+            del app.dependency_overrides[get_current_user]
+
+    def test_no_matching_test_executions_in_filter(
+        self, test_client: TestClient, generator: DataGenerator
+    ):
+        """Filter that matches no test executions should succeed silently"""
+
+        # Create user with no teams or AMR
+        user = generator.gen_user(name="alice")
+        user.teams = []
+        user.is_admin = False
+        generator._add_object(user)
+        
+        # Create app with bulk permission (required for filter operations)
+        application = generator.gen_application(
+            name="test-app",
+            permissions=[Permission.change_rerun_bulk],
+        )
+
+        # Create test execution but it won't match our filter
+        artefact = generator.gen_artefact(
+            name="test-snap",
+            family=FamilyName.snap,
+            stage=StageName.stable,
+        )
+        build = generator.gen_artefact_build(artefact=artefact)
+        environment = generator.gen_environment("test-env")
+        test_execution = generator.gen_test_execution(artefact_build=build, environment=environment)
+
+        tc = generator.gen_test_case("test_case_1")
+        generator.gen_test_result(tc, test_execution, status=TestResultStatus.PASSED)
+
+        # Mock user and app injection
+        app.dependency_overrides[get_current_user] = lambda: user
+        app.dependency_overrides[get_current_application] = lambda: application
+
+        try:
+            # Filter for FAILED status (none exist) - in silent mode should succeed
+            response = test_client.post(
+                reruns_url,
+                params={"silent": True},
+                json={
+                    "test_results_filters": {
+                        "test_result_statuses": ["FAILED"],
+                    }
+                },
+            )
+            # Should succeed because silent=True and no AMR check needed when filter matches nothing
+            assert response.status_code == 200
+        finally:
+            del app.dependency_overrides[get_current_user]
+            del app.dependency_overrides[get_current_application]

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -186,8 +186,9 @@ def test_execution_to_pending_rerun(test_execution: TestExecution) -> dict:
 # ==============================================================================
 
 
-def test_post_no_data_returns_422(post: Post):
-    assert post(None).status_code == 422
+def test_post_no_data_returns_422(test_client: TestClient):
+    response = test_client.post(reruns_url, json=None)
+    assert response.status_code == 422
 
 
 def test_post_invalid_id_returns_404_with_message(post: Post):
@@ -950,12 +951,9 @@ def test_delete_bulk_permission_not_required_for_single_id(
 
 def test_post_with_empty_test_execution_ids_list(test_client: TestClient, get: Get):
     """Test that posting with empty test_execution_ids list returns 404"""
-    response = make_authenticated_request(
-        lambda: test_client.post(
-            reruns_url,
-            json={"test_execution_ids": []},
-        ),
-        Permission.change_rerun,
+    response = test_client.post(
+        reruns_url,
+        json={"test_execution_ids": []},
     )
 
     # Empty list is treated as not finding any test executions
@@ -967,13 +965,10 @@ def test_post_with_empty_test_execution_ids_list(test_client: TestClient, get: G
 
 def test_post_silent_with_empty_ids_does_nothing(test_client: TestClient, get: Get):
     """Test that silent mode with empty IDs gracefully does nothing"""
-    response = make_authenticated_request(
-        lambda: test_client.post(
-            reruns_url,
-            params={"silent": True},
-            json={"test_execution_ids": []},
-        ),
-        Permission.change_rerun,
+    response = test_client.post(
+        reruns_url,
+        params={"silent": True},
+        json={"test_execution_ids": []},
     )
 
     assert response.status_code == 200
@@ -1098,13 +1093,10 @@ def test_delete_with_empty_ids_does_nothing(test_client: TestClient, post: Post,
     assert len(get().json()) == 1
 
     # Delete with empty list should do nothing
-    response = make_authenticated_request(
-        lambda: test_client.request(
-            "DELETE",
-            reruns_url,
-            json={"test_execution_ids": []},
-        ),
-        Permission.change_rerun,
+    response = test_client.request(
+        "DELETE",
+        reruns_url,
+        json={"test_execution_ids": []},
     )
 
     assert response.status_code == 200

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -191,9 +191,9 @@ def test_post_no_data_returns_422(test_client: TestClient):
     assert response.status_code == 422
 
 
-def test_post_invalid_id_returns_403(test_client: TestClient):
-    response = test_client.post(reruns_url, json={"test_execution_ids": [1]})
-    assert response.status_code == 403
+def test_post_invalid_id_returns_404(post: Post):
+    response = post({"test_execution_ids": [99999]})
+    assert response.status_code == 404
 
 
 def test_valid_post(post: Post, test_execution: TestExecution):

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -191,10 +191,9 @@ def test_post_no_data_returns_422(test_client: TestClient):
     assert response.status_code == 422
 
 
-def test_post_invalid_id_returns_404_with_message(post: Post):
-    response = post({"test_execution_ids": [1]})
-    assert response.status_code == 404
-    assert response.json()["detail"] == "Didn't find test executions with provided ids"
+def test_post_invalid_id_returns_403(test_client: TestClient):
+    response = test_client.post(reruns_url, json={"test_execution_ids": [1]})
+    assert response.status_code == 403
 
 
 def test_valid_post(post: Post, test_execution: TestExecution):
@@ -949,12 +948,9 @@ def test_delete_bulk_permission_not_required_for_single_id(
 # ==============================================================================
 
 
-def test_post_with_empty_test_execution_ids_list(test_client: TestClient, get: Get):
+def test_post_with_empty_test_execution_ids_list(post: Post, get: Get):
     """Test that posting with empty test_execution_ids list returns 404"""
-    response = test_client.post(
-        reruns_url,
-        json={"test_execution_ids": []},
-    )
+    response = post({"test_execution_ids": []})
 
     # Empty list is treated as not finding any test executions
     assert response.status_code == 404
@@ -965,10 +961,13 @@ def test_post_with_empty_test_execution_ids_list(test_client: TestClient, get: G
 
 def test_post_silent_with_empty_ids_does_nothing(test_client: TestClient, get: Get):
     """Test that silent mode with empty IDs gracefully does nothing"""
-    response = test_client.post(
-        reruns_url,
-        params={"silent": True},
-        json={"test_execution_ids": []},
+    response = make_authenticated_request(
+        lambda: test_client.post(
+            reruns_url,
+            params={"silent": True},
+            json={"test_execution_ids": []},
+        ),
+        Permission.change_rerun,
     )
 
     assert response.status_code == 200
@@ -1081,7 +1080,7 @@ def test_post_filters_by_environment_name(test_client: TestClient, get: Get, gen
     assert reruns[0]["test_execution"]["environment"]["name"] == "rpi4"
 
 
-def test_delete_with_empty_ids_does_nothing(test_client: TestClient, post: Post, get: Get, generator: DataGenerator):
+def test_delete_with_empty_ids_does_nothing(post: Post, get: Get, delete: Delete, generator: DataGenerator):
     """Test that deleting with empty IDs does nothing"""
     a = generator.gen_artefact(StageName.beta)
     ab = generator.gen_artefact_build(a)
@@ -1093,11 +1092,7 @@ def test_delete_with_empty_ids_does_nothing(test_client: TestClient, post: Post,
     assert len(get().json()) == 1
 
     # Delete with empty list should do nothing
-    response = test_client.request(
-        "DELETE",
-        reruns_url,
-        json={"test_execution_ids": []},
-    )
+    response = delete({"test_execution_ids": []})
 
     assert response.status_code == 200
     # Rerun should still exist


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

As the final part of TO-299, this PR adds permission checking with ArtefactMatchingRules for `change_rerun`. As it's a very unusual way to gate access to endpoints, I tried to make the tests very comprehensive.

Additionally, gating that for reruns is a bit different from `change_artefact` because in the rerun endpoints we:
- May have multiple artefacts
- May not know upfront what the artefacts are

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

TO-299

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Many tests!!! I think we can trust copilot to review the code logic inside them but please as a reviewer try to see if you can find uncovered corner cases