### PR TITLE
[IQA-3563] Move docs behind optional authentication

### DIFF
--- a/backend/test_observer/common/permissions.py
+++ b/backend/test_observer/common/permissions.py
@@ -24,7 +24,7 @@ from test_observer.controllers.applications.application_injection import (
 )
 from test_observer.data_access.models import Application, Artefact, ArtefactMatchingRule, User
 from test_observer.data_access.queries import match_artefact
-from test_observer.users.user_injection import get_current_user
+from test_observer.users.user_injection import get_current_user, get_current_user_browser_friendly
 
 
 def requires_authentication() -> bool:
@@ -45,6 +45,23 @@ def authentication_checker(
     """
     A simple dependency to check if the request is authenticated with either a user or an application.
     This is used for endpoints that don't require specific permissions, but still require authentication.
+    """
+    if authentication_required and not user and not app:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+
+def authentication_checker_browser_friendly(
+    user: User | None = Depends(get_current_user_browser_friendly),
+    app: Application | None = Depends(get_current_application),
+    authentication_required: bool = Depends(requires_authentication),
+) -> None:
+    """
+    A browser-friendly version of the authentication checker that allows GET requests without a CSRF token
+    through the underlying `get_current_user_browser_friendly` dependency.
+    This must only be used for endpoints that are safe to trigger cross-site and have no side effects.
+
+    At the time of writing, this should only be used for the /docs endpoint, as that is the only endpoint
+    intended to be used directly in the browser. Other endpoints can be used in the browser _from_ the Swagger docs.
     """
     if authentication_required and not user and not app:
         raise HTTPException(status_code=401, detail="Not authenticated")

--- a/backend/test_observer/controllers/docs/docs.py
+++ b/backend/test_observer/controllers/docs/docs.py
@@ -13,14 +13,21 @@
 # SPDX-FileCopyrightText: Copyright 2025 Canonical Ltd.
 # SPDX-License-Identifier: AGPL-3.0-only
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.openapi.docs import get_swagger_ui_html
 from fastapi.responses import HTMLResponse, JSONResponse
+
+from test_observer.common.enums import Permission
+from test_observer.common.permissions import authentication_checker, authentication_checker_browser_friendly
 
 router: APIRouter = APIRouter()
 
 
-@router.get("/openapi.json", include_in_schema=False)
+@router.get(
+    "/openapi.json",
+    include_in_schema=False,
+    dependencies=[Depends(authentication_checker)],
+)
 async def custom_openapi(request: Request):
     app = request.app
     openapi_schema = app.openapi()
@@ -31,7 +38,7 @@ async def custom_openapi(request: Request):
             continue
 
         # Get security scopes for all dependencies
-        security_scopes = []
+        security_scopes: list[Permission] = []
         for dep in route.dependant.dependencies:
             security_scopes.extend(dep.security_scopes)
         if len(security_scopes) == 0:
@@ -46,7 +53,11 @@ async def custom_openapi(request: Request):
     return JSONResponse(openapi_schema)
 
 
-@router.get("/docs", include_in_schema=False)
+@router.get(
+    "/docs",
+    include_in_schema=False,
+    dependencies=[Depends(authentication_checker_browser_friendly)],
+)
 async def custom_swagger_ui_html():
     html = get_swagger_ui_html(openapi_url="/openapi.json", title="API Documentation")
 

--- a/backend/test_observer/users/user_injection.py
+++ b/backend/test_observer/users/user_injection.py
@@ -58,6 +58,10 @@ def get_user_session_browser_friendly(request: Request, db: Session = Depends(ge
     Other endpoints can be used in the browser _from_ the Swagger docs.
     """
 
+    # Enforce that this dependency is only used for the /docs endpoint
+    if request.url.path != "/docs":
+        return None
+
     if request.method != "GET" and "X-CSRF-Token" not in request.headers:
         return None
 

--- a/backend/test_observer/users/user_injection.py
+++ b/backend/test_observer/users/user_injection.py
@@ -45,3 +45,36 @@ def get_current_user(
     if session:
         return session.user
     return None
+
+
+def get_user_session_browser_friendly(request: Request, db: Session = Depends(get_db)) -> UserSession | None:
+    """
+    Browser-friendly session getter that allows GET requests without a CSRF token.
+    This must only be used for endpoints that are safe to trigger cross-site
+    and have no side effects.
+
+    At the time of writing, this should only be used for the /docs endpoint,
+    as that is the only endpoint intended to be used directly in the browser.
+    Other endpoints can be used in the browser _from_ the Swagger docs.
+    """
+
+    if request.method != "GET" and "X-CSRF-Token" not in request.headers:
+        return None
+
+    session_id = request.session.get("id")
+    if not session_id:
+        return None
+
+    session = db.get(UserSession, session_id, options=[selectinload(UserSession.user)])
+    if not session or session.expires_at < datetime.now():
+        return None
+
+    return session
+
+
+def get_current_user_browser_friendly(
+    session: UserSession | None = Depends(get_user_session_browser_friendly),
+) -> User | None:
+    if session:
+        return session.user
+    return None

--- a/backend/tests/controllers/docs/test_docs.py
+++ b/backend/tests/controllers/docs/test_docs.py
@@ -17,7 +17,11 @@ from collections.abc import Callable
 
 from fastapi.testclient import TestClient
 
-from test_observer.common.permissions import requires_authentication
+from test_observer.common.permissions import (
+    authentication_checker,
+    authentication_checker_browser_friendly,
+    requires_authentication,
+)
 from test_observer.main import app
 from tests.conftest import authenticate_user
 from tests.data_generator import DataGenerator
@@ -70,7 +74,7 @@ def test_openapi_authenticated_user_auth_not_required(
         app.dependency_overrides[requires_authentication] = lambda: False
         user = generator.gen_user()
         authenticate_user(test_client, user, generator, create_session_cookie)
-        response = test_client.get("/openapi.json")
+        response = test_client.get("/openapi.json", headers={"X-CSRF-Token": "1"})
         assert response.status_code == 200
         assert "openapi" in response.json()
     finally:
@@ -198,3 +202,24 @@ def test_docs_authenticated_user_auth_required(
         assert "text/html" in response.headers["content-type"]
     finally:
         app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_only_docs_browser_friendly(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    """
+    Test that only the docs endpoint is browser-friendly and allows GET requests without a CSRF token
+    when authentication is required and a user is authenticated.
+    """
+    try:
+        user = generator.gen_user()
+        authenticate_user(test_client, user, generator, create_session_cookie)
+
+        # We override the authentication checker so that /openapi.json uses the browser-friendly version
+        app.dependency_overrides[authentication_checker] = authentication_checker_browser_friendly
+
+        # But the browser-friendly version should enforce that only /docs is allowed
+        response = test_client.get("/openapi.json", headers={"X-CSRF-Token": "1"})
+        assert response.status_code == 401
+    finally:
+        app.dependency_overrides.pop(authentication_checker, None)

--- a/backend/tests/controllers/docs/test_docs.py
+++ b/backend/tests/controllers/docs/test_docs.py
@@ -208,10 +208,11 @@ def test_only_docs_browser_friendly(
     test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
 ):
     """
-    Test that only the docs endpoint is browser-friendly and allows GET requests without a CSRF token
-    when authentication is required and a user is authenticated.
+    Test that only the docs endpoint is browser-friendly and allows GET requests without a CSRF token.
+    This only applies when authentication is required
     """
     try:
+        app.dependency_overrides[requires_authentication] = lambda: True
         user = generator.gen_user()
         authenticate_user(test_client, user, generator, create_session_cookie)
 
@@ -223,3 +224,4 @@ def test_only_docs_browser_friendly(
         assert response.status_code == 401
     finally:
         app.dependency_overrides.pop(authentication_checker, None)
+        app.dependency_overrides.pop(requires_authentication, None)

--- a/backend/tests/controllers/docs/test_docs.py
+++ b/backend/tests/controllers/docs/test_docs.py
@@ -1,0 +1,200 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from collections.abc import Callable
+
+from fastapi.testclient import TestClient
+
+from test_observer.common.permissions import requires_authentication
+from test_observer.main import app
+from tests.conftest import authenticate_user
+from tests.data_generator import DataGenerator
+
+
+def test_openapi_unauthenticated_auth_not_required(test_client: TestClient):
+    """Test that unauthenticated access to OpenAPI endpoint works when authentication is not required"""
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        response = test_client.get("/openapi.json")
+        assert response.status_code == 200
+        assert "openapi" in response.json()
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_openapi_unauthenticated_auth_required(test_client: TestClient):
+    """Test that unauthenticated access to OpenAPI endpoint returns 401 when authentication is required"""
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        response = test_client.get("/openapi.json")
+        assert response.status_code == 401
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_openapi_authenticated_app_auth_not_required(test_client: TestClient, generator: DataGenerator):
+    """
+    Test that authenticated access to the OpenAPI endpoint works and returns schema
+    when authentication is not required and an application is authenticated
+    """
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        application = generator.gen_application(permissions=[])
+        response = test_client.get("/openapi.json", headers={"Authorization": f"Bearer {application.api_key}"})
+        assert response.status_code == 200
+        assert "openapi" in response.json()
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_openapi_authenticated_user_auth_not_required(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    """
+    Test that authenticated access to the OpenAPI endpoint works and returns schema
+    when authentication is not required and a user is authenticated
+    """
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        user = generator.gen_user()
+        authenticate_user(test_client, user, generator, create_session_cookie)
+        response = test_client.get("/openapi.json")
+        assert response.status_code == 200
+        assert "openapi" in response.json()
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_openapi_authenticated_app_auth_required(test_client: TestClient, generator: DataGenerator):
+    """
+    Test that authenticated access to the OpenAPI endpoint works and returns schema
+    when authentication is required and an application is authenticated
+    """
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        application = generator.gen_application(permissions=[])
+        response = test_client.get("/openapi.json", headers={"Authorization": f"Bearer {application.api_key}"})
+        assert response.status_code == 200
+        assert "openapi" in response.json()
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_openapi_authenticated_user_auth_required(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    """
+    Test that authenticated access to the OpenAPI endpoint works and returns schema
+    when authentication is required and a user is authenticated
+    """
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        user = generator.gen_user()
+        authenticate_user(test_client, user, generator, create_session_cookie)
+        response = test_client.get("/openapi.json", headers={"X-CSRF-Token": "1"})
+        assert response.status_code == 200
+        assert "openapi" in response.json()
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_docs_unauthenticated_auth_not_required(test_client: TestClient):
+    """Test that unauthenticated access to docs endpoint works when authentication is not required"""
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        response = test_client.get("/docs")
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_docs_unauthenticated_auth_required(test_client: TestClient):
+    """Test that unauthenticated access to docs endpoint returns 401 when authentication is required"""
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        response = test_client.get("/docs")
+        assert response.status_code == 401
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_docs_authenticated_app_auth_not_required(test_client: TestClient, generator: DataGenerator):
+    """
+    Test that authenticated access to the docs endpoint works and returns HTML
+    when authentication is not required and an application is authenticated
+    """
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        application = generator.gen_application(permissions=[])
+        response = test_client.get("/docs", headers={"Authorization": f"Bearer {application.api_key}"})
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_docs_authenticated_user_auth_not_required(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    """
+    Test that authenticated access to the docs endpoint works and returns HTML
+    when authentication is not required and a user is authenticated
+    """
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        user = generator.gen_user()
+        authenticate_user(test_client, user, generator, create_session_cookie)
+        response = test_client.get("/docs")
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_docs_authenticated_app_auth_required(test_client: TestClient, generator: DataGenerator):
+    """
+    Test that authenticated access to the docs endpoint works and returns HTML
+    when authentication is required and an application is authenticated
+    """
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        application = generator.gen_application(permissions=[])
+        response = test_client.get("/docs", headers={"Authorization": f"Bearer {application.api_key}"})
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_docs_authenticated_user_auth_required(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    """
+    Test that authenticated access to the docs endpoint works and returns HTML
+    when authentication is required and a user is authenticated
+    """
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        user = generator.gen_user()
+        authenticate_user(test_client, user, generator, create_session_cookie)
+        # A browser request to the docs endpoint should work with a valid session cookie even without a CSRF token,
+        # due to the browser-friendly dependencies used by the endpoint.
+        # The point of this test is to check that we don't need the CSRF token
+        response = test_client.get("/docs")
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR is split from https://github.com/canonical/test_observer/pull/674

This PR adds the `/openapi.json` and `/docs` endpoints behind the authentication checking mechanism.
If authentication is required, the `/openapi.json` endpoint will not be directly viewable in the browser,
but the `/docs` endpoint will be. This requires the `/docs` endpoint to use a new authentication checker
that ignores the requirement of the `X-CSRF-Token` header required by most other endpoints.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

IQA-3563

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

The `/openapi.json` and `/docs` endpoints can optionally require authentication to view.

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Unit tests are added. Manual testing confirms the desired behavior. When authentication is not required, both endpoints just work. When authentication is required, the `/docs` endpoint does not work in the browser until a user has signed in via the frontend.