### PR TITLE
Feat: Expose metrics configuration variables in the charm

### DIFF
--- a/backend/charm/charmcraft.yaml
+++ b/backend/charm/charmcraft.yaml
@@ -102,6 +102,14 @@ config:
       description: Whether to enable periodic syncing of issues from GitHub, Jira, and Launchpad
       type: boolean
       default: false
+    metrics_init_days:
+      description: Number of days of historical data to load when initializing metrics on startup. Use 0 to load all historical data.
+      type: int
+      default: 30
+    metrics_init_enabled:
+      description: Whether to initialize Prometheus metrics from the database on startup.
+      type: boolean
+      default: true
 
 resources:
   api-image:

--- a/backend/charm/src/charm.py
+++ b/backend/charm/src/charm.py
@@ -267,6 +267,8 @@ class TestObserverBackendCharm(CharmBase):
             "SESSIONS_SECRET": self.config["sessions_secret"],
             "IGNORE_PERMISSIONS": self.config.get("ignore_permissions", ""),
             "ENABLE_ISSUE_SYNC": str(self.config.get("enable_issue_sync", "false")),
+            "METRICS_INIT_DAYS": str(self.config.get("metrics_init_days", 30)),
+            "METRICS_INIT_ENABLED": str(self.config.get("metrics_init_enabled", True)).lower(),
         }
         # Only set SAML environment variables if IDP metadata URL is provided
         if self.config.get("saml_idp_metadata_url"):

--- a/backend/test_observer/common/config.py
+++ b/backend/test_observer/common/config.py
@@ -34,4 +34,6 @@ IGNORE_PERMISSIONS = {
     permission.strip() for permission in os.getenv("IGNORE_PERMISSIONS", "").lower().split(",") if permission.strip()
 }
 METRICS_PORT = int(os.getenv("METRICS_PORT", "9090"))
+METRICS_INIT_DAYS = int(os.getenv("METRICS_INIT_DAYS", "30"))
+METRICS_INIT_ENABLED = os.getenv("METRICS_INIT_ENABLED", "true").lower() == "true"
 REQUIRE_AUTHENTICATION = os.getenv("REQUIRE_AUTHENTICATION", "false").lower() == "true"

--- a/backend/test_observer/common/config.py
+++ b/backend/test_observer/common/config.py
@@ -34,6 +34,7 @@ IGNORE_PERMISSIONS = {
     permission.strip() for permission in os.getenv("IGNORE_PERMISSIONS", "").lower().split(",") if permission.strip()
 }
 METRICS_PORT = int(os.getenv("METRICS_PORT", "9090"))
-METRICS_INIT_DAYS = int(os.getenv("METRICS_INIT_DAYS", "30"))
+__METRICS_INIT_DAYS__ = int(os.getenv("METRICS_INIT_DAYS", "30"))
+METRICS_INIT_DAYS = __METRICS_INIT_DAYS__ if __METRICS_INIT_DAYS__ > 0 else 0
 METRICS_INIT_ENABLED = os.getenv("METRICS_INIT_ENABLED", "true").lower() == "true"
 REQUIRE_AUTHENTICATION = os.getenv("REQUIRE_AUTHENTICATION", "false").lower() == "true"

--- a/backend/test_observer/common/metrics_initializer.py
+++ b/backend/test_observer/common/metrics_initializer.py
@@ -22,11 +22,11 @@ immediately reflects the current state rather than starting from zero.
 
 import logging
 from datetime import datetime, timedelta
-from os import environ
 
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
+from test_observer.common.config import METRICS_INIT_DAYS, METRICS_INIT_ENABLED
 from test_observer.common.metrics import (
     test_results,
     test_results_metadata,
@@ -47,10 +47,6 @@ from test_observer.data_access.models import (
 )
 
 logger = logging.getLogger(__name__)
-
-# Configuration from environment
-METRICS_INIT_ENABLED = environ.get("METRICS_INIT_ENABLED", "true").lower() == "true"
-METRICS_INIT_DAYS = int(environ.get("METRICS_INIT_DAYS", "30"))
 
 
 def initialize_all_metrics(db: Session) -> None:
@@ -86,7 +82,7 @@ def initialize_all_metrics(db: Session) -> None:
 
 def _get_cutoff_date() -> datetime | None:
     """Get the cutoff date for metrics initialization based on config."""
-    if METRICS_INIT_DAYS == 0:
+    if METRICS_INIT_DAYS <= 0:
         return None  # No time limit
     return datetime.utcnow() - timedelta(days=METRICS_INIT_DAYS)
 


### PR DESCRIPTION
## Description

The `METRICS_INIT_ENABLED` and `METRICS_INIT_DAYS` environment variables that control Prometheus metrics initialization were previously only configurable outside of Juju. This PR exposes them as charm config options so operators can tune this behaviour through standard Juju config.

Implementation approach:

  - Added `metrics_init_enabled` and `metrics_init_days` to charmcraft.yaml as charm config options with sensible defaults (`true` and `30` respectively).
  - `charm.py` now maps these config values to the corresponding environment variables passed to the API container.
  - The env var reads were consolidated into the existing `config.py` module, removing the duplicate reads that were in `metrics_initializer.py`.
  - fix: `METRICS_INIT_DAYS <= 0` instead of `== 0` to ensure negative values are also treated as "no time limit".

## Resolved issues
N/A

## Documentation
N/A


## Tests
Covered by existing tests