### PR TITLE
[Fix] Remove commit after deleting previous results

### DIFF
--- a/backend/test_observer/controllers/test_executions/end_test.py
+++ b/backend/test_observer/controllers/test_executions/end_test.py
@@ -112,8 +112,6 @@ def _store_c3_test_results(
         db.flush()
         apply_test_result_attachment_rules(db, test_result)
 
-    db.commit()
-
 
 def _parse_c3_test_result_status(status: C3TestResultStatus) -> TestResultStatus:
     match status:

--- a/backend/test_observer/controllers/test_executions/end_test.py
+++ b/backend/test_observer/controllers/test_executions/end_test.py
@@ -66,6 +66,11 @@ def end_test_execution(request: EndTestExecutionRequest, db: Session = Depends(g
 
 
 def _find_related_test_execution(request: EndTestExecutionRequest, db: Session) -> TestExecution | None:
+    # Serialise concurrent requests for the same execution. Without this lock,
+    # a retry can race through when there are no pre-existing rows to lock on,
+    # and both requests insert a full duplicate set.
+    # with_for_update(of=TestExecution) locks only the test_execution row,
+    # not the joined rows.
     stmt = (
         select(TestExecution)
         .where(TestExecution.ci_link == request.ci_link)
@@ -73,6 +78,7 @@ def _find_related_test_execution(request: EndTestExecutionRequest, db: Session) 
             joinedload(TestExecution.artefact_build).joinedload(ArtefactBuild.artefact),
             joinedload(TestExecution.test_results).joinedload(TestResult.test_case),
         )
+        .with_for_update(of=TestExecution)
     )
 
     return db.execute(stmt).unique().scalar_one_or_none()

--- a/backend/test_observer/controllers/test_executions/logic.py
+++ b/backend/test_observer/controllers/test_executions/logic.py
@@ -34,6 +34,7 @@ def delete_previous_results(
     test_execution: TestExecution,
 ):
     db.execute(delete(TestResult).where(TestResult.test_execution_id == test_execution.id))
+    db.expire(test_execution, ["test_results"])
 
 
 def delete_previous_test_events(
@@ -41,6 +42,7 @@ def delete_previous_test_events(
     test_execution: TestExecution,
 ):
     db.execute(delete(TestEvent).where(TestEvent.test_execution_id == test_execution.id))
+    db.expire(test_execution, ["test_events"])
 
 
 def get_previous_test_results(

--- a/backend/test_observer/controllers/test_executions/logic.py
+++ b/backend/test_observer/controllers/test_executions/logic.py
@@ -34,7 +34,6 @@ def delete_previous_results(
     test_execution: TestExecution,
 ):
     db.execute(delete(TestResult).where(TestResult.test_execution_id == test_execution.id))
-    db.commit()
 
 
 def delete_previous_test_events(
@@ -42,7 +41,6 @@ def delete_previous_test_events(
     test_execution: TestExecution,
 ):
     db.execute(delete(TestEvent).where(TestEvent.test_execution_id == test_execution.id))
-    db.commit()
 
 
 def get_previous_test_results(

--- a/backend/test_observer/controllers/test_executions/post_results.py
+++ b/backend/test_observer/controllers/test_executions/post_results.py
@@ -47,6 +47,9 @@ def post_results(
     request: list[TestResultRequest],
     db: Session = Depends(get_db),
 ):
+    # Serialise concurrent requests for the same execution. Without this lock,
+    # a retry can miss uncommitted inserts from the first request (READ COMMITTED)
+    # and produce duplicate rows.
     test_execution = db.get(
         TestExecution,
         id,
@@ -55,6 +58,7 @@ def post_results(
             selectinload(TestExecution.environment),
             selectinload(TestExecution.execution_metadata),
         ],
+        with_for_update=True,
     )
 
     if test_execution is None:


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

After deleting previous test results we should not commit as the operation should all be done in one large transaction.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

Duplicate test results on retries.

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

N/A

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

N/A

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Existing tests show backwards compatible.