### PR TITLE
[IQA-3564] Optionally require auth for /me endpoints

### DIFF
--- a/backend/test_observer/controllers/applications/applications.py
+++ b/backend/test_observer/controllers/applications/applications.py
@@ -18,7 +18,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from test_observer.common.enums import Permission
-from test_observer.common.permissions import permission_checker
+from test_observer.common.permissions import permission_checker, requires_authentication
 from test_observer.controllers.applications.application_injection import (
     get_current_application,
 )
@@ -62,7 +62,10 @@ def get_applications(
 @router.get("/me", response_model=ApplicationResponse | None)
 def get_authenticated_application(
     app: Application | None = Depends(get_current_application),
+    authentication_required: bool = Depends(requires_authentication),
 ):
+    if authentication_required and app is None:
+        raise HTTPException(status_code=401, detail="Not authenticated")
     return app
 
 

--- a/backend/test_observer/controllers/users/users.py
+++ b/backend/test_observer/controllers/users/users.py
@@ -20,7 +20,7 @@ from sqlalchemy import ColumnElement, and_, func, or_, select
 from sqlalchemy.orm import Session
 
 from test_observer.common.enums import Permission
-from test_observer.common.permissions import permission_checker
+from test_observer.common.permissions import permission_checker, requires_authentication
 from test_observer.controllers.users.models import (
     UserPatch,
     UserResponse,
@@ -34,7 +34,12 @@ router = APIRouter(tags=["users"])
 
 
 @router.get("/me", response_model=UserResponse | None)
-def get_authenticated_user(user: User | None = Depends(get_current_user)):
+def get_authenticated_user(
+    user: User | None = Depends(get_current_user),
+    authentication_required: bool = Depends(requires_authentication),
+):
+    if authentication_required and user is None:
+        raise HTTPException(status_code=401, detail="Not authenticated")
     return user
 
 

--- a/backend/tests/controllers/applications/test_applications.py
+++ b/backend/tests/controllers/applications/test_applications.py
@@ -109,8 +109,7 @@ def test_get_me_unauthenticated_auth_required(test_client: TestClient):
 
 def test_get_me_authenticated_app_auth_not_required(test_client: TestClient, generator: DataGenerator):
     """
-    Test that an authenticated application still gets nothing from /me since it is user-specific,
-    even if authentication is not required
+    Test that an authenticated application gets its application data from /me when authentication is not required
     """
     try:
         app.dependency_overrides[requires_authentication] = lambda: False
@@ -132,7 +131,7 @@ def test_get_me_authenticated_user_auth_not_required(
     test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
 ):
     """
-    Test that an authenticated user gets their user data from /me when authentication is not required
+    Test that an authenticated user gets nothing from /me when authentication is not required
     """
     try:
         app.dependency_overrides[requires_authentication] = lambda: False
@@ -148,7 +147,7 @@ def test_get_me_authenticated_user_auth_not_required(
 
 def test_get_me_authenticated_app_auth_required(test_client: TestClient, generator: DataGenerator):
     """
-    Test that an authenticated application gets their application data from /me when authentication is required
+    Test that an authenticated application gets its application data from /me when authentication is required
     """
     try:
         app.dependency_overrides[requires_authentication] = lambda: True

--- a/backend/tests/controllers/applications/test_applications.py
+++ b/backend/tests/controllers/applications/test_applications.py
@@ -13,12 +13,16 @@
 # SPDX-FileCopyrightText: Copyright 2025 Canonical Ltd.
 # SPDX-License-Identifier: AGPL-3.0-only
 
+from collections.abc import Callable
+
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from test_observer.common.enums import Permission
+from test_observer.common.permissions import requires_authentication
 from test_observer.data_access.models import Application
-from tests.conftest import make_authenticated_request
+from test_observer.main import app
+from tests.conftest import authenticate_user, make_authenticated_request
 from tests.data_generator import DataGenerator
 
 
@@ -44,11 +48,11 @@ def test_create_application(test_client: TestClient, db_session: Session):
     assert data["api_key"][0:3] == "to_"
 
     app_id = data["id"]
-    app = db_session.get(Application, app_id)
-    assert app is not None
-    assert app.name == "myscript"
-    assert app.permissions == [Permission.view_user]
-    assert app.api_key == data["api_key"]
+    application = db_session.get(Application, app_id)
+    assert application is not None
+    assert application.name == "myscript"
+    assert application.permissions == [Permission.view_user]
+    assert application.api_key == data["api_key"]
 
 
 def test_get_applications(test_client: TestClient, generator: DataGenerator):
@@ -84,21 +88,99 @@ def test_get_application(test_client: TestClient, generator: DataGenerator):
     }
 
 
-def test_get_current_application(test_client: TestClient, generator: DataGenerator):
-    application = generator.gen_application()
+def test_get_me_unauthenticated_auth_not_required(test_client: TestClient):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        response = test_client.get("/v1/applications/me")
+        assert response.status_code == 200
+        assert response.json() is None
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
 
-    response = test_client.get(
-        "/v1/applications/me",
-        headers={"Authorization": f"Bearer {application.api_key}"},
-    )
 
-    assert response.status_code == 200
-    assert response.json() == {
-        "id": application.id,
-        "name": application.name,
-        "permissions": application.permissions,
-        "api_key": application.api_key,
-    }
+def test_get_me_unauthenticated_auth_required(test_client: TestClient):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        response = test_client.get("/v1/applications/me")
+        assert response.status_code == 401
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_me_authenticated_app_auth_not_required(test_client: TestClient, generator: DataGenerator):
+    """
+    Test that an authenticated application still gets nothing from /me since it is user-specific,
+    even if authentication is not required
+    """
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        application = generator.gen_application(permissions=["view_user"])
+        response = test_client.get("/v1/applications/me", headers={"Authorization": f"Bearer {application.api_key}"})
+        assert response.status_code == 200
+
+        json_ = response.json()
+        assert json_ is not None
+        assert json_.get("id") == application.id
+        assert json_.get("name") == application.name
+        assert json_.get("permissions") == application.permissions
+        assert json_.get("api_key") == application.api_key
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_me_authenticated_user_auth_not_required(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    """
+    Test that an authenticated user gets their user data from /me when authentication is not required
+    """
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        user = generator.gen_user()
+        authenticate_user(test_client, user, generator, create_session_cookie)
+        response = test_client.get("/v1/applications/me", headers={"X-CSRF-Token": "1"})
+
+        assert response.status_code == 200
+        assert response.json() is None
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_me_authenticated_app_auth_required(test_client: TestClient, generator: DataGenerator):
+    """
+    Test that an authenticated application gets their application data from /me when authentication is required
+    """
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        application = generator.gen_application(permissions=["view_user"])
+        response = test_client.get("/v1/applications/me", headers={"Authorization": f"Bearer {application.api_key}"})
+        assert response.status_code == 200
+
+        json_ = response.json()
+        assert json_ is not None
+        assert json_.get("id") == application.id
+        assert json_.get("name") == application.name
+        assert json_.get("permissions") == application.permissions
+        assert json_.get("api_key") == application.api_key
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_me_authenticated_user_auth_required(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    """
+    Test that an authenticated user gets 401 from /me when authentication is required
+    """
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        user = generator.gen_user()
+        authenticate_user(test_client, user, generator, create_session_cookie)
+        response = test_client.get("/v1/applications/me", headers={"X-CSRF-Token": "1"})
+
+        assert response.status_code == 401
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
 
 
 def test_update_application_permissions(test_client: TestClient, generator: DataGenerator):

--- a/backend/tests/controllers/users/test_users.py
+++ b/backend/tests/controllers/users/test_users.py
@@ -20,8 +20,10 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from test_observer.common.enums import Permission
+from test_observer.common.permissions import requires_authentication
 from test_observer.data_access.models_enums import FamilyName
-from tests.conftest import make_authenticated_request
+from test_observer.main import app
+from tests.conftest import authenticate_user, make_authenticated_request
 from tests.data_generator import DataGenerator
 
 
@@ -43,63 +45,181 @@ def test_get_me_without_csrf_token_returns_none(
     assert response.json() is None
 
 
-def test_get_me_without_session_returns_none(test_client: TestClient):
-    response = test_client.get("/v1/users/me", headers={"X-CSRF-Token": "1"})
+def test_get_me_unauthenticated_auth_not_required(test_client: TestClient):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        response = test_client.get("/v1/users/me")
+        assert response.status_code == 200
+        assert response.json() is None
 
-    assert response.status_code == 200
-    assert response.json() is None
+        response = test_client.get("/v1/users/me", headers={"X-CSRF-Token": "1"})
+        assert response.status_code == 200
+        assert response.json() is None
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
 
 
-def test_get_me_with_expired_session_returns_none(
+def test_get_me_unauthenticated_auth_required(test_client: TestClient):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        response = test_client.get("/v1/users/me")
+        assert response.status_code == 401
+
+        # It takes more than just a token header to be authenticated.
+        # A session cookie is required as well
+        response = test_client.get("/v1/users/me", headers={"X-CSRF-Token": "1"})
+        assert response.status_code == 401
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_me_authenticated_app_auth_not_required(test_client: TestClient, generator: DataGenerator):
+    """
+    Test that an authenticated application still gets nothing from /me since it is user-specific,
+    even if authentication is not required
+    """
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        application = generator.gen_application(permissions=["view_user"])
+        response = test_client.get("/v1/users/me", headers={"Authorization": f"Bearer {application.api_key}"})
+        assert response.status_code == 200
+        assert response.json() is None
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_me_authenticated_user_auth_not_required(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    """
+    Test that an authenticated user gets their user data from /me when authentication is not required
+    """
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        user = generator.gen_user()
+        authenticate_user(test_client, user, generator, create_session_cookie)
+        response = test_client.get("/v1/users/me", headers={"X-CSRF-Token": "1"})
+
+        assert response.status_code == 200
+        user_data = response.json()
+        assert user_data is not None
+        assert user_data["id"] == user.id
+        assert user_data["name"] == user.name
+        assert user_data["email"] == user.email
+        assert user_data["launchpad_handle"] == user.launchpad_handle
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_me_authenticated_app_auth_required(test_client: TestClient, generator: DataGenerator):
+    """
+    Test that an authenticated application gets a 401 from /me when auth is required,
+    since it is user-specific
+    """
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        application = generator.gen_application(permissions=["view_user"])
+        response = test_client.get("/v1/users/me", headers={"Authorization": f"Bearer {application.api_key}"})
+        assert response.status_code == 401
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_me_authenticated_user_auth_required(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    """
+    Test that an authenticated user gets their user data from /me when authentication is required
+    """
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        user = generator.gen_user()
+        authenticate_user(test_client, user, generator, create_session_cookie)
+        response = test_client.get("/v1/users/me", headers={"X-CSRF-Token": "1"})
+
+        assert response.status_code == 200
+        user_data = response.json()
+        assert user_data is not None
+        assert user_data["id"] == user.id
+        assert user_data["name"] == user.name
+        assert user_data["email"] == user.email
+        assert user_data["launchpad_handle"] == user.launchpad_handle
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_me_with_expired_session_returns_none_auth_not_required(
     test_client: TestClient,
     generator: DataGenerator,
     create_session_cookie: Callable[[int], str],
 ):
-    user = generator.gen_user()
-    session = generator.gen_user_session(user, expires_at=datetime.now() - timedelta(days=1))
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        user = generator.gen_user()
+        session = generator.gen_user_session(user, expires_at=datetime.now() - timedelta(days=1))
 
-    session_cookie = create_session_cookie(session.id)
-    test_client.cookies.set("session", session_cookie)
+        session_cookie = create_session_cookie(session.id)
+        test_client.cookies.set("session", session_cookie)
 
-    response = test_client.get("/v1/users/me", headers={"X-CSRF-Token": "1"})
+        response = test_client.get("/v1/users/me", headers={"X-CSRF-Token": "1"})
 
-    assert response.status_code == 200
-    assert response.json() is None
-
-
-def test_get_me_with_nonexistent_session_returns_none(
-    test_client: TestClient,
-    create_session_cookie: Callable[[int], str],
-):
-    session_cookie = create_session_cookie(999999)  # Non-existent session ID
-    test_client.cookies.set("session", session_cookie)
-
-    response = test_client.get("/v1/users/me", headers={"X-CSRF-Token": "1"})
-
-    assert response.status_code == 200
-    assert response.json() is None
+        assert response.status_code == 200
+        assert response.json() is None
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
 
 
-def test_get_me_with_valid_session_returns_user_data(
+def test_get_me_with_expired_session_errors_auth_required(
     test_client: TestClient,
     generator: DataGenerator,
     create_session_cookie: Callable[[int], str],
 ):
-    user = generator.gen_user()
-    session = generator.gen_user_session(user)
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        user = generator.gen_user()
+        session = generator.gen_user_session(user, expires_at=datetime.now() - timedelta(days=1))
 
-    session_cookie = create_session_cookie(session.id)
-    test_client.cookies.set("session", session_cookie)
+        session_cookie = create_session_cookie(session.id)
+        test_client.cookies.set("session", session_cookie)
 
-    response = test_client.get("/v1/users/me", headers={"X-CSRF-Token": "1"})
+        response = test_client.get("/v1/users/me", headers={"X-CSRF-Token": "1"})
 
-    assert response.status_code == 200
-    user_data = response.json()
-    assert user_data is not None
-    assert user_data["id"] == user.id
-    assert user_data["name"] == user.name
-    assert user_data["email"] == user.email
-    assert user_data["launchpad_handle"] == user.launchpad_handle
+        assert response.status_code == 401
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_me_with_nonexistent_session_returns_none_auth_not_required(
+    test_client: TestClient,
+    create_session_cookie: Callable[[int], str],
+):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        session_cookie = create_session_cookie(999999)  # Non-existent session ID
+        test_client.cookies.set("session", session_cookie)
+
+        response = test_client.get("/v1/users/me", headers={"X-CSRF-Token": "1"})
+
+        assert response.status_code == 200
+        assert response.json() is None
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_me_with_nonexistent_session_returns_none_auth_required(
+    test_client: TestClient,
+    create_session_cookie: Callable[[int], str],
+):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        session_cookie = create_session_cookie(999999)  # Non-existent session ID
+        test_client.cookies.set("session", session_cookie)
+
+        response = test_client.get("/v1/users/me", headers={"X-CSRF-Token": "1"})
+
+        assert response.status_code == 401
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
 
 
 def test_get_users_response_format(test_client: TestClient, generator: DataGenerator):

--- a/backend/tests/controllers/users/test_users.py
+++ b/backend/tests/controllers/users/test_users.py
@@ -27,24 +27,6 @@ from tests.conftest import authenticate_user, make_authenticated_request
 from tests.data_generator import DataGenerator
 
 
-def test_get_me_without_csrf_token_returns_none(
-    test_client: TestClient,
-    generator: DataGenerator,
-    create_session_cookie: Callable[[int], str],
-):
-    """Test that accessing /me without X-CSRF-Token header returns None"""
-    user = generator.gen_user()
-    session = generator.gen_user_session(user)
-
-    session_cookie = create_session_cookie(session.id)
-    test_client.cookies.set("session", session_cookie)
-
-    response = test_client.get("/v1/users/me")
-
-    assert response.status_code == 200
-    assert response.json() is None
-
-
 def test_get_me_unauthenticated_auth_not_required(test_client: TestClient):
     try:
         app.dependency_overrides[requires_authentication] = lambda: False


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR is split from https://github.com/canonical/test_observer/pull/674
This PR adds the `/v1/users/me` and `/v1/applications/me` endpoints behind the authentication checking mechanism.

If authentication is not required, these will just return `null` when accessed without authentication and will return the proper data when accessed with authentication.

If authentication is required, they will error when accessed without authentication and will return the proper data when accessed with authentication. Additionally, an authenticated app will error if trying to access `/v1/users/me`, and an authenticated user will error if trying to access `/v1/applications/me`.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

IQA-3564

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

`/v1/users/me` and `/v1/applications/me` can optionally require authentication, which in principle will allow users and applications to view themselves even without the `view_user` or `view_application` permission. This works for applications, but because the frontend doesn't expose the `/v1/users/me` endpoint, in practice this means authenticated users can't easily view their own info. We might want to consider adding something to the frontend that exposes a user's own data to themselves, similar to how we do it in Weebl.

## Tests

Unit tests have been added, and manual testing suggests things work as well.

It's worth noting that there's not really a good way to manually test `/v1/users/me` in the authenticated scenario, because directly accessing that endpoint in a browser doesn't send the CSRF token. 