### PR TITLE
[IQA-3571] Update notification handling

### DIFF
--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -4490,25 +4490,215 @@
         ]
       }
     },
-    "/v1/users/{id}/notifications/count": {
+    "/v1/users/me/notifications/count": {
+      "get": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Get Own Notifications",
+        "description": "Get all notifications for the authenticated user",
+        "operationId": "get_own_notifications_v1_users_me_notifications_count_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "description": "Maximum number of results to return (default: 50)",
+              "default": 50,
+              "title": "Limit"
+            },
+            "description": "Maximum number of results to return (default: 50)"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Number of results to skip for pagination (default: 0)",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Number of results to skip for pagination (default: 0)"
+          },
+          {
+            "name": "unread_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Whether to return only unread notifications (default: false)",
+              "default": false,
+              "title": "Unread Only"
+            },
+            "description": "Whether to return only unread notifications (default: false)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "title": "Response Get Own Notifications V1 Users Me Notifications Count Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/users/me/notifications": {
+      "get": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Get Own Notifications",
+        "description": "Get all notifications for the authenticated user",
+        "operationId": "get_own_notifications_v1_users_me_notifications_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "description": "Maximum number of results to return (default: 50)",
+              "default": 50,
+              "title": "Limit"
+            },
+            "description": "Maximum number of results to return (default: 50)"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Number of results to skip for pagination (default: 0)",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Number of results to skip for pagination (default: 0)"
+          },
+          {
+            "name": "unread_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Whether to return only unread notifications (default: false)",
+              "default": false,
+              "title": "Unread Only"
+            },
+            "description": "Whether to return only unread notifications (default: false)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/users/me/notifications/{notification_id}/dismiss": {
+      "post": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Mark Own Notification As Read",
+        "description": "Mark the authenticated user's own notification as read",
+        "operationId": "mark_own_notification_as_read_v1_users_me_notifications__notification_id__dismiss_post",
+        "parameters": [
+          {
+            "name": "notification_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Notification Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/users/{user_id}/notifications/count": {
       "get": {
         "tags": [
           "notifications"
         ],
         "summary": "Get Notifications",
         "description": "Get all notifications for the specified user",
-        "operationId": "get_notifications_v1_users__id__notifications_count_get",
+        "operationId": "get_notifications_v1_users__user_id__notifications_count_get",
         "parameters": [
           {
-            "name": "id",
+            "name": "user_id",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "description": "User ID or 'me' for current user",
-              "title": "Id"
+              "type": "integer",
+              "description": "ID of the user whose notifications will be fetched",
+              "title": "User Id"
             },
-            "description": "User ID or 'me' for current user"
+            "description": "ID of the user whose notifications will be fetched"
           },
           {
             "name": "limit",
@@ -4557,7 +4747,7 @@
               "application/json": {
                 "schema": {
                   "type": "integer",
-                  "title": "Response Get Notifications V1 Users  Id  Notifications Count Get"
+                  "title": "Response Get Notifications V1 Users  User Id  Notifications Count Get"
                 }
               }
             }
@@ -4578,25 +4768,25 @@
         ]
       }
     },
-    "/v1/users/{id}/notifications": {
+    "/v1/users/{user_id}/notifications": {
       "get": {
         "tags": [
           "notifications"
         ],
         "summary": "Get Notifications",
         "description": "Get all notifications for the specified user",
-        "operationId": "get_notifications_v1_users__id__notifications_get",
+        "operationId": "get_notifications_v1_users__user_id__notifications_get",
         "parameters": [
           {
-            "name": "id",
+            "name": "user_id",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "description": "User ID or 'me' for current user",
-              "title": "Id"
+              "type": "integer",
+              "description": "ID of the user whose notifications will be fetched",
+              "title": "User Id"
             },
-            "description": "User ID or 'me' for current user"
+            "description": "ID of the user whose notifications will be fetched"
           },
           {
             "name": "limit",
@@ -4665,25 +4855,25 @@
         ]
       }
     },
-    "/v1/users/{id}/notifications/{notification_id}/dismiss": {
+    "/v1/users/{user_id}/notifications/{notification_id}/dismiss": {
       "post": {
         "tags": [
           "notifications"
         ],
         "summary": "Mark Notification As Read",
         "description": "Mark a notification as read",
-        "operationId": "mark_notification_as_read_v1_users__id__notifications__notification_id__dismiss_post",
+        "operationId": "mark_notification_as_read_v1_users__user_id__notifications__notification_id__dismiss_post",
         "parameters": [
           {
-            "name": "id",
+            "name": "user_id",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "description": "User ID or 'me' for current user",
-              "title": "Id"
+              "type": "integer",
+              "description": "ID of the user whose notification will be dismissed",
+              "title": "User Id"
             },
-            "description": "User ID or 'me' for current user"
+            "description": "ID of the user whose notification will be dismissed"
           },
           {
             "name": "notification_id",

--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -4490,80 +4490,6 @@
         ]
       }
     },
-    "/v1/users/me/notifications/count": {
-      "get": {
-        "tags": [
-          "notifications"
-        ],
-        "summary": "Get Own Notifications",
-        "description": "Get all notifications for the authenticated user",
-        "operationId": "get_own_notifications_v1_users_me_notifications_count_get",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "description": "Maximum number of results to return (default: 50)",
-              "default": 50,
-              "title": "Limit"
-            },
-            "description": "Maximum number of results to return (default: 50)"
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "description": "Number of results to skip for pagination (default: 0)",
-              "default": 0,
-              "title": "Offset"
-            },
-            "description": "Number of results to skip for pagination (default: 0)"
-          },
-          {
-            "name": "unread_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "Whether to return only unread notifications (default: false)",
-              "default": false,
-              "title": "Unread Only"
-            },
-            "description": "Whether to return only unread notifications (default: false)"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "integer",
-                  "title": "Response Get Own Notifications V1 Users Me Notifications Count Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/v1/users/me/notifications": {
       "get": {
         "tags": [
@@ -4637,6 +4563,53 @@
         }
       }
     },
+    "/v1/users/me/notifications/count": {
+      "get": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Get Own Notification Count",
+        "description": "Get the count of notifications for the authenticated user",
+        "operationId": "get_own_notification_count_v1_users_me_notifications_count_get",
+        "parameters": [
+          {
+            "name": "unread_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Whether to return only unread notifications (default: false)",
+              "default": false,
+              "title": "Unread Only"
+            },
+            "description": "Whether to return only unread notifications (default: false)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "title": "Response Get Own Notification Count V1 Users Me Notifications Count Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/users/me/notifications/{notification_id}/dismiss": {
       "post": {
         "tags": [
@@ -4678,94 +4651,6 @@
             }
           }
         }
-      }
-    },
-    "/v1/users/{user_id}/notifications/count": {
-      "get": {
-        "tags": [
-          "notifications"
-        ],
-        "summary": "Get Notifications",
-        "description": "Get all notifications for the specified user",
-        "operationId": "get_notifications_v1_users__user_id__notifications_count_get",
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "description": "ID of the user whose notifications will be fetched",
-              "title": "User Id"
-            },
-            "description": "ID of the user whose notifications will be fetched"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "description": "Maximum number of results to return (default: 50)",
-              "default": 50,
-              "title": "Limit"
-            },
-            "description": "Maximum number of results to return (default: 50)"
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "description": "Number of results to skip for pagination (default: 0)",
-              "default": 0,
-              "title": "Offset"
-            },
-            "description": "Number of results to skip for pagination (default: 0)"
-          },
-          {
-            "name": "unread_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "Whether to return only unread notifications (default: false)",
-              "default": false,
-              "title": "Unread Only"
-            },
-            "description": "Whether to return only unread notifications (default: false)"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "integer",
-                  "title": "Response Get Notifications V1 Users  User Id  Notifications Count Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "x-permissions": [
-          "view_notification"
-        ]
       }
     },
     "/v1/users/{user_id}/notifications": {
@@ -4835,6 +4720,67 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/NotificationsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-permissions": [
+          "view_notification"
+        ]
+      }
+    },
+    "/v1/users/{user_id}/notifications/count": {
+      "get": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Get Notification Count",
+        "description": "Get the count of notifications for the specified user",
+        "operationId": "get_notification_count_v1_users__user_id__notifications_count_get",
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "ID of the user whose notification count will be fetched",
+              "title": "User Id"
+            },
+            "description": "ID of the user whose notification count will be fetched"
+          },
+          {
+            "name": "unread_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Whether to return only unread notifications (default: false)",
+              "default": false,
+              "title": "Unread Only"
+            },
+            "description": "Whether to return only unread notifications (default: false)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "title": "Response Get Notification Count V1 Users  User Id  Notifications Count Get"
                 }
               }
             }

--- a/backend/scripts/check_endpoint_permissions.sh
+++ b/backend/scripts/check_endpoint_permissions.sh
@@ -23,6 +23,8 @@ OPENAPI_JSON="$1"
 # /health/live and /health/ready should remain exceptions,
 # because they enforce their own checks that restrict access to internal-only.
 # They are used by Docker for health checks that would be cumbersome to authenticate.
+# The endpoints that include a /me are exceptions because they have their own
+# checks that just require authentication without specific permissions
 EXCEPTIONS='[
   {"method": "get", "path": "/v1/version"},
   {"method": "get", "path": "/"},
@@ -35,6 +37,9 @@ EXCEPTIONS='[
   {"method": "get", "path": "/v1/auth/saml/sls"},
   {"method": "post", "path": "/v1/auth/saml/sls"},
   {"method": "get", "path": "/v1/users/me"},
+  {"method": "get", "path": "/v1/users/me/notifications"},
+  {"method": "get", "path": "/v1/users/me/notifications/count"},
+  {"method": "post", "path": "/v1/users/me/notifications/{notification_id}/dismiss"},
   {"method": "get", "path": "/v1/applications/me"},
   {"method": "get", "path": "/health/live"},
   {"method": "get", "path": "/health/ready"}

--- a/backend/test_observer/controllers/notifications/notifications.py
+++ b/backend/test_observer/controllers/notifications/notifications.py
@@ -23,11 +23,12 @@ from sqlalchemy.orm import Session
 
 from test_observer.common.enums import Permission
 from test_observer.common.permissions import permission_checker, requires_authentication
+from test_observer.controllers.applications.application_injection import get_current_application
 from test_observer.controllers.notifications.models import (
     NotificationResponse,
     NotificationsResponse,
 )
-from test_observer.data_access.models import Notification, User
+from test_observer.data_access.models import Application, Notification, User
 from test_observer.data_access.setup import get_db
 from test_observer.users.user_injection import get_current_user
 
@@ -77,14 +78,18 @@ def get_own_notifications(
     ] = False,
     db: Session = Depends(get_db),
     user: User | None = Depends(get_current_user),
+    application: Application | None = Depends(get_current_application),
     authentication_required: bool = Depends(requires_authentication),
 ):
     """Get all notifications for the authenticated user"""
     # Even if an app is authenticated, it doesn't make sense for an app to access this endpoint,
     # since notifications are inherently user-specific. Thus, we require a user.
-    if authentication_required and user is None:
+    if authentication_required and user is None and application is None:
         raise HTTPException(status_code=401, detail="Not authenticated")
+    if authentication_required and user is None and application is not None:
+        raise HTTPException(status_code=403, detail="Forbidden")
 
+    # If authentication is not required, we might not have a user
     if user is None:
         if request.url.path.endswith("/count"):
             return 0
@@ -111,13 +116,17 @@ def mark_own_notification_as_read(
     notification_id: int,
     db: Session = Depends(get_db),
     user: User | None = Depends(get_current_user),
+    application: Application | None = Depends(get_current_application),
 ):
     """Mark the authenticated user's own notification as read"""
 
     # In this case, regardless of whether authentication is required,
     # this endpoint only makes sense if a user is authenticated
     if user is None:
-        raise HTTPException(status_code=401, detail="Not authenticated")
+        if application is None:
+            raise HTTPException(status_code=401, detail="Not authenticated")
+        else:
+            raise HTTPException(status_code=403, detail="Forbidden")
 
     notification = db.scalar(
         select(Notification).where(Notification.id == notification_id).where(Notification.user_id == user.id)

--- a/backend/test_observer/controllers/notifications/notifications.py
+++ b/backend/test_observer/controllers/notifications/notifications.py
@@ -39,6 +39,7 @@ def _get_user_notification_count(db: Session, user_id: int, unread_only: bool) -
     query = select(func.count(Notification.id)).where(Notification.user_id == user_id)
     if unread_only:
         query = query.where(Notification.dismissed_at.is_(None))
+    # The or 0 is just to satisfy the type checker
     return db.scalar(query) or 0
 
 

--- a/backend/test_observer/controllers/notifications/notifications.py
+++ b/backend/test_observer/controllers/notifications/notifications.py
@@ -17,7 +17,7 @@ from collections.abc import Sequence
 from datetime import datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, Security
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Security
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
@@ -52,9 +52,7 @@ def _get_user_notifications(
 
 
 @router.get("/me/notifications", response_model=NotificationsResponse)
-@router.get("/me/notifications/count", response_model=int)
 def get_own_notifications(
-    request: Request,
     limit: Annotated[
         int,
         Query(
@@ -91,14 +89,9 @@ def get_own_notifications(
 
     # If authentication is not required, we might not have a user
     if user is None:
-        if request.url.path.endswith("/count"):
-            return 0
         return NotificationsResponse(notifications=[], count=0, limit=limit, offset=offset)
 
     count = _get_user_notification_count(db, user.id, unread_only)
-    if request.url.path.endswith("/count"):
-        return count
-
     notifications = _get_user_notifications(db, user.id, limit, offset, unread_only)
     return NotificationsResponse(
         notifications=notifications,  # type: ignore[arg-type]
@@ -106,6 +99,34 @@ def get_own_notifications(
         limit=limit,
         offset=offset,
     )
+
+
+@router.get("/me/notifications/count", response_model=int)
+def get_own_notification_count(
+    unread_only: Annotated[
+        bool,
+        Query(
+            description="Whether to return only unread notifications (default: false)",
+        ),
+    ] = False,
+    db: Session = Depends(get_db),
+    user: User | None = Depends(get_current_user),
+    application: Application | None = Depends(get_current_application),
+    authentication_required: bool = Depends(requires_authentication),
+):
+    """Get the count of notifications for the authenticated user"""
+    # Even if an app is authenticated, it doesn't make sense for an app to access this endpoint,
+    # since notifications are inherently user-specific. Thus, we require a user.
+    if authentication_required and user is None and application is None:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    if authentication_required and user is None and application is not None:
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    # If authentication is not required, we might not have a user
+    if user is None:
+        return 0
+
+    return _get_user_notification_count(db, user.id, unread_only)
 
 
 @router.post(
@@ -147,13 +168,7 @@ def mark_own_notification_as_read(
     response_model=NotificationsResponse,
     dependencies=[Security(permission_checker, scopes=[Permission.view_notification])],
 )
-@router.get(
-    "/{user_id}/notifications/count",
-    response_model=int,
-    dependencies=[Security(permission_checker, scopes=[Permission.view_notification])],
-)
 def get_notifications(
-    request: Request,
     user_id: Annotated[int, Path(description="ID of the user whose notifications will be fetched")],
     limit: Annotated[
         int,
@@ -180,18 +195,42 @@ def get_notifications(
 ):
     """Get all notifications for the specified user"""
 
+    user = db.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
     count = _get_user_notification_count(db, user_id, unread_only)
-    if request.url.path.endswith("/count"):
-        return count
-
     notifications = _get_user_notifications(db, user_id, limit, offset, unread_only)
-
     return NotificationsResponse(
         notifications=list(notifications),  # type: ignore[arg-type]
         count=count,
         limit=limit,
         offset=offset,
     )
+
+
+@router.get(
+    "/{user_id}/notifications/count",
+    response_model=int,
+    dependencies=[Security(permission_checker, scopes=[Permission.view_notification])],
+)
+def get_notification_count(
+    user_id: Annotated[int, Path(description="ID of the user whose notification count will be fetched")],
+    unread_only: Annotated[
+        bool,
+        Query(
+            description="Whether to return only unread notifications (default: false)",
+        ),
+    ] = False,
+    db: Session = Depends(get_db),
+):
+    """Get the count of notifications for the specified user"""
+
+    user = db.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    return _get_user_notification_count(db, user_id, unread_only)
 
 
 @router.post(
@@ -205,6 +244,10 @@ def mark_notification_as_read(
     db: Session = Depends(get_db),
 ):
     """Mark a notification as read"""
+
+    user = db.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
 
     notification = db.scalar(
         select(Notification).where(Notification.id == notification_id).where(Notification.user_id == user_id)

--- a/backend/test_observer/controllers/notifications/notifications.py
+++ b/backend/test_observer/controllers/notifications/notifications.py
@@ -13,6 +13,7 @@
 # SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
 # SPDX-License-Identifier: AGPL-3.0-only
 
+from collections.abc import Sequence
 from datetime import datetime
 from typing import Annotated
 
@@ -21,7 +22,7 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from test_observer.common.enums import Permission
-from test_observer.common.permissions import permission_checker
+from test_observer.common.permissions import permission_checker, requires_authentication
 from test_observer.controllers.notifications.models import (
     NotificationResponse,
     NotificationsResponse,
@@ -33,45 +34,26 @@ from test_observer.users.user_injection import get_current_user
 router = APIRouter(tags=["notifications"])
 
 
-def _resolve_user_id(
-    user_id: str,
-    current_user: User | None,
-    db: Session,
-) -> User:
-    """
-    Resolve user_id parameter to a User object.
-    Supports 'me' as an alias for the current user.
-    """
-    if user_id == "me":
-        if not current_user:
-            raise HTTPException(status_code=401, detail="Not authenticated")
-        return current_user
-
-    try:
-        user_id_int = int(user_id)
-    except ValueError:
-        raise HTTPException(status_code=400, detail="Invalid user_id format") from None
-
-    user = db.get(User, user_id_int)
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")
-
-    return user
+def _get_user_notification_count(db: Session, user_id: int, unread_only: bool) -> int:
+    query = select(func.count(Notification.id)).where(Notification.user_id == user_id)
+    if unread_only:
+        query = query.where(Notification.dismissed_at.is_(None))
+    return db.scalar(query) or 0
 
 
-@router.get(
-    "/{id}/notifications",
-    response_model=NotificationsResponse,
-    dependencies=[Security(permission_checker, scopes=[Permission.view_notification])],
-)
-@router.get(
-    "/{id}/notifications/count",
-    response_model=int,
-    dependencies=[Security(permission_checker, scopes=[Permission.view_notification])],
-)
-def get_notifications(
+def _get_user_notifications(
+    db: Session, user_id: int, limit: int, offset: int, unread_only: bool
+) -> Sequence[Notification]:
+    query = select(Notification).where(Notification.user_id == user_id)
+    if unread_only:
+        query = query.where(Notification.dismissed_at.is_(None))
+    return db.scalars(query.order_by(Notification.created_at.desc()).limit(limit).offset(offset)).all()
+
+
+@router.get("/me/notifications", response_model=NotificationsResponse)
+@router.get("/me/notifications/count", response_model=int)
+def get_own_notifications(
     request: Request,
-    id: Annotated[str, Path(description="User ID or 'me' for current user")],
     limit: Annotated[
         int,
         Query(
@@ -93,51 +75,130 @@ def get_notifications(
             description="Whether to return only unread notifications (default: false)",
         ),
     ] = False,
-    user: User | None = Depends(get_current_user),
     db: Session = Depends(get_db),
+    user: User | None = Depends(get_current_user),
+    authentication_required: bool = Depends(requires_authentication),
 ):
-    """Get all notifications for the specified user"""
-    target_user = _resolve_user_id(id, user, db)
+    """Get all notifications for the authenticated user"""
+    # Even if an app is authenticated, it doesn't make sense for an app to access this endpoint,
+    # since notifications are inherently user-specific. Thus, we require a user.
+    if authentication_required and user is None:
+        raise HTTPException(status_code=401, detail="Not authenticated")
 
-    # Get total count
-    count_query = select(func.count(Notification.id)).where(Notification.user_id == target_user.id)
-    if unread_only:
-        count_query = count_query.where(Notification.dismissed_at.is_(None))
-    total_count = db.scalar(count_query) or 0
+    if user is None:
+        if request.url.path.endswith("/count"):
+            return 0
+        return NotificationsResponse(notifications=[], count=0, limit=limit, offset=offset)
 
+    count = _get_user_notification_count(db, user.id, unread_only)
     if request.url.path.endswith("/count"):
-        return total_count
+        return count
 
-    # Get paginated notifications
-    select_query = select(Notification).where(Notification.user_id == target_user.id)
-    if unread_only:
-        select_query = select_query.where(Notification.dismissed_at.is_(None))
-    notifications = db.scalars(select_query.order_by(Notification.created_at.desc()).limit(limit).offset(offset)).all()
-
+    notifications = _get_user_notifications(db, user.id, limit, offset, unread_only)
     return NotificationsResponse(
-        notifications=list(notifications),  # type: ignore[arg-type]
-        count=total_count,
+        notifications=notifications,  # type: ignore[arg-type]
+        count=count,
         limit=limit,
         offset=offset,
     )
 
 
 @router.post(
-    "/{id}/notifications/{notification_id}/dismiss",
+    "/me/notifications/{notification_id}/dismiss",
+    response_model=NotificationResponse,
+)
+def mark_own_notification_as_read(
+    notification_id: int,
+    db: Session = Depends(get_db),
+    user: User | None = Depends(get_current_user),
+):
+    """Mark the authenticated user's own notification as read"""
+
+    # In this case, regardless of whether authentication is required,
+    # this endpoint only makes sense if a user is authenticated
+    if user is None:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    notification = db.scalar(
+        select(Notification).where(Notification.id == notification_id).where(Notification.user_id == user.id)
+    )
+    if not notification:
+        raise HTTPException(status_code=404, detail="Notification not found")
+
+    if notification.dismissed_at is None:
+        notification.dismissed_at = datetime.now()
+        db.commit()
+        db.refresh(notification)
+
+    return notification
+
+
+@router.get(
+    "/{user_id}/notifications",
+    response_model=NotificationsResponse,
+    dependencies=[Security(permission_checker, scopes=[Permission.view_notification])],
+)
+@router.get(
+    "/{user_id}/notifications/count",
+    response_model=int,
+    dependencies=[Security(permission_checker, scopes=[Permission.view_notification])],
+)
+def get_notifications(
+    request: Request,
+    user_id: Annotated[int, Path(description="ID of the user whose notifications will be fetched")],
+    limit: Annotated[
+        int,
+        Query(
+            ge=1,
+            le=1000,
+            description="Maximum number of results to return (default: 50)",
+        ),
+    ] = 50,
+    offset: Annotated[
+        int,
+        Query(
+            ge=0,
+            description="Number of results to skip for pagination (default: 0)",
+        ),
+    ] = 0,
+    unread_only: Annotated[
+        bool,
+        Query(
+            description="Whether to return only unread notifications (default: false)",
+        ),
+    ] = False,
+    db: Session = Depends(get_db),
+):
+    """Get all notifications for the specified user"""
+
+    count = _get_user_notification_count(db, user_id, unread_only)
+    if request.url.path.endswith("/count"):
+        return count
+
+    notifications = _get_user_notifications(db, user_id, limit, offset, unread_only)
+
+    return NotificationsResponse(
+        notifications=list(notifications),  # type: ignore[arg-type]
+        count=count,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.post(
+    "/{user_id}/notifications/{notification_id}/dismiss",
     response_model=NotificationResponse,
     dependencies=[Security(permission_checker, scopes=[Permission.change_notification])],
 )
 def mark_notification_as_read(
-    id: Annotated[str, Path(description="User ID or 'me' for current user")],
+    user_id: Annotated[int, Path(description="ID of the user whose notification will be dismissed")],
     notification_id: int,
-    user: User | None = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     """Mark a notification as read"""
-    target_user = _resolve_user_id(id, user, db)
 
     notification = db.scalar(
-        select(Notification).where(Notification.id == notification_id).where(Notification.user_id == target_user.id)
+        select(Notification).where(Notification.id == notification_id).where(Notification.user_id == user_id)
     )
     if not notification:
         raise HTTPException(status_code=404, detail="Notification not found")

--- a/backend/tests/controllers/notifications/test_notifications.py
+++ b/backend/tests/controllers/notifications/test_notifications.py
@@ -166,7 +166,7 @@ def test_get_own_notifications_authenticated_app_auth_required(test_client: Test
         response = test_client.get(
             "/v1/users/me/notifications", headers={"Authorization": f"Bearer {application.api_key}"}
         )
-        assert response.status_code == 401
+        assert response.status_code == 403
     finally:
         app.dependency_overrides.pop(requires_authentication, None)
 
@@ -178,7 +178,7 @@ def test_get_own_notifications_count_authenticated_app_auth_required(test_client
         response = test_client.get(
             "/v1/users/me/notifications/count", headers={"Authorization": f"Bearer {application.api_key}"}
         )
-        assert response.status_code == 401
+        assert response.status_code == 403
     finally:
         app.dependency_overrides.pop(requires_authentication, None)
 
@@ -236,6 +236,48 @@ def test_get_notifications_app_with_permissions(test_client: TestClient, generat
     assert json_.get("count") == 1
     assert len(json_.get("notifications", [])) == 1
     assert json_["notifications"][0]["id"] == notification.id
+
+
+### Begin NOTE:
+# The /v1/users/me/notifications/{notification.id}/dismiss endpoint doesn't change behavior
+# based on whether authentication is required or not.
+# It always requires a user to be authenticated and doesn't allow an application,
+# because posting to a /me-based endpoint just doesn't make sense outside of an authenticated user context
+
+
+def test_dismiss_own_notification_unauthenticated(test_client: TestClient, generator: DataGenerator):
+    """Test that dismissing a notification without authentication returns 401"""
+    user = generator.gen_user(email="unauth@test.com")
+    notification = generator.gen_notification(user=user)
+
+    response = test_client.post(f"/v1/users/me/notifications/{notification.id}/dismiss")
+    assert response.status_code == 401
+
+
+def test_dismiss_own_notification_authenticated_user(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    """Test that an authenticated user can dismiss their own notification"""
+    user = generator.gen_user(email="user@test.com")
+    notification = generator.gen_notification(user=user)
+    authenticate_user(test_client, user, generator, create_session_cookie)
+    response = test_client.post(f"/v1/users/me/notifications/{notification.id}/dismiss", headers={"X-CSRF-Token": "1"})
+    assert response.status_code == 200
+    json_ = response.json()
+    assert json_["id"] == notification.id
+    assert json_["dismissed_at"] is not None
+
+
+def test_dismiss_own_notification_authenticated_app(test_client: TestClient, generator: DataGenerator):
+    """Test that an authenticated application is forbidden from /me-based notification endpoints"""
+    application = generator.gen_application(permissions=["change_notification"])
+    response = test_client.post(
+        "/v1/users/me/notifications/1/dismiss", headers={"Authorization": f"Bearer {application.api_key}"}
+    )
+    assert response.status_code == 403
+
+
+### End NOTE
 
 
 def test_get_multiple_notifications(

--- a/backend/tests/controllers/notifications/test_notifications.py
+++ b/backend/tests/controllers/notifications/test_notifications.py
@@ -19,19 +19,226 @@ from datetime import datetime
 from fastapi.testclient import TestClient
 
 from test_observer.common.enums import Permission
+from test_observer.common.permissions import requires_authentication
 from test_observer.data_access.models import Notification
 from test_observer.data_access.models_enums import NotificationType
+from test_observer.main import app
 from tests.conftest import authenticate_user, make_authenticated_request
 from tests.data_generator import DataGenerator
 
 
-def test_get_notifications_without_auth(test_client: TestClient):
-    """Test that accessing notifications without auth returns 403"""
-    response = test_client.get("/v1/users/me/notifications")
+def test_get_own_notifications_unauthenticated_auth_not_required(test_client: TestClient):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        response = test_client.get("/v1/users/me/notifications")
+        assert response.status_code == 200
+        assert response.json() == {"notifications": [], "count": 0, "limit": 50, "offset": 0}
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_own_notifications_count_unauthenticated_auth_not_required(test_client: TestClient):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        response = test_client.get("/v1/users/me/notifications/count")
+        assert response.status_code == 200
+        assert response.json() == 0
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_own_notifications_unauthenticated_auth_required(test_client: TestClient):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        response = test_client.get("/v1/users/me/notifications")
+        assert response.status_code == 401
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_own_notifications_count_unauthenticated_auth_required(test_client: TestClient):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        response = test_client.get("/v1/users/me/notifications/count")
+        assert response.status_code == 401
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_own_notifications_authenticated_user_auth_not_required(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        user = generator.gen_user(email="user@test.com")
+        notification = generator.gen_notification(user=user)
+        authenticate_user(test_client, user, generator, create_session_cookie)
+        response = test_client.get("/v1/users/me/notifications", headers={"X-CSRF-Token": "1"})
+        assert response.status_code == 200
+        json_ = response.json()
+        assert json_.get("count") == 1
+        assert len(json_.get("notifications", [])) == 1
+        assert json_["notifications"][0]["id"] == notification.id
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_own_notifications_count_authenticated_user_auth_not_required(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        user = generator.gen_user(email="user@test.com")
+        generator.gen_notification(user=user)
+        authenticate_user(test_client, user, generator, create_session_cookie)
+        response = test_client.get("/v1/users/me/notifications/count", headers={"X-CSRF-Token": "1"})
+        assert response.status_code == 200
+        assert response.json() == 1
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_own_notifications_authenticated_user_auth_required(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        user = generator.gen_user(email="user@test.com")
+        notification = generator.gen_notification(user=user)
+        authenticate_user(test_client, user, generator, create_session_cookie)
+        response = test_client.get("/v1/users/me/notifications", headers={"X-CSRF-Token": "1"})
+        assert response.status_code == 200
+        json_ = response.json()
+        assert json_.get("count") == 1
+        assert len(json_.get("notifications", [])) == 1
+        assert json_["notifications"][0]["id"] == notification.id
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_own_notifications_count_authenticated_user_auth_required(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        user = generator.gen_user(email="user@test.com")
+        generator.gen_notification(user=user)
+        authenticate_user(test_client, user, generator, create_session_cookie)
+        response = test_client.get("/v1/users/me/notifications/count", headers={"X-CSRF-Token": "1"})
+        assert response.status_code == 200
+        assert response.json() == 1
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_own_notifications_authenticated_app_auth_not_required(test_client: TestClient, generator: DataGenerator):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        application = generator.gen_application(permissions=[])
+        response = test_client.get(
+            "/v1/users/me/notifications", headers={"Authorization": f"Bearer {application.api_key}"}
+        )
+        assert response.status_code == 200
+        assert response.json() == {"notifications": [], "count": 0, "limit": 50, "offset": 0}
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_own_notifications_count_authenticated_app_auth_not_required(
+    test_client: TestClient, generator: DataGenerator
+):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        application = generator.gen_application(permissions=[])
+        response = test_client.get(
+            "/v1/users/me/notifications/count", headers={"Authorization": f"Bearer {application.api_key}"}
+        )
+        assert response.status_code == 200
+        assert response.json() == 0
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_own_notifications_authenticated_app_auth_required(test_client: TestClient, generator: DataGenerator):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        application = generator.gen_application(permissions=[])
+        response = test_client.get(
+            "/v1/users/me/notifications", headers={"Authorization": f"Bearer {application.api_key}"}
+        )
+        assert response.status_code == 401
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_own_notifications_count_authenticated_app_auth_required(test_client: TestClient, generator: DataGenerator):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        application = generator.gen_application(permissions=[])
+        response = test_client.get(
+            "/v1/users/me/notifications/count", headers={"Authorization": f"Bearer {application.api_key}"}
+        )
+        assert response.status_code == 401
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_get_notifications_user_no_permissions(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    """Test that a user without view_notification permission cannot get notifications"""
+    user = generator.gen_user(email="no-permissions@test.com")
+    authenticate_user(test_client, user, generator, create_session_cookie)
+    response = make_authenticated_request(
+        lambda: test_client.get(f"/v1/users/{user.id}/notifications", headers={"X-CSRF-Token": "1"}),
+    )
     assert response.status_code == 403
 
 
-def test_get_notifications(
+def test_get_notifications_app_no_permissions(test_client: TestClient, generator: DataGenerator):
+    """Test that an application without view_notification permission cannot get notifications"""
+    user = generator.gen_user(email="user@test.com")
+    application = generator.gen_application(permissions=[])
+    response = test_client.get(
+        f"/v1/users/{user.id}/notifications", headers={"Authorization": f"Bearer {application.api_key}"}
+    )
+    assert response.status_code == 403
+
+
+def test_get_notifications_user_with_permissions(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    """Test that a user with view_notification permission can get notifications"""
+    user = generator.gen_user(email="user@test.com")
+    notification = generator.gen_notification(user=user)
+    authenticate_user(test_client, user, generator, create_session_cookie)
+    response = make_authenticated_request(
+        lambda: test_client.get(f"/v1/users/{user.id}/notifications", headers={"X-CSRF-Token": "1"}),
+        Permission.view_notification,
+    )
+    assert response.status_code == 200
+    json_ = response.json()
+    assert json_.get("count") == 1
+    assert len(json_.get("notifications", [])) == 1
+    assert json_["notifications"][0]["id"] == notification.id
+
+
+def test_get_notifications_app_with_permissions(test_client: TestClient, generator: DataGenerator):
+    """Test that an application with view_notification permission can get notifications"""
+    user = generator.gen_user(email="user@test.com")
+    notification = generator.gen_notification(user=user)
+    application = generator.gen_application(permissions=[Permission.view_notification])
+    response = test_client.get(
+        f"/v1/users/{user.id}/notifications", headers={"Authorization": f"Bearer {application.api_key}"}
+    )
+    assert response.status_code == 200
+    json_ = response.json()
+    assert json_.get("count") == 1
+    assert len(json_.get("notifications", [])) == 1
+    assert json_["notifications"][0]["id"] == notification.id
+
+
+def test_get_multiple_notifications(
     test_client: TestClient,
     generator: DataGenerator,
     create_session_cookie: Callable[[int], str],
@@ -50,13 +257,9 @@ def test_get_notifications(
         dismissed_at=datetime.now(),
     )
 
-    # Another user's notification (should not appear)
-    other_user = generator.gen_user(email="other@test.com")
-    generator.gen_notification(user=other_user)
-
     authenticate_user(test_client, user, generator, create_session_cookie)
     response = make_authenticated_request(
-        lambda: test_client.get("/v1/users/me/notifications", headers={"X-CSRF-Token": "1"}),
+        lambda: test_client.get(f"/v1/users/{user.id}/notifications", headers={"X-CSRF-Token": "1"}),
         Permission.view_notification,
     )
 
@@ -70,12 +273,6 @@ def test_get_notifications(
     assert data["offset"] == 0
 
 
-def test_get_count_without_auth(test_client: TestClient):
-    """Test that accessing unread count without auth returns 403"""
-    response = test_client.get("/v1/users/me/notifications/count")
-    assert response.status_code == 403
-
-
 def test_get_unread_count(
     test_client: TestClient,
     generator: DataGenerator,
@@ -87,13 +284,11 @@ def test_get_unread_count(
     generator.gen_notification(user=user)
     generator.gen_notification(user=user, dismissed_at=datetime.now())
 
-    # Another user's notification (should not be counted)
-    other_user = generator.gen_user(email="other-unread@test.com")
-    generator.gen_notification(user=other_user)
-
     authenticate_user(test_client, user, generator, create_session_cookie)
     response = make_authenticated_request(
-        lambda: test_client.get("/v1/users/me/notifications/count?unread_only=true", headers={"X-CSRF-Token": "1"}),
+        lambda: test_client.get(
+            f"/v1/users/{user.id}/notifications/count?unread_only=true", headers={"X-CSRF-Token": "1"}
+        ),
         Permission.view_notification,
     )
 
@@ -106,7 +301,7 @@ def test_mark_notification_as_read_without_auth(test_client: TestClient, generat
     user = generator.gen_user(email="mark-no-auth@test.com")
     notification = generator.gen_notification(user=user)
 
-    response = test_client.post(f"/v1/users/me/notifications/{notification.id}/dismiss")
+    response = test_client.post(f"/v1/users/{user.id}/notifications/{notification.id}/dismiss")
     assert response.status_code == 403
 
 
@@ -124,7 +319,7 @@ def test_mark_notification_as_read(
     authenticate_user(test_client, user, generator, create_session_cookie)
     response = make_authenticated_request(
         lambda: test_client.post(
-            f"/v1/users/me/notifications/{notification.id}/dismiss", headers={"X-CSRF-Token": "1"}
+            f"/v1/users/{user.id}/notifications/{notification.id}/dismiss", headers={"X-CSRF-Token": "1"}
         ),
         Permission.change_notification,
     )
@@ -133,27 +328,6 @@ def test_mark_notification_as_read(
     data = response.json()
     assert data["id"] == notification.id
     assert data["dismissed_at"] is not None
-
-
-def test_mark_notification_as_read_wrong_user(
-    test_client: TestClient,
-    generator: DataGenerator,
-    create_session_cookie: Callable[[int], str],
-):
-    """Test that a user cannot mark another user's notification as read"""
-    user = generator.gen_user(email="wrong-user@test.com")
-    other_user = generator.gen_user(email="wrong-user-other@test.com")
-    notification = generator.gen_notification(user=user)
-
-    authenticate_user(test_client, other_user, generator, create_session_cookie)
-    response = make_authenticated_request(
-        lambda: test_client.post(
-            f"/v1/users/me/notifications/{notification.id}/dismiss", headers={"X-CSRF-Token": "1"}
-        ),
-        Permission.change_notification,
-    )
-
-    assert response.status_code == 404
 
 
 def test_mark_nonexistent_notification_as_read(
@@ -166,7 +340,7 @@ def test_mark_nonexistent_notification_as_read(
 
     authenticate_user(test_client, user, generator, create_session_cookie)
     response = make_authenticated_request(
-        lambda: test_client.post("/v1/users/me/notifications/99999/dismiss", headers={"X-CSRF-Token": "1"}),
+        lambda: test_client.post(f"/v1/users/{user.id}/notifications/99999/dismiss", headers={"X-CSRF-Token": "1"}),
         Permission.change_notification,
     )
 
@@ -196,7 +370,7 @@ def test_get_notifications_with_pagination(
 
     # Test limit
     response = make_authenticated_request(
-        lambda: test_client.get("/v1/users/me/notifications?limit=2", headers={"X-CSRF-Token": "1"}),
+        lambda: test_client.get(f"/v1/users/{user.id}/notifications?limit=2", headers={"X-CSRF-Token": "1"}),
         Permission.view_notification,
     )
     assert response.status_code == 200
@@ -208,7 +382,7 @@ def test_get_notifications_with_pagination(
 
     # Test offset
     response = make_authenticated_request(
-        lambda: test_client.get("/v1/users/me/notifications?limit=2&offset=2", headers={"X-CSRF-Token": "1"}),
+        lambda: test_client.get(f"/v1/users/{user.id}/notifications?limit=2&offset=2", headers={"X-CSRF-Token": "1"}),
         Permission.view_notification,
     )
     assert response.status_code == 200
@@ -220,7 +394,7 @@ def test_get_notifications_with_pagination(
 
     # Test offset beyond results
     response = make_authenticated_request(
-        lambda: test_client.get("/v1/users/me/notifications?limit=10&offset=3", headers={"X-CSRF-Token": "1"}),
+        lambda: test_client.get(f"/v1/users/{user.id}/notifications?limit=10&offset=3", headers={"X-CSRF-Token": "1"}),
         Permission.view_notification,
     )
     assert response.status_code == 200

--- a/backend/tests/controllers/notifications/test_notifications.py
+++ b/backend/tests/controllers/notifications/test_notifications.py
@@ -208,12 +208,13 @@ def test_get_notifications_app_no_permissions(test_client: TestClient, generator
 def test_get_notifications_user_with_permissions(
     test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
 ):
-    """Test that a user with view_notification permission can get notifications"""
-    user = generator.gen_user(email="user@test.com")
-    notification = generator.gen_notification(user=user)
-    authenticate_user(test_client, user, generator, create_session_cookie)
+    """Test that a user with view_notification permission can view notifications of another user"""
+    user_1 = generator.gen_user(email="user1@test.com")
+    user_2 = generator.gen_user(email="user2@test.com")
+    notification = generator.gen_notification(user=user_1)
+    authenticate_user(test_client, user_2, generator, create_session_cookie)
     response = make_authenticated_request(
-        lambda: test_client.get(f"/v1/users/{user.id}/notifications", headers={"X-CSRF-Token": "1"}),
+        lambda: test_client.get(f"/v1/users/{user_1.id}/notifications", headers={"X-CSRF-Token": "1"}),
         Permission.view_notification,
     )
     assert response.status_code == 200

--- a/backend/tests/controllers/notifications/test_notifications.py
+++ b/backend/tests/controllers/notifications/test_notifications.py
@@ -328,6 +328,19 @@ def test_get_notification_for_nonexistent_user(
     assert response.status_code == 404
 
 
+def test_get_count_for_nonexistent_user(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    """Test that getting notification count for a non-existent user returns 404"""
+    user = generator.gen_user(email="user@test.com")
+    authenticate_user(test_client, user, generator, create_session_cookie)
+    response = make_authenticated_request(
+        lambda: test_client.get("/v1/users/99999/notifications/count", headers={"X-CSRF-Token": "1"}),
+        Permission.view_notification,
+    )
+    assert response.status_code == 404
+
+
 def test_get_unread_count(
     test_client: TestClient,
     generator: DataGenerator,

--- a/backend/tests/controllers/notifications/test_notifications.py
+++ b/backend/tests/controllers/notifications/test_notifications.py
@@ -315,6 +315,19 @@ def test_get_multiple_notifications(
     assert data["offset"] == 0
 
 
+def test_get_notification_for_nonexistent_user(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    """Test that getting notifications for a non-existent user returns 404"""
+    user = generator.gen_user(email="user@test.com")
+    authenticate_user(test_client, user, generator, create_session_cookie)
+    response = make_authenticated_request(
+        lambda: test_client.get("/v1/users/99999/notifications", headers={"X-CSRF-Token": "1"}),
+        Permission.view_notification,
+    )
+    assert response.status_code == 404
+
+
 def test_get_unread_count(
     test_client: TestClient,
     generator: DataGenerator,
@@ -370,6 +383,21 @@ def test_mark_notification_as_read(
     data = response.json()
     assert data["id"] == notification.id
     assert data["dismissed_at"] is not None
+
+
+def test_mark_notification_as_read_nonexistent_user(
+    test_client: TestClient,
+    generator: DataGenerator,
+    create_session_cookie: Callable[[int], str],
+):
+    """Test that marking a notification as read for a non-existent user returns 404"""
+    user = generator.gen_user(email="user@test.com")
+    authenticate_user(test_client, user, generator, create_session_cookie)
+    response = make_authenticated_request(
+        lambda: test_client.post("/v1/users/99999/notifications/1/dismiss", headers={"X-CSRF-Token": "1"}),
+        Permission.change_notification,
+    )
+    assert response.status_code == 404
 
 
 def test_mark_nonexistent_notification_as_read(


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR is split from https://github.com/canonical/test_observer/pull/674, although it also further develops what was done there regarding notifications, so it's more than just a copy.

This PR splits the handling of the `/v1/users/me/notifications/*` endpoints, so that `me` is handled differently from accessing a user by the user ID. Authenticated users can always read and clear their own notifications. Authenticated users and applications with the `view_notification` and `change_notification` permissions _can_ view and change notifications of users by using the ID-based endpoints.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

IQA-3571

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

* `/v1/users/me/notifications`, `/v1/users/me/notifications/count`, and `/v1/users/me/notifications/{notification_id}/dismiss` now have separate handling to allow authenticated users to view and dismiss their own notifications without explicit permissions
* `/v1/users/{user_id}/notifications/*` do not have any changes in behavior, though the internals are simplified a bit due to the separate handling of `/me`

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Many tests are added, some existing tests were tweaked to switch from `/me` to `/{user_id}`