### PR TITLE
[IQA-3584] Update miscellaneous endpoints with auth and permissions

### DIFF
--- a/backend/migrations/versions/2026_04_17_1524-6f522a3527ca_add_sentry_debug_permission.py
+++ b/backend/migrations/versions/2026_04_17_1524-6f522a3527ca_add_sentry_debug_permission.py
@@ -1,0 +1,236 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""add_sentry_debug_permission
+
+Revision ID: 6f522a3527ca
+Revises: f0847700d32e
+Create Date: 2026-04-17 15:24:42.713382+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "6f522a3527ca"
+down_revision = "f0847700d32e"
+branch_labels = None
+depends_on = None
+
+
+PERMISSION_ENUM_NAME = "permission"
+
+# Manually copied from 2026_03_23_1733-c29b4f545a9b_add_permissions_to_amrs.py
+OLD_PERMISSIONS = {
+    "view_user",
+    "change_user",
+    "view_team",
+    "change_team",
+    "add_application",
+    "change_application",
+    "view_application",
+    "view_permission",
+    "view_issue",
+    "change_issue",
+    "change_issue_attachment",
+    "change_issue_attachment_bulk",
+    "change_attachment_rule",
+    "change_auto_rerun",
+    "view_test",
+    "change_test",
+    "view_rerun",
+    "change_rerun",
+    "change_rerun_bulk",
+    "view_artefact",
+    "change_artefact",
+    "view_environment_review",
+    "change_environment_review",
+    "view_report",
+    "view_test_case_reported_issue",
+    "change_test_case_reported_issue",
+    "view_environment_reported_issue",
+    "change_environment_reported_issue",
+    "view_notification",
+    "change_notification",
+}
+
+NEW_PERMISSIONS = OLD_PERMISSIONS.union({"view_sentry_debug"})
+
+
+def upgrade() -> None:
+    """
+    Although PostgreSQL does support adding new values to an enum type,
+    it does not support removing values from an enum type,
+    which is what we would need to do in the downgrade.
+    As a result, we take a more symmetric approach to upgrading and downgrading,
+    where we create new enum types in both cases.
+    """
+    # Rename the old enum to a new temporary name, so that we can create the new enum with the same name.
+    op.execute(f"ALTER TYPE {PERMISSION_ENUM_NAME} RENAME TO {PERMISSION_ENUM_NAME}_old")
+
+    # Create the new enum with the same name as the old enum.
+    formatted_options = ", ".join(f"'{p}'" for p in sorted(NEW_PERMISSIONS))
+    op.execute(f"CREATE TYPE {PERMISSION_ENUM_NAME} AS ENUM ({formatted_options})")
+
+    # artefact_matching_rule comes from this migration:
+    # 2026_03_23_1733-c29b4f545a9b_add_permissions_to_amrs.py
+    # application and team come from this migration:
+    # 2026_03_31_1410-f0847700d32e_convert_permission_to_enum.py
+    columns_to_update = [
+        ("application", "permissions"),
+        ("artefact_matching_rule", "grant_permissions"),
+        ("team", "permissions"),
+    ]
+
+    # Update existing table columns to use the new enum type
+    # However, we have to remove any values that are not in the new enum
+    # For this migration, this should be a no-op.
+    # However, I will leave it here as a reference for any future readers
+    # who need to create a similar migration
+    to_remove = ", ".join(f"'{p}'" for p in sorted(OLD_PERMISSIONS - NEW_PERMISSIONS))
+    for table_name, column_name in columns_to_update:
+        # Check if a default currently exists
+        # This query returns the default expression string if it exists, or None
+        has_default = (
+            op.get_bind()
+            .execute(
+                sa.text(
+                    f"""
+                    SELECT column_default 
+                    FROM information_schema.columns 
+                    WHERE table_name = '{table_name}' 
+                    AND column_name = '{column_name}'
+                    """
+                )
+            )
+            .scalar()
+        )
+
+        if has_default:
+            # We have to drop the default before altering the column type,
+            # otherwise PostgreSQL will complain about being unable to cast the default value to the new enum type.
+            op.execute(f"ALTER TABLE {table_name} ALTER COLUMN {column_name} DROP DEFAULT")
+
+        # Remove any values that are not in the new enum if there are any
+        if to_remove:
+            op.execute(
+                f"""
+                UPDATE {table_name} SET {column_name} = COALESCE(
+                    ARRAY(
+                        SELECT val
+                        FROM unnest({column_name}) AS val
+                        WHERE val::text NOT IN ({to_remove})
+                    ),
+                    '{{}}'
+                )
+                WHERE {column_name}::text[] && ARRAY[{to_remove}]::text[]
+                """
+            )
+
+        op.execute(
+            f"""
+            ALTER TABLE {table_name} ALTER COLUMN {column_name} TYPE {PERMISSION_ENUM_NAME}[]
+            USING {column_name}::text[]::{PERMISSION_ENUM_NAME}[]
+            """
+        )
+
+        if has_default:
+            # Reapply the default, which is an empty array of the new enum type.
+            op.execute(
+                f"ALTER TABLE {table_name} ALTER COLUMN {column_name} SET DEFAULT '{{}}'::{PERMISSION_ENUM_NAME}[]"
+            )
+
+    # Drop the old enum type
+    # We need to use SQL here, because otherwise the SQLAlchemy Enum object will attempt to drop the new enum,
+    # since it has the same name as the old enum.
+    # This will fail, since values were updated to point to the new enum.
+    op.execute(f"DROP TYPE {PERMISSION_ENUM_NAME}_old")
+
+
+def downgrade() -> None:
+    """
+    PostgreSQL does not support removing enum values,
+    so one option is to just do nothing in the downgrade.
+    However, for the sake of attempting to create a somewhat reversible process,
+    we will rename the current enum, create the old enum, and convert the columns back to the old enum.
+    """
+
+    # Rename the current enum to a new temporary name, so that we can create the old enum with the same name.
+    op.execute(f"ALTER TYPE {PERMISSION_ENUM_NAME} RENAME TO {PERMISSION_ENUM_NAME}_new")
+
+    # Create the old enum with the same name as the current enum.
+    formatted_options = ", ".join(f"'{p}'" for p in sorted(OLD_PERMISSIONS))
+    op.execute(f"CREATE TYPE {PERMISSION_ENUM_NAME} AS ENUM ({formatted_options})")
+
+    columns_to_update = [
+        ("application", "permissions"),
+        ("artefact_matching_rule", "grant_permissions"),
+        ("team", "permissions"),
+    ]
+
+    # Update existing table columns to use the old enum type
+    # However, we have to remove any values that are not in the old enum
+    to_remove = ", ".join(f"'{p}'" for p in sorted(NEW_PERMISSIONS - OLD_PERMISSIONS))
+    for table_name, column_name in columns_to_update:
+        has_default = (
+            op.get_bind()
+            .execute(
+                sa.text(
+                    f"""
+                    SELECT column_default 
+                    FROM information_schema.columns 
+                    WHERE table_name = '{table_name}' 
+                    AND column_name = '{column_name}'
+                    """
+                )
+            )
+            .scalar()
+        )
+
+        if has_default:
+            # We have to drop the default before altering the column type,
+            # otherwise PostgreSQL will complain about being unable to cast the default value to the old enum type.
+            op.execute(f"ALTER TABLE {table_name} ALTER COLUMN {column_name} DROP DEFAULT")
+
+        # Remove any values that are not in the old enum if there are any
+        if to_remove:
+            op.execute(
+                f"""
+                UPDATE {table_name} SET {column_name} = COALESCE(
+                    ARRAY(
+                        SELECT val
+                        FROM unnest({column_name}) AS val
+                        WHERE val::text NOT IN ({to_remove})
+                    ),
+                    '{{}}'
+                )
+                WHERE {column_name}::text[] && ARRAY[{to_remove}]::text[]
+                """
+            )
+
+        op.execute(
+            f"""
+            ALTER TABLE {table_name} ALTER COLUMN {column_name} TYPE {PERMISSION_ENUM_NAME}[]
+            USING {column_name}::text[]::{PERMISSION_ENUM_NAME}[]
+            """
+        )
+
+        if has_default:
+            op.execute(
+                f"ALTER TABLE {table_name} ALTER COLUMN {column_name} SET DEFAULT '{{}}'::{PERMISSION_ENUM_NAME}[]"
+            )
+
+    op.execute(f"DROP TYPE {PERMISSION_ENUM_NAME}_new")

--- a/backend/migrations/versions/2026_04_17_1900-daf0503863d7_add_sentry_debug_permission.py
+++ b/backend/migrations/versions/2026_04_17_1900-daf0503863d7_add_sentry_debug_permission.py
@@ -1,23 +1,8 @@
-# Copyright 2026 Canonical Ltd.
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License version 3, as
-# published by the Free Software Foundation.
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-#
-# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
-# SPDX-License-Identifier: AGPL-3.0-only
-
 """add_sentry_debug_permission
 
-Revision ID: 6f522a3527ca
-Revises: f0847700d32e
-Create Date: 2026-04-17 15:24:42.713382+00:00
+Revision ID: daf0503863d7
+Revises: d9c144615947
+Create Date: 2026-04-17 19:00:17.056259+00:00
 
 """
 
@@ -25,8 +10,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "6f522a3527ca"
-down_revision = "f0847700d32e"
+revision = "daf0503863d7"
+down_revision = "d9c144615947"
 branch_labels = None
 depends_on = None
 

--- a/backend/migrations/versions/2026_04_17_1900-daf0503863d7_add_sentry_debug_permission.py
+++ b/backend/migrations/versions/2026_04_17_1900-daf0503863d7_add_sentry_debug_permission.py
@@ -1,3 +1,18 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
 """add_sentry_debug_permission
 
 Revision ID: daf0503863d7

--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -5170,7 +5170,10 @@
               }
             }
           }
-        }
+        },
+        "x-permissions": [
+          "view_sentry_debug"
+        ]
       }
     }
   },
@@ -7356,7 +7359,8 @@
           "view_environment_reported_issue",
           "change_environment_reported_issue",
           "view_notification",
-          "change_notification"
+          "change_notification",
+          "view_sentry_debug"
         ],
         "title": "Permission"
       },

--- a/backend/scripts/check_endpoint_permissions.sh
+++ b/backend/scripts/check_endpoint_permissions.sh
@@ -28,7 +28,6 @@ OPENAPI_JSON="$1"
 EXCEPTIONS='[
   {"method": "get", "path": "/v1/version"},
   {"method": "get", "path": "/"},
-  {"method": "get", "path": "/sentry-debug"},
   {"method": "get", "path": "/openapi.json"},
   {"method": "get", "path": "/docs"},
   {"method": "get", "path": "/v1/auth/saml/login"},

--- a/backend/scripts/seed_data.py
+++ b/backend/scripts/seed_data.py
@@ -23,7 +23,7 @@ from textwrap import dedent
 import requests
 from fastapi.testclient import TestClient
 from pydantic import HttpUrl
-from sqlalchemy import select
+from sqlalchemy import inspect, select
 from sqlalchemy.orm import Session
 
 from test_observer.controllers.environments.models import (
@@ -43,8 +43,6 @@ from test_observer.controllers.issues.models import (
     IssuePutRequest,
     IssueTestResultAttachmentRulePostRequest,
 )
-from test_observer.common.enums import Permission
-
 from test_observer.controllers.artefacts.models import TestExecutionRelevantLinkCreate
 
 from test_observer.data_access.models import Artefact, User, TestResult, Application
@@ -55,7 +53,6 @@ from test_observer.data_access.models_enums import (
     CharmStage,
     ImageStage,
     IssueStatus,
-    IssueSource,
 )
 from test_observer.data_access.setup import SessionLocal
 from test_observer.users.add_user import add_user
@@ -799,9 +796,15 @@ def seed_data(client: TestClient | requests.Session, session: Session | None = N
     certbot.is_admin = True
 
     # Create an application with all permissions
+    # Following the conversion of permissions to be a PostgreSQL enum,
+    # we need to pull the values from the database rather than the Python code.
+    # Otherwise, the code could contain values not present in the database,
+    # which would cause an error when trying to add the application.
     application = session.scalar(select(Application).where(Application.name == "seed_data_app"))
+    inspector = inspect(session.get_bind())
+    permissions = next(e["labels"] for e in inspector.get_enums() if e["name"] == "permission")  # type: ignore
     if not application:
-        application = Application(name="seed_data_app", permissions=[p.value for p in Permission])
+        application = Application(name="seed_data_app", permissions=permissions)
         session.add(application)
         session.commit()
         session.refresh(application)

--- a/backend/test_observer/common/enums.py
+++ b/backend/test_observer/common/enums.py
@@ -63,3 +63,8 @@ class Permission(StrEnum):
     # Notifications
     view_notification = auto()
     change_notification = auto()
+
+    # Miscellaneous
+    # /sentry-debug, which is intended to be used for testing Sentry integration
+    # and does nothing but raise an exception
+    view_sentry_debug = auto()

--- a/backend/test_observer/controllers/router.py
+++ b/backend/test_observer/controllers/router.py
@@ -13,10 +13,12 @@
 # SPDX-FileCopyrightText: Copyright 2023 Canonical Ltd.
 # SPDX-License-Identifier: AGPL-3.0-only
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Security
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
+from test_observer.common.enums import Permission
+from test_observer.common.permissions import authentication_checker, permission_checker
 from test_observer.controllers.applications import applications
 from test_observer.controllers.docs import docs
 from test_observer.controllers.permissions import permissions
@@ -61,13 +63,13 @@ router.include_router(artefact_matching_rules.router, prefix="/v1/artefact-match
 router.include_router(health.router, prefix="/health")
 
 
-@router.get("/")
+@router.get("/", dependencies=[Depends(authentication_checker)])
 def root(db: Session = Depends(get_db)):
     db.execute(text("select 'test db connection'"))
     return "test observer api"
 
 
-@router.get("/sentry-debug")
+@router.get("/sentry-debug", dependencies=[Security(permission_checker, scopes=[Permission.view_sentry_debug])])
 def trigger_error():
     division_by_zero = 1 / 0
     return division_by_zero

--- a/backend/tests/controllers/test_router.py
+++ b/backend/tests/controllers/test_router.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from collections.abc import Callable
+
+import pytest
+from fastapi.testclient import TestClient
+
+from test_observer.common.enums import Permission
+from test_observer.common.permissions import requires_authentication
+from test_observer.main import app
+from tests.conftest import authenticate_user, make_authenticated_request
+from tests.data_generator import DataGenerator
+
+
+def test_base_unauthenticated_auth_not_required(test_client: TestClient):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        response = test_client.get("/")
+        assert response.status_code == 200
+        assert response.text == '"test observer api"'
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_base_unauthenticated_auth_required(test_client: TestClient):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        response = test_client.get("/")
+        assert response.status_code == 401
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_base_authenticated_app_auth_not_required(test_client: TestClient, generator: DataGenerator):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        application = generator.gen_application(permissions=[])
+        response = test_client.get("/", headers={"Authorization": f"Bearer {application.api_key}"})
+        assert response.status_code == 200
+        assert response.text == '"test observer api"'
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_base_authenticated_user_auth_not_required(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: False
+        user = generator.gen_user()
+        authenticate_user(test_client, user, generator, create_session_cookie)
+        response = test_client.get("/", headers={"X-CSRF-Token": "1"})
+        assert response.status_code == 200
+        assert response.text == '"test observer api"'
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_base_authenticated_app_auth_required(test_client: TestClient, generator: DataGenerator):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        application = generator.gen_application(permissions=[])
+        response = test_client.get("/", headers={"Authorization": f"Bearer {application.api_key}"})
+        assert response.status_code == 200
+        assert response.text == '"test observer api"'
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_base_authenticated_user_auth_required(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    try:
+        app.dependency_overrides[requires_authentication] = lambda: True
+        user = generator.gen_user()
+        authenticate_user(test_client, user, generator, create_session_cookie)
+        response = test_client.get("/", headers={"X-CSRF-Token": "1"})
+        assert response.status_code == 200
+        assert response.text == '"test observer api"'
+    finally:
+        app.dependency_overrides.pop(requires_authentication, None)
+
+
+def test_sentry_debug_without_permission(test_client: TestClient):
+    response = make_authenticated_request(
+        lambda: test_client.get("/sentry-debug"),
+    )
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Insufficient permissions"}
+
+
+def test_sentry_debug_with_permission(test_client: TestClient):
+    with pytest.raises(ZeroDivisionError):
+        make_authenticated_request(
+            lambda: test_client.get("/sentry-debug"),
+            Permission.view_sentry_debug,
+        )

--- a/backend/tests/migrations/test_daf0503863d7_add_sentry_debug_permission.py
+++ b/backend/tests/migrations/test_daf0503863d7_add_sentry_debug_permission.py
@@ -1,0 +1,207 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Tests for migration daf0503863d7: add_sentry_debug_permission"""
+
+from collections.abc import Generator
+from urllib.parse import urlparse, urlunparse
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import Engine, create_engine, text
+from sqlalchemy_utils import create_database, database_exists, drop_database  # type: ignore[import-untyped]
+
+# Migration revision constants
+PREVIOUS_REV = "d9c144615947"
+TARGET_REV = "daf0503863d7"
+
+
+@pytest.fixture
+def migration_context(db_url: str) -> Generator[tuple[Engine, Config], None, None]:
+    """
+    Create an isolated database context for migration testing.
+
+    Yields:
+        tuple: (SQLAlchemy Engine, Alembic Config) for the test database
+    """
+    # Parse the URL and create a unique test database name
+    parsed = urlparse(db_url)
+    test_db_url = urlunparse(
+        (parsed.scheme, parsed.netloc, "/test_migration_sentry_debug", parsed.params, parsed.query, parsed.fragment)
+    )
+
+    # Clean up any existing test database
+    if database_exists(test_db_url):
+        drop_database(test_db_url)
+
+    # Create new test database
+    create_database(test_db_url)
+
+    engine = None
+    try:
+        # Initialize engine and alembic config
+        engine = create_engine(test_db_url)
+        alembic_config = Config("alembic.ini")
+        alembic_config.set_main_option("sqlalchemy.url", test_db_url)
+
+        yield engine, alembic_config
+
+    finally:
+        # Cleanup: dispose engine and drop database
+        if engine:
+            engine.dispose()
+        if database_exists(test_db_url):
+            drop_database(test_db_url)
+
+
+def test_upgrade_and_downgrade_new_permission(migration_context: tuple[Engine, Config]) -> None:
+    """
+    Test that the new permission can be used after upgrade,
+    and is correctly stripped out during a downgrade without losing other permissions.
+    """
+    engine, alembic_config = migration_context
+
+    # Step 1: Migrate to revision before the target migration
+    command.upgrade(alembic_config, PREVIOUS_REV)
+
+    # Insert test data with old permissions
+    with engine.begin() as conn:
+        conn.execute(
+            text("""
+            INSERT INTO team (name, permissions, created_at, updated_at) 
+            VALUES 
+                ('team_old_only', '{"view_user"}'::permission[], NOW(), NOW()),
+                ('team_empty_perms', '{}'::permission[], NOW(), NOW())
+        """)
+        )
+
+    # Step 2: Upgrade to the target migration
+    command.upgrade(alembic_config, TARGET_REV)
+
+    # Step 3: Verify the new enum type includes the new permission by inserting and updating rows
+    with engine.begin() as conn:
+        # Insert a team with only the new permission
+        conn.execute(
+            text("""
+            INSERT INTO team (name, permissions, created_at, updated_at) 
+            VALUES ('team_new_only', '{"view_sentry_debug"}'::permission[], NOW(), NOW())
+        """)
+        )
+        # Update a team to have both an old permission and the new permission
+        conn.execute(
+            text("""
+            UPDATE team 
+            SET permissions = array_append(permissions, 'view_sentry_debug'::permission) 
+            WHERE name = 'team_old_only'
+        """)
+        )
+
+    # Verify data after upgrade
+    with engine.connect() as conn:
+        results = conn.execute(text("SELECT name, permissions::text[] FROM team ORDER BY name")).fetchall()
+        permissions_by_team = {row[0]: row[1] for row in results}
+
+        assert "view_sentry_debug" in permissions_by_team["team_new_only"]
+        assert set(permissions_by_team["team_old_only"]) == {"view_user", "view_sentry_debug"}
+
+    # Step 4: Downgrade back to the previous version
+    command.downgrade(alembic_config, PREVIOUS_REV)
+
+    # Step 5: Verify the new permission was safely stripped away, while preserving old permissions
+    with engine.connect() as conn:
+        results = conn.execute(text("SELECT name, permissions::text[] FROM team ORDER BY name")).fetchall()
+        permissions_by_team = {row[0]: row[1] for row in results}
+
+        # team_new_only had ONLY view_sentry_debug, so it should now have an empty array
+        assert len(permissions_by_team["team_new_only"]) == 0
+
+        # team_old_only should have lost view_sentry_debug but kept view_user
+        assert set(permissions_by_team["team_old_only"]) == {"view_user"}
+
+
+def test_default_values_preserved(migration_context: tuple[Engine, Config]) -> None:
+    """
+    Test that default values work correctly before and after the migration.
+    The migration drops and re-adds defaults, so we need to verify:
+    1. The column has a DEFAULT after upgrade
+    2. Empty arrays can be inserted and retrieved after upgrade
+    3. The column has a DEFAULT after downgrade
+    4. Empty arrays can be inserted and retrieved after downgrade
+    """
+    engine, alembic_config = migration_context
+
+    def _verify_column_default(e: Engine, table: str) -> None:
+        with e.connect() as conn:
+            result = conn.execute(
+                text("""
+                SELECT column_default
+                FROM information_schema.columns
+                WHERE table_name = :table AND column_name = 'permissions'
+            """),
+                {"table": table},
+            ).fetchone()
+            assert result is not None, f"Column 'permissions' not found in {table}"
+            assert result[0] is not None, f"Column {table}.permissions should have a default value"
+
+    # Upgrade to the target migration
+    command.upgrade(alembic_config, TARGET_REV)
+
+    # Verify column has a default after upgrade
+    _verify_column_default(engine, "team")
+
+    # Test with explicit empty array after upgrade
+    with engine.begin() as conn:
+        conn.execute(
+            text("""
+            INSERT INTO team (name, created_at, updated_at) 
+            VALUES ('test_default_team', NOW(), NOW())
+        """)
+        )
+
+        result = conn.execute(
+            text("""
+            SELECT permissions::text[] FROM team WHERE name = 'test_default_team'
+        """)
+        ).fetchone()
+
+        assert result is not None
+        assert result[0] == []
+
+        conn.execute(text("DELETE FROM team WHERE name = 'test_default_team'"))
+
+    # Downgrade and test defaults still work
+    command.downgrade(alembic_config, PREVIOUS_REV)
+
+    # Verify column has a default after downgrade
+    _verify_column_default(engine, "team")
+
+    # Test with default insertion after downgrade
+    with engine.begin() as conn:
+        conn.execute(
+            text("""
+            INSERT INTO team (name, created_at, updated_at) 
+            VALUES ('test_default_team_2', NOW(), NOW())
+        """)
+        )
+
+        result = conn.execute(
+            text("""
+            SELECT permissions::text[] FROM team WHERE name = 'test_default_team_2'
+        """)
+        ).fetchone()
+
+        assert result is not None
+        assert result[0] == []


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR is split from https://github.com/canonical/test_observer/pull/674

This PR adds the optional authentication requirement to the `/` endpoint, and it introduces a new `view_sentry_debug` permission for `/sentry-debug`, which in turn requires a migration. It also updates the seed data script to pull permissions from the database enum instead of the Python class.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

IQA-3584

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

* The `/` endpoint can optionally require authentication
* The `/sentry-debug` endpoint now requires the `view_sentry_debug` permission

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Added some tests