### PR TITLE
[IQA-3562] Add Authentication Checker

### DIFF
--- a/backend/dev_entrypoint.sh
+++ b/backend/dev_entrypoint.sh
@@ -38,7 +38,7 @@ if [ "${SEED_DATA:-false}" = "true" ]; then
     timeout=60
     count=0
     while [ $count -lt $timeout ]; do
-        if curl -f http://localhost:30000/v1/version > /dev/null 2>&1; then
+        if curl -f http://localhost:30000/health/ready > /dev/null 2>&1; then
             echo "API server is ready. Starting database seeding..."
             break
         fi

--- a/backend/test_observer/common/config.py
+++ b/backend/test_observer/common/config.py
@@ -31,3 +31,4 @@ IGNORE_PERMISSIONS = {
     permission.strip() for permission in os.getenv("IGNORE_PERMISSIONS", "").lower().split(",") if permission.strip()
 }
 METRICS_PORT = int(os.getenv("METRICS_PORT", "9090"))
+REQUIRE_AUTHENTICATION = os.getenv("REQUIRE_AUTHENTICATION", "false").lower() == "true"

--- a/backend/test_observer/common/permissions.py
+++ b/backend/test_observer/common/permissions.py
@@ -17,7 +17,7 @@ from fastapi import Depends, HTTPException
 from fastapi.security import SecurityScopes
 from sqlalchemy.orm import Session, selectinload
 
-from test_observer.common.config import IGNORE_PERMISSIONS
+from test_observer.common.config import IGNORE_PERMISSIONS, REQUIRE_AUTHENTICATION
 from test_observer.common.enums import Permission
 from test_observer.controllers.applications.application_injection import (
     get_current_application,
@@ -25,6 +25,30 @@ from test_observer.controllers.applications.application_injection import (
 from test_observer.data_access.models import Application, Artefact, ArtefactMatchingRule, User
 from test_observer.data_access.queries import match_artefact
 from test_observer.users.user_injection import get_current_user
+
+
+def require_authentication() -> bool:
+    """
+    Simply returns the REQUIRE_AUTHENTICATION config value.
+    By making this a function, it can be used as a dependency
+    for routes that require authentication, and being a dependency
+    in turn makes it easier to override in tests if needed.
+    """
+    return REQUIRE_AUTHENTICATION
+
+
+def authentication_checker(
+    user: User | None = Depends(get_current_user),
+    app: Application | None = Depends(get_current_application),
+    authentication_required: bool = Depends(require_authentication),
+) -> None:
+    """
+    A simple dependency to check if the request is authenticated with either a user or an application.
+    This is used for endpoints that don't require specific permissions, but still require authentication.
+    """
+    if authentication_required and not user and not app:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    return None
 
 
 def permission_checker(

--- a/backend/test_observer/common/permissions.py
+++ b/backend/test_observer/common/permissions.py
@@ -48,7 +48,6 @@ def authentication_checker(
     """
     if authentication_required and not user and not app:
         raise HTTPException(status_code=401, detail="Not authenticated")
-    return None
 
 
 def permission_checker(

--- a/backend/test_observer/common/permissions.py
+++ b/backend/test_observer/common/permissions.py
@@ -27,7 +27,7 @@ from test_observer.data_access.queries import match_artefact
 from test_observer.users.user_injection import get_current_user
 
 
-def require_authentication() -> bool:
+def requires_authentication() -> bool:
     """
     Simply returns the REQUIRE_AUTHENTICATION config value.
     By making this a function, it can be used as a dependency
@@ -40,7 +40,7 @@ def require_authentication() -> bool:
 def authentication_checker(
     user: User | None = Depends(get_current_user),
     app: Application | None = Depends(get_current_application),
-    authentication_required: bool = Depends(require_authentication),
+    authentication_required: bool = Depends(requires_authentication),
 ) -> None:
     """
     A simple dependency to check if the request is authenticated with either a user or an application.

--- a/backend/test_observer/controllers/application/version.py
+++ b/backend/test_observer/controllers/application/version.py
@@ -16,12 +16,14 @@
 import importlib.metadata
 from importlib.metadata import PackageNotFoundError
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+
+from test_observer.common.permissions import authentication_checker
 
 router = APIRouter()
 
 
-@router.get("")
+@router.get("", dependencies=[Depends(authentication_checker)])
 async def get_version():
     try:
         version = importlib.metadata.version("test-observer")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -39,7 +39,7 @@ from test_observer.common.enums import Permission
 from test_observer.controllers.applications.application_injection import (
     get_current_application,
 )
-from test_observer.data_access.models import Application, TestExecution
+from test_observer.data_access.models import Application, TestExecution, User
 from test_observer.data_access.models_enums import StageName
 from test_observer.data_access.setup import get_db
 from test_observer.main import app
@@ -192,3 +192,15 @@ def create_session_cookie() -> Callable[[int], str]:
         return signer.sign(b64encode(session_json.encode()).decode()).decode()
 
     return _create_session_cookie
+
+
+def authenticate_user(
+    test_client: TestClient,
+    user: User,
+    generator: DataGenerator,
+    create_session_cookie: Callable[[int], str],
+) -> None:
+    """Helper to authenticate a user in test client"""
+    session = generator.gen_user_session(user)
+    session_cookie = create_session_cookie(session.id)
+    test_client.cookies.set("session", session_cookie)

--- a/backend/tests/controllers/application/test_version.py
+++ b/backend/tests/controllers/application/test_version.py
@@ -17,7 +17,7 @@ from collections.abc import Callable
 
 from fastapi.testclient import TestClient
 
-from test_observer.common.permissions import require_authentication
+from test_observer.common.permissions import requires_authentication
 from test_observer.main import app
 from tests.conftest import authenticate_user
 from tests.data_generator import DataGenerator
@@ -26,33 +26,66 @@ from tests.data_generator import DataGenerator
 def test_version_unauthenticated_auth_not_required(test_client: TestClient):
     """Test that unauthenticated access to version endpoint works when authentication is not required"""
     try:
-        app.dependency_overrides[require_authentication] = lambda: False
+        app.dependency_overrides[requires_authentication] = lambda: False
         response = test_client.get("/v1/version")
         assert response.status_code == 200
         assert "version" in response.json()
     finally:
-        app.dependency_overrides.pop(require_authentication, None)
+        app.dependency_overrides.pop(requires_authentication, None)
 
 
 def test_version_unauthenticated_auth_required(test_client: TestClient):
     """Test that unauthenticated access to version endpoint returns 401 when authentication is required"""
     try:
-        app.dependency_overrides[require_authentication] = lambda: True
+        app.dependency_overrides[requires_authentication] = lambda: True
         response = test_client.get("/v1/version")
         assert response.status_code == 401
     finally:
-        app.dependency_overrides.pop(require_authentication, None)
+        app.dependency_overrides.pop(requires_authentication, None)
 
 
-def test_version_authenticated_auth_not_required(
+def test_version_authenticated_auth_not_required_app(test_client: TestClient, generator: DataGenerator):
+    """
+    Test that authenticated access to the version endpoint works and returns version
+    when authentication is not required and an application is authenticated
+    """
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        application = generator.gen_application(permissions=[])
+        response = test_client.get("/v1/version", headers={"Authorization": f"Bearer {application.api_key}"})
+        assert response.status_code == 200
+        assert "version" in response.json()
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_version_authenticated_auth_not_required_user(
     test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
 ):
     """
-    Test that authenticated access to version endpoint works and returns version
-    when authentication is not required
+    Test that authenticated access to the version endpoint works and returns version
+    when authentication is not required and a user is authenticated
     """
     try:
-        app.dependency_overrides[require_authentication] = lambda: False
+        app.dependency_overrides[requires_authentication] = lambda: False
+        user = generator.gen_user()
+        authenticate_user(test_client, user, generator, create_session_cookie)
+        response = test_client.get("/v1/version", headers={"X-CSRF-Token": "1"})
+        assert response.status_code == 200
+        assert "version" in response.json()
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_version_authenticated_auth_required_app(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    """
+    Test that authenticated access to the version endpoint works and returns version
+    when authentication is required and an application is authenticated
+    """
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
 
         application = generator.gen_application(permissions=[])
         response = test_client.get("/v1/version", headers={"Authorization": f"Bearer {application.api_key}"})
@@ -65,28 +98,22 @@ def test_version_authenticated_auth_not_required(
         assert response.status_code == 200
         assert "version" in response.json()
     finally:
-        app.dependency_overrides.pop(require_authentication, None)
+        app.dependency_overrides.pop(requires_authentication, None)
 
 
-def test_version_authenticated_auth_required(
+def test_version_authenticated_auth_required_user(
     test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
 ):
     """
-    Test that authenticated access to version endpoint works and returns version
-    when authentication is required
+    Test that authenticated access to the version endpoint works and returns version
+    when authentication is required and a user is authenticated
     """
     try:
-        app.dependency_overrides[require_authentication] = lambda: True
-
-        application = generator.gen_application(permissions=[])
-        response = test_client.get("/v1/version", headers={"Authorization": f"Bearer {application.api_key}"})
-        assert response.status_code == 200
-        assert "version" in response.json()
-
+        app.dependency_overrides[requires_authentication] = lambda: True
         user = generator.gen_user()
         authenticate_user(test_client, user, generator, create_session_cookie)
         response = test_client.get("/v1/version", headers={"X-CSRF-Token": "1"})
         assert response.status_code == 200
         assert "version" in response.json()
     finally:
-        app.dependency_overrides.pop(require_authentication, None)
+        app.dependency_overrides.pop(requires_authentication, None)

--- a/backend/tests/controllers/application/test_version.py
+++ b/backend/tests/controllers/application/test_version.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from collections.abc import Callable
+
+from fastapi.testclient import TestClient
+
+from test_observer.common.permissions import require_authentication
+from test_observer.main import app
+from tests.conftest import authenticate_user
+from tests.data_generator import DataGenerator
+
+
+def test_version_unauthenticated_auth_not_required(test_client: TestClient):
+    """Test that unauthenticated access to version endpoint works when authentication is not required"""
+    try:
+        app.dependency_overrides[require_authentication] = lambda: False
+        response = test_client.get("/v1/version")
+        assert response.status_code == 200
+        assert "version" in response.json()
+    finally:
+        app.dependency_overrides.pop(require_authentication, None)
+
+
+def test_version_unauthenticated_auth_required(test_client: TestClient):
+    """Test that unauthenticated access to version endpoint returns 401 when authentication is required"""
+    try:
+        app.dependency_overrides[require_authentication] = lambda: True
+        response = test_client.get("/v1/version")
+        assert response.status_code == 401
+    finally:
+        app.dependency_overrides.pop(require_authentication, None)
+
+
+def test_version_authenticated_auth_not_required(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    """
+    Test that authenticated access to version endpoint works and returns version
+    when authentication is not required
+    """
+    try:
+        app.dependency_overrides[require_authentication] = lambda: False
+
+        application = generator.gen_application(permissions=[])
+        response = test_client.get("/v1/version", headers={"Authorization": f"Bearer {application.api_key}"})
+        assert response.status_code == 200
+        assert "version" in response.json()
+
+        user = generator.gen_user()
+        authenticate_user(test_client, user, generator, create_session_cookie)
+        response = test_client.get("/v1/version", headers={"X-CSRF-Token": "1"})
+        assert response.status_code == 200
+        assert "version" in response.json()
+    finally:
+        app.dependency_overrides.pop(require_authentication, None)
+
+
+def test_version_authenticated_auth_required(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    """
+    Test that authenticated access to version endpoint works and returns version
+    when authentication is required
+    """
+    try:
+        app.dependency_overrides[require_authentication] = lambda: True
+
+        application = generator.gen_application(permissions=[])
+        response = test_client.get("/v1/version", headers={"Authorization": f"Bearer {application.api_key}"})
+        assert response.status_code == 200
+        assert "version" in response.json()
+
+        user = generator.gen_user()
+        authenticate_user(test_client, user, generator, create_session_cookie)
+        response = test_client.get("/v1/version", headers={"X-CSRF-Token": "1"})
+        assert response.status_code == 200
+        assert "version" in response.json()
+    finally:
+        app.dependency_overrides.pop(require_authentication, None)

--- a/backend/tests/controllers/notifications/test_notifications.py
+++ b/backend/tests/controllers/notifications/test_notifications.py
@@ -19,22 +19,10 @@ from datetime import datetime
 from fastapi.testclient import TestClient
 
 from test_observer.common.enums import Permission
-from test_observer.data_access.models import User
+from test_observer.data_access.models import Notification
 from test_observer.data_access.models_enums import NotificationType
-from tests.conftest import make_authenticated_request
+from tests.conftest import authenticate_user, make_authenticated_request
 from tests.data_generator import DataGenerator
-
-
-def _authenticate_user(
-    test_client: TestClient,
-    user: User,
-    generator: DataGenerator,
-    create_session_cookie: Callable[[int], str],
-) -> None:
-    """Helper to authenticate a user in test client"""
-    session = generator.gen_user_session(user)
-    session_cookie = create_session_cookie(session.id)
-    test_client.cookies.set("session", session_cookie)
 
 
 def test_get_notifications_without_auth(test_client: TestClient):
@@ -66,7 +54,7 @@ def test_get_notifications(
     other_user = generator.gen_user(email="other@test.com")
     generator.gen_notification(user=other_user)
 
-    _authenticate_user(test_client, user, generator, create_session_cookie)
+    authenticate_user(test_client, user, generator, create_session_cookie)
     response = make_authenticated_request(
         lambda: test_client.get("/v1/users/me/notifications", headers={"X-CSRF-Token": "1"}),
         Permission.view_notification,
@@ -103,7 +91,7 @@ def test_get_unread_count(
     other_user = generator.gen_user(email="other-unread@test.com")
     generator.gen_notification(user=other_user)
 
-    _authenticate_user(test_client, user, generator, create_session_cookie)
+    authenticate_user(test_client, user, generator, create_session_cookie)
     response = make_authenticated_request(
         lambda: test_client.get("/v1/users/me/notifications/count?unread_only=true", headers={"X-CSRF-Token": "1"}),
         Permission.view_notification,
@@ -133,7 +121,7 @@ def test_mark_notification_as_read(
 
     assert notification.dismissed_at is None
 
-    _authenticate_user(test_client, user, generator, create_session_cookie)
+    authenticate_user(test_client, user, generator, create_session_cookie)
     response = make_authenticated_request(
         lambda: test_client.post(
             f"/v1/users/me/notifications/{notification.id}/dismiss", headers={"X-CSRF-Token": "1"}
@@ -157,7 +145,7 @@ def test_mark_notification_as_read_wrong_user(
     other_user = generator.gen_user(email="wrong-user-other@test.com")
     notification = generator.gen_notification(user=user)
 
-    _authenticate_user(test_client, other_user, generator, create_session_cookie)
+    authenticate_user(test_client, other_user, generator, create_session_cookie)
     response = make_authenticated_request(
         lambda: test_client.post(
             f"/v1/users/me/notifications/{notification.id}/dismiss", headers={"X-CSRF-Token": "1"}
@@ -176,7 +164,7 @@ def test_mark_nonexistent_notification_as_read(
     """Test marking a non-existent notification as read returns 404"""
     user = generator.gen_user(email="nonexistent@test.com")
 
-    _authenticate_user(test_client, user, generator, create_session_cookie)
+    authenticate_user(test_client, user, generator, create_session_cookie)
     response = make_authenticated_request(
         lambda: test_client.post("/v1/users/me/notifications/99999/dismiss", headers={"X-CSRF-Token": "1"}),
         Permission.change_notification,
@@ -194,7 +182,7 @@ def test_get_notifications_with_pagination(
     user = generator.gen_user(email="pagination@test.com")
 
     # Create 5 notifications with different artefact families
-    notifications = []
+    notifications: list[Notification] = []
     families = ["snaps", "images", "debs", "charms", "snaps"]
     for idx, family in enumerate(families):
         notification = generator.gen_notification(
@@ -204,7 +192,7 @@ def test_get_notifications_with_pagination(
         )
         notifications.append(notification)
 
-    _authenticate_user(test_client, user, generator, create_session_cookie)
+    authenticate_user(test_client, user, generator, create_session_cookie)
 
     # Test limit
     response = make_authenticated_request(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       UV_DYNAMIC_VERSIONING_BYPASS: "0.0.0" # this is to be set at image build time for production images
       PYTHONDONTWRITEBYTECODE: "1" # Prevent .pyc files in development
       SESSIONS_HTTPS_ONLY: "false"
+      REQUIRE_AUTHENTICATION: "${REQUIRE_AUTHENTICATION:-false}"
     volumes:
       # Mount source code from host for development
       - ./backend:/home/app


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR is split from https://github.com/canonical/test_observer/pull/674

It adds a new config option that can make authentication required and adds a new routing dependency that can make use of that option. To put it into practice, it then moves the `/v1/version` endpoint behind that authentication checker.

This also fixes the `dev_entrypoint.sh` script to use the `/health/ready` endpoint (which really should have been done in https://github.com/canonical/test_observer/pull/678), because otherwise the service won't start correctly if `REQUIRE_AUTHENTICATION` is set to `true`.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

IQA-3562

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

The `/v1/version` endpoint can be hidden behind authentication if the `REQUIRE_AUTHENTICATION` environment variable is set

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Tests are added
