### PR TITLE
Allow configurable CORS origins

### DIFF
--- a/backend/charm/charmcraft.yaml
+++ b/backend/charm/charmcraft.yaml
@@ -80,6 +80,10 @@ config:
       default: test-observer-api
       description: Public hostname for the service.
       type: string
+    additional_cors_origins:
+      default: ""
+      description: Additional origins for CORS headers as comma-separated full origins, including scheme and optional port (for example, https://example.com or http://localhost:3000)
+      type: string
     frontend_hostname:
       default: test-observer
       description: Public hostname for the frontend connected to this API

--- a/backend/charm/src/charm.py
+++ b/backend/charm/src/charm.py
@@ -262,6 +262,7 @@ class TestObserverBackendCharm(CharmBase):
             "SENTRY_DSN": self.config["sentry_dsn"],
             "CELERY_BROKER_URL": self._celery_broker_url,
             "SAML_SP_BASE_URL": f"https://{self.config['hostname']}",
+            "ADDITIONAL_CORS_ORIGINS": self.config["additional_cors_origins"],
             "FRONTEND_URL": f"https://{self.config['frontend_hostname']}",
             "SESSIONS_SECRET": self.config["sessions_secret"],
             "IGNORE_PERMISSIONS": self.config.get("ignore_permissions", ""),

--- a/backend/test_observer/common/config.py
+++ b/backend/test_observer/common/config.py
@@ -24,6 +24,9 @@ SAML_IDP_METADATA_URL = os.getenv(
 )
 SAML_SP_X509_CERT = os.getenv("SAML_SP_X509_CERT", "")
 SAML_SP_KEY = os.getenv("SAML_SP_KEY", "")
+ADDITIONAL_CORS_ORIGINS = [
+    origin.strip() for origin in os.getenv("ADDITIONAL_CORS_ORIGINS", "").split(",") if origin.strip()
+]
 FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:30001")
 SESSIONS_SECRET = os.getenv("SESSIONS_SECRET", "secret")
 SESSIONS_HTTPS_ONLY = os.getenv("SESSIONS_HTTPS_ONLY", "true").lower() == "true"

--- a/backend/test_observer/main.py
+++ b/backend/test_observer/main.py
@@ -23,6 +23,7 @@ from prometheus_client import start_http_server
 from starlette.middleware.sessions import SessionMiddleware
 
 from test_observer.common.config import (
+    ADDITIONAL_CORS_ORIGINS,
     FRONTEND_URL,
     METRICS_PORT,
     SENTRY_DSN,
@@ -97,7 +98,7 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[FRONTEND_URL],
+    allow_origins=[FRONTEND_URL] + ADDITIONAL_CORS_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/terraform/ps5/test-observer.tf
+++ b/terraform/ps5/test-observer.tf
@@ -77,6 +77,12 @@ variable "api_hostname" {
   type        = string
 }
 
+variable "additional_cors_origins" {
+  description = "Additional origins for CORS headers (comma separated)"
+  type        = string
+  default     = ""
+}
+
 variable "frontend_hostname" {
   description = "Test Observer front-end hostname"
   type        = string
@@ -216,16 +222,17 @@ resource "juju_application" "test-observer-api" {
   }
 
   config = {
-    hostname              = var.api_hostname
-    frontend_hostname     = var.frontend_hostname
-    port                  = var.environment == "development" ? 80 : 443
-    sentry_dsn            = "${local.sentry_dsn_map[var.environment]}"
-    saml_idp_metadata_url = var.saml_idp_metadata_url
-    saml_sp_cert          = var.saml_sp_cert
-    saml_sp_key           = var.saml_sp_key
-    sessions_secret       = var.sessions_secret
-    ignore_permissions    = join(",", var.ignore_permissions)
-    enable_issue_sync     = var.enable_issue_sync
+    hostname                = var.api_hostname
+    additional_cors_origins = var.additional_cors_origins
+    frontend_hostname       = var.frontend_hostname
+    port                    = var.environment == "development" ? 80 : 443
+    sentry_dsn              = "${local.sentry_dsn_map[var.environment]}"
+    saml_idp_metadata_url   = var.saml_idp_metadata_url
+    saml_sp_cert            = var.saml_sp_cert
+    saml_sp_key             = var.saml_sp_key
+    sessions_secret         = var.sessions_secret
+    ignore_permissions      = join(",", var.ignore_permissions)
+    enable_issue_sync       = var.enable_issue_sync
   }
 
   units = 3

--- a/terraform/ps6/main.tf
+++ b/terraform/ps6/main.tf
@@ -135,16 +135,17 @@ resource "juju_application" "test-observer-api" {
   }
 
   config = {
-    hostname              = var.api_hostname
-    frontend_hostname     = var.frontend_hostname
-    port                  = var.api_port
-    sentry_dsn            = var.sentry_dsn
-    saml_idp_metadata_url = var.saml_idp_metadata_url
-    saml_sp_cert          = var.saml_sp_cert
-    saml_sp_key           = var.saml_sp_key
-    sessions_secret       = var.sessions_secret
-    ignore_permissions    = join(",", var.ignore_permissions)
-    enable_issue_sync     = var.enable_issue_sync
+    hostname                = var.api_hostname
+    additional_cors_origins = var.additional_cors_origins
+    frontend_hostname       = var.frontend_hostname
+    port                    = var.api_port
+    sentry_dsn              = var.sentry_dsn
+    saml_idp_metadata_url   = var.saml_idp_metadata_url
+    saml_sp_cert            = var.saml_sp_cert
+    saml_sp_key             = var.saml_sp_key
+    sessions_secret         = var.sessions_secret
+    ignore_permissions      = join(",", var.ignore_permissions)
+    enable_issue_sync       = var.enable_issue_sync
   }
 
   units = 3

--- a/terraform/ps6/variables.tf
+++ b/terraform/ps6/variables.tf
@@ -95,6 +95,12 @@ variable "sentry_dsn" {
   type        = string
 }
 
+variable "additional_cors_origins" {
+  description = "Additional origins for CORS headers (comma separated)"
+  type        = string
+  default     = ""
+}
+
 variable "frontend_hostname" {
   description = "hostname for frontend"
   type        = string


### PR DESCRIPTION
## Description

Allow to configure additional origins in CORS headers.

## Resolved issues

- #709 

## Documentation

Self documented in `charmcraft.yaml`

## Web service API changes

N/A

## Tests

Not yet tested, I'm waiting for the CI to get a charm.