### PR TITLE
Fix: Exports the product artifact deep dive dashboard in a compatible format

### DIFF
--- a/backend/charm/src/grafana_dashboards/product_artifact_deepdive.json
+++ b/backend/charm/src/grafana_dashboards/product_artifact_deepdive.json
@@ -1,909 +1,684 @@
 {
-  "apiVersion": "dashboard.grafana.app/v2beta1",
-  "kind": "Dashboard",
-  "metadata": {
-    "name": "product-deep-dive",
-    "generation": 11,
-    "creationTimestamp": "2026-02-05T19:38:21Z",
-    "labels": {},
-    "annotations": {}
-  },
-  "spec": {
-    "annotations": [
-      {
-        "kind": "AnnotationQuery",
-        "spec": {
-          "builtIn": true,
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "query": {
-            "group": "grafana",
-            "kind": "DataQuery",
-            "spec": {},
-            "version": "v0"
-          }
-        }
-      }
-    ],
-    "cursorSync": "Off",
-    "editable": true,
-    "elements": {
-      "panel-1": {
-        "kind": "Panel",
-        "spec": {
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "editorMode": "code",
-                        "expr": "sum by (status) (test_observer_test_results{artefact_name=~\"$artefact\", track=~\"$track\", artefact_stage=~\"$stage\", family=~\"$family\"})",
-                        "legendFormat": "{{status}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "A"
-                  }
-                }
-              ],
-              "queryOptions": {},
-              "transformations": []
-            }
-          },
-          "description": "",
-          "id": 1,
-          "links": [],
-          "title": "Status Breakdown",
-          "vizConfig": {
-            "group": "piechart",
-            "kind": "VizConfig",
-            "spec": {
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    }
-                  }
-                },
-                "overrides": [
-                  {
-                    "matcher": {
-                      "id": "byName",
-                      "options": "FAILED"
-                    },
-                    "properties": [
-                      {
-                        "id": "color",
-                        "value": {
-                          "fixedColor": "red",
-                          "mode": "fixed"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "matcher": {
-                      "id": "byName",
-                      "options": "PASSED"
-                    },
-                    "properties": [
-                      {
-                        "id": "color",
-                        "value": {
-                          "fixedColor": "green",
-                          "mode": "fixed"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              "options": {
-                "displayLabels": ["percent"],
-                "legend": {
-                  "displayMode": "list",
-                  "placement": "right",
-                  "showLegend": true
-                },
-                "pieType": "donut",
-                "reduceOptions": {
-                  "calcs": ["lastNotNull"],
-                  "fields": "",
-                  "values": false
-                },
-                "sort": "desc",
-                "tooltip": {
-                  "hideZeros": false,
-                  "mode": "single",
-                  "sort": "none"
-                }
-              }
-            },
-            "version": "12.3.2"
-          }
-        }
-      },
-      "panel-2": {
-        "kind": "Panel",
-        "spec": {
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "editorMode": "code",
-                        "expr": "sum by (environment_name) (test_observer_test_results{status=\"FAILED\", artefact_name=~\"$artefact\", track=~\"$track\", family=~\"$family\"})",
-                        "legendFormat": "{{environment_name}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "A"
-                  }
-                }
-              ],
-              "queryOptions": {},
-              "transformations": []
-            }
-          },
-          "description": "",
-          "id": 2,
-          "links": [],
-          "title": "Failures by Environment",
-          "vizConfig": {
-            "group": "barchart",
-            "kind": "VizConfig",
-            "spec": {
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "fixedColor": "red",
-                    "mode": "palette-classic-by-name"
-                  },
-                  "custom": {
-                    "axisBorderShow": false,
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "fillOpacity": 0,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "lineWidth": 1,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green",
-                        "value": 0
-                      }
-                    ]
-                  }
-                },
-                "overrides": []
-              },
-              "options": {
-                "barRadius": 0,
-                "barWidth": 0.97,
-                "fullHighlight": false,
-                "groupWidth": 0.7,
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "orientation": "auto",
-                "showValue": "auto",
-                "stacking": "none",
-                "tooltip": {
-                  "hideZeros": false,
-                  "mode": "single",
-                  "sort": "none"
-                },
-                "xTickLabelRotation": 0,
-                "xTickLabelSpacing": 0
-              }
-            },
-            "version": "12.3.2"
-          }
-        }
-      },
-      "panel-3": {
-        "kind": "Panel",
-        "spec": {
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "editorMode": "code",
-                        "expr": "sum by (test_plan) (test_observer_test_results{status=\"FAILED\", artefact_name=~\"$artefact\", track=~\"$track\", family=~\"$family\"})",
-                        "format": "table",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "A"
-                  }
-                }
-              ],
-              "queryOptions": {},
-              "transformations": []
-            }
-          },
-          "description": "",
-          "id": 3,
-          "links": [],
-          "title": "Failing Test Plans",
-          "vizConfig": {
-            "group": "table",
-            "kind": "VizConfig",
-            "spec": {
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "thresholds"
-                  },
-                  "custom": {
-                    "align": "auto",
-                    "cellOptions": {
-                      "type": "auto"
-                    },
-                    "footer": {
-                      "reducers": ["sum"]
-                    },
-                    "inspect": false
-                  },
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green",
-                        "value": 0
-                      },
-                      {
-                        "color": "red",
-                        "value": 1
-                      }
-                    ]
-                  }
-                },
-                "overrides": []
-              },
-              "options": {
-                "cellHeight": "sm",
-                "enablePagination": true,
-                "showHeader": true,
-                "sortBy": []
-              }
-            },
-            "version": "12.3.2"
-          }
-        }
-      },
-      "panel-4": {
-        "kind": "Panel",
-        "spec": {
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "editorMode": "code",
-                        "expr": "topk(10, sum by (test_name) (test_observer_test_results{status=\"FAILED\", artefact_name=~\"$artefact\", track=~\"$track\", family=~\"$family\"}))",
-                        "format": "time_series",
-                        "legendFormat": "{{test_name}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "A"
-                  }
-                }
-              ],
-              "queryOptions": {},
-              "transformations": []
-            }
-          },
-          "description": "",
-          "id": 4,
-          "links": [],
-          "title": "Top Failing Individual Tests",
-          "vizConfig": {
-            "group": "barchart",
-            "kind": "VizConfig",
-            "spec": {
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisBorderShow": false,
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "fillOpacity": 0,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "lineWidth": 1,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green",
-                        "value": 0
-                      }
-                    ]
-                  }
-                },
-                "overrides": []
-              },
-              "options": {
-                "barRadius": 0,
-                "barWidth": 0.97,
-                "fullHighlight": false,
-                "groupWidth": 0.7,
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "orientation": "horizontal",
-                "showValue": "auto",
-                "stacking": "none",
-                "tooltip": {
-                  "hideZeros": false,
-                  "mode": "single",
-                  "sort": "none"
-                },
-                "xTickLabelRotation": 0,
-                "xTickLabelSpacing": 0
-              }
-            },
-            "version": "12.3.2"
-          }
-        }
-      },
-      "panel-5": {
-        "kind": "Panel",
-        "spec": {
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "editorMode": "code",
-                        "exemplar": false,
-                        "expr": "topk(10, sum by (artefact_name) (test_observer_test_results{status=\"FAILED\", family=~\"$family\", track=~\"$track\", artefact_stage=~\"$stage\"}))",
-                        "format": "table",
-                        "instant": true,
-                        "legendFormat": "",
-                        "range": false
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "A"
-                  }
-                }
-              ],
-              "queryOptions": {},
-              "transformations": []
-            }
-          },
-          "description": "",
-          "id": 5,
-          "links": [],
-          "title": "Top Failing Artefacts",
-          "vizConfig": {
-            "group": "barchart",
-            "kind": "VizConfig",
-            "spec": {
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisBorderShow": false,
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "fillOpacity": 80,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "lineWidth": 1,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green",
-                        "value": 0
-                      }
-                    ]
-                  },
-                  "unit": "short"
-                },
-                "overrides": []
-              },
-              "options": {
-                "barRadius": 0,
-                "barWidth": 0.97,
-                "fullHighlight": false,
-                "groupWidth": 0.7,
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "list",
-                  "placement": "right",
-                  "showLegend": true
-                },
-                "orientation": "horizontal",
-                "showValue": "never",
-                "stacking": "none",
-                "tooltip": {
-                  "hideZeros": false,
-                  "mode": "single",
-                  "sort": "none"
-                },
-                "xTickLabelRotation": 0,
-                "xTickLabelSpacing": 0
-              }
-            },
-            "version": "12.3.2"
-          }
-        }
-      },
-      "panel-6": {
-        "kind": "Panel",
-        "spec": {
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "editorMode": "code",
-                        "exemplar": false,
-                        "expr": "topk(25, sum by (Interface) (\n  label_replace(\n    test_observer_test_results{status=\"FAILED\", artefact_name=~\"$artefact\", track=~\"$track\", family=~\"$family\"},\n    \"Interface\",\n    \"$1\",\n    \"test_plan\",\n    \"[^/]+/[^/]+/([^/]+)/.*\"\n  )\n))",
-                        "format": "table",
-                        "instant": true,
-                        "legendFormat": "__auto",
-                        "range": false
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "A"
-                  }
-                }
-              ],
-              "queryOptions": {},
-              "transformations": [
-                {
-                  "kind": "filterByRefId",
-                  "spec": {
-                    "id": "filterByRefId",
-                    "options": {
-                      "include": ""
-                    }
-                  }
-                }
-              ]
-            }
-          },
-          "description": "Note: Only works with the Charm family",
-          "id": 6,
-          "links": [],
-          "title": "Top 25 failing Interfaces",
-          "vizConfig": {
-            "group": "barchart",
-            "kind": "VizConfig",
-            "spec": {
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "thresholds"
-                  },
-                  "custom": {
-                    "axisBorderShow": false,
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "fillOpacity": 80,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "lineWidth": 1,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green",
-                        "value": 0
-                      },
-                      {
-                        "color": "red",
-                        "value": 80
-                      }
-                    ]
-                  }
-                },
-                "overrides": []
-              },
-              "options": {
-                "barRadius": 0,
-                "barWidth": 0.97,
-                "fullHighlight": false,
-                "groupWidth": 0.7,
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "orientation": "horizontal",
-                "showValue": "auto",
-                "stacking": "none",
-                "tooltip": {
-                  "hideZeros": false,
-                  "mode": "single",
-                  "sort": "none"
-                },
-                "xTickLabelRotation": 0,
-                "xTickLabelSpacing": 0
-              }
-            },
-            "version": "12.3.2"
-          }
-        }
-      }
+  "__inputs": [
+    {
+      "name": "DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1",
+      "label": "juju_k8s-stg-sqa-cos-default_7890c240-ba69-4086-8b7a-f74a7b750d45_mimir_1",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "barchart",
+      "name": "Bar chart",
+      "version": ""
     },
-    "layout": {
-      "kind": "GridLayout",
-      "spec": {
-        "items": [
-          {
-            "kind": "GridLayoutItem",
-            "spec": {
-              "element": {
-                "kind": "ElementReference",
-                "name": "panel-1"
-              },
-              "height": 8,
-              "width": 8,
-              "x": 0,
-              "y": 0
-            }
-          },
-          {
-            "kind": "GridLayoutItem",
-            "spec": {
-              "element": {
-                "kind": "ElementReference",
-                "name": "panel-2"
-              },
-              "height": 8,
-              "width": 16,
-              "x": 8,
-              "y": 0
-            }
-          },
-          {
-            "kind": "GridLayoutItem",
-            "spec": {
-              "element": {
-                "kind": "ElementReference",
-                "name": "panel-3"
-              },
-              "height": 11,
-              "width": 12,
-              "x": 0,
-              "y": 8
-            }
-          },
-          {
-            "kind": "GridLayoutItem",
-            "spec": {
-              "element": {
-                "kind": "ElementReference",
-                "name": "panel-4"
-              },
-              "height": 11,
-              "width": 12,
-              "x": 12,
-              "y": 8
-            }
-          },
-          {
-            "kind": "GridLayoutItem",
-            "spec": {
-              "element": {
-                "kind": "ElementReference",
-                "name": "panel-6"
-              },
-              "height": 13,
-              "width": 12,
-              "x": 0,
-              "y": 19
-            }
-          },
-          {
-            "kind": "GridLayoutItem",
-            "spec": {
-              "element": {
-                "kind": "ElementReference",
-                "name": "panel-5"
-              },
-              "height": 13,
-              "width": 12,
-              "x": 12,
-              "y": 19
-            }
-          }
-        ]
-      }
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "12.0.2"
     },
-    "links": [],
-    "liveNow": false,
-    "preload": false,
-    "tags": ["product", "deep-dive"],
-    "timeSettings": {
-      "autoRefresh": "",
-      "autoRefreshIntervals": [
-        "5s",
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
-      ],
-      "fiscalYearStartMonth": 0,
-      "from": "now-30d",
-      "hideTimepicker": false,
-      "timezone": "",
-      "to": "now"
+    {
+      "type": "panel",
+      "id": "piechart",
+      "name": "Pie chart",
+      "version": ""
     },
-    "title": "Product & Artifact Deep Dive",
-    "variables": [
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
       {
-        "kind": "QueryVariable",
-        "spec": {
-          "allValue": ".*",
-          "allowCustomValue": true,
-          "current": {
-            "text": "",
-            "value": ""
-          },
-          "definition": "label_values(test_observer_test_results, family)",
-          "hide": "dontHide",
-          "includeAll": true,
-          "label": "Product Family",
-          "multi": true,
-          "name": "family",
-          "options": [],
-          "query": {
-            "group": "prometheus",
-            "kind": "DataQuery",
-            "spec": {
-              "query": "label_values(test_observer_test_results, family)",
-              "refId": "StandardVariableQuery"
-            },
-            "version": "v0"
-          },
-          "refresh": "onDashboardLoad",
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": "alphabeticalAsc"
-        }
-      },
-      {
-        "kind": "QueryVariable",
-        "spec": {
-          "allValue": ".*",
-          "allowCustomValue": true,
-          "current": {
-            "text": "",
-            "value": ""
-          },
-          "definition": "label_values(test_observer_test_results{family=~\"$family\"}, artefact_name)",
-          "hide": "dontHide",
-          "includeAll": true,
-          "label": "Artefact Name",
-          "multi": true,
-          "name": "artefact",
-          "options": [],
-          "query": {
-            "group": "prometheus",
-            "kind": "DataQuery",
-            "spec": {
-              "query": "label_values(test_observer_test_results{family=~\"$family\"}, artefact_name)",
-              "refId": "StandardVariableQuery"
-            },
-            "version": "v0"
-          },
-          "refresh": "onDashboardLoad",
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": "alphabeticalAsc"
-        }
-      },
-      {
-        "kind": "QueryVariable",
-        "spec": {
-          "allValue": ".*",
-          "allowCustomValue": true,
-          "current": {
-            "text": "",
-            "value": ""
-          },
-          "definition": "label_values(test_observer_test_results{artefact_name=~\"$artefact\"}, artefact_stage)",
-          "hide": "dontHide",
-          "includeAll": true,
-          "label": "Stage",
-          "multi": true,
-          "name": "stage",
-          "options": [],
-          "query": {
-            "group": "prometheus",
-            "kind": "DataQuery",
-            "spec": {
-              "query": "label_values(test_observer_test_results{artefact_name=~\"$artefact\"}, artefact_stage)",
-              "refId": "StandardVariableQuery"
-            },
-            "version": "v0"
-          },
-          "refresh": "onDashboardLoad",
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": "alphabeticalAsc"
-        }
-      },
-      {
-        "kind": "QueryVariable",
-        "spec": {
-          "allValue": ".*",
-          "allowCustomValue": true,
-          "current": {
-            "text": "",
-            "value": ""
-          },
-          "definition": "label_values(test_observer_test_results{artefact_name=~\"$artefact\"}, track)",
-          "hide": "dontHide",
-          "includeAll": true,
-          "label": "Track",
-          "multi": true,
-          "name": "track",
-          "options": [],
-          "query": {
-            "group": "prometheus",
-            "kind": "DataQuery",
-            "spec": {
-              "query": "label_values(test_observer_test_results{artefact_name=~\"$artefact\"}, track)",
-              "refId": "StandardVariableQuery"
-            },
-            "version": "v0"
-          },
-          "refresh": "onDashboardLoad",
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": "alphabeticalAsc"
-        }
-      },
-      {
-        "kind": "ConstantVariable",
-        "spec": {
-          "current": {
-            "text": "TestObserver",
-            "value": "TestObserver"
-          },
-          "hide": "hideVariable",
-          "name": "DS_PROMETHEUS",
-          "query": "TestObserver",
-          "skipUrlSync": true
-        }
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
       }
     ]
   },
-  "status": {}
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FAILED"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PASSED"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "displayLabels": ["percent"],
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "expr": "sum by (status) (test_observer_test_results{artefact_name=~\"$artefact\", track=~\"$track\", artefact_stage=~\"$stage\", family=~\"$family\"})",
+          "legendFormat": "{{status}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+          }
+        }
+      ],
+      "title": "Status Breakdown",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "red",
+            "mode": "palette-classic-by-name"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "expr": "sum by (environment_name) (test_observer_test_results{status=\"FAILED\", artefact_name=~\"$artefact\", track=~\"$track\", family=~\"$family\"})",
+          "legendFormat": "{{environment_name}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+          }
+        }
+      ],
+      "title": "Failures by Environment",
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "cellHeight": "sm",
+        "enablePagination": true,
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "expr": "sum by (test_plan) (test_observer_test_results{status=\"FAILED\", artefact_name=~\"$artefact\", track=~\"$track\", family=~\"$family\"})",
+          "format": "table",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+          }
+        }
+      ],
+      "title": "Failing Test Plans",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "expr": "topk(10, sum by (test_name) (test_observer_test_results{status=\"FAILED\", artefact_name=~\"$artefact\", track=~\"$track\", family=~\"$family\"}))",
+          "legendFormat": "{{test_name}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+          }
+        }
+      ],
+      "title": "Top Failing Individual Tests",
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+      },
+      "description": "Note: Only works with the Charm family",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 0,
+        "y": 19
+      },
+      "id": 6,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "expr": "topk(25, sum by (Interface) (label_replace(test_observer_test_results{status=\"FAILED\", artefact_name=~\"$artefact\", track=~\"$track\", family=~\"$family\"}, \"Interface\", \"$1\", \"test_plan\", \"[^/]+/[^/]+/([^/]+)/.*\")))",
+          "format": "table",
+          "instant": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+          }
+        }
+      ],
+      "title": "Top 25 failing Interfaces",
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "id": 5,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "horizontal",
+        "showValue": "never",
+        "stacking": "none",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "expr": "topk(10, sum by (artefact_name) (test_observer_test_results{status=\"FAILED\", family=~\"$family\", track=~\"$track\", artefact_stage=~\"$stage\"}))",
+          "format": "table",
+          "instant": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+          }
+        }
+      ],
+      "title": "Top Failing Artefacts",
+      "type": "barchart"
+    }
+  ],
+  "schemaVersion": 41,
+  "tags": ["product", "deep-dive"],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+        },
+        "definition": "label_values(test_observer_test_results, family)",
+        "includeAll": true,
+        "label": "Product Family",
+        "multi": true,
+        "name": "family",
+        "options": [],
+        "query": "label_values(test_observer_test_results, family)",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+        },
+        "definition": "label_values(test_observer_test_results{family=~\"$family\"}, artefact_name)",
+        "includeAll": true,
+        "label": "Artefact Name",
+        "multi": true,
+        "name": "artefact",
+        "options": [],
+        "query": "label_values(test_observer_test_results{family=~\"$family\"}, artefact_name)",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+        },
+        "definition": "label_values(test_observer_test_results{artefact_name=~\"$artefact\"}, artefact_stage)",
+        "includeAll": true,
+        "label": "Stage",
+        "multi": true,
+        "name": "stage",
+        "options": [],
+        "query": "label_values(test_observer_test_results{artefact_name=~\"$artefact\"}, artefact_stage)",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+        },
+        "definition": "label_values(test_observer_test_results{artefact_name=~\"$artefact\"}, track)",
+        "includeAll": true,
+        "label": "Track",
+        "multi": true,
+        "name": "track",
+        "options": [],
+        "query": "label_values(test_observer_test_results{artefact_name=~\"$artefact\"}, track)",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "hide": 2,
+        "includeAll": false,
+        "label": "Prometheus Datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Product & Artifact Deep Dive",
+  "uid": "04373d0d-2c85-467f-a2e5-71b0505b99eb",
+  "version": 2,
+  "weekStart": ""
 }

--- a/backend/charm/src/grafana_dashboards/product_artifact_deepdive.json
+++ b/backend/charm/src/grafana_dashboards/product_artifact_deepdive.json
@@ -1,14 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1",
-      "label": "juju_k8s-stg-sqa-cos-default_7890c240-ba69-4086-8b7a-f74a7b750d45_mimir_1",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
   "__elements": {},
   "__requires": [
     {
@@ -64,7 +54,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+        "uid": "${prometheusds}"
       },
       "fieldConfig": {
         "defaults": {
@@ -147,7 +137,7 @@
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+            "uid": "${prometheusds}"
           }
         }
       ],
@@ -157,7 +147,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+        "uid": "${prometheusds}"
       },
       "fieldConfig": {
         "defaults": {
@@ -235,7 +225,7 @@
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+            "uid": "${prometheusds}"
           }
         }
       ],
@@ -245,7 +235,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+        "uid": "${prometheusds}"
       },
       "fieldConfig": {
         "defaults": {
@@ -301,7 +291,7 @@
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+            "uid": "${prometheusds}"
           }
         }
       ],
@@ -311,7 +301,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+        "uid": "${prometheusds}"
       },
       "fieldConfig": {
         "defaults": {
@@ -392,7 +382,7 @@
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+            "uid": "${prometheusds}"
           }
         }
       ],
@@ -402,7 +392,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+        "uid": "${prometheusds}"
       },
       "description": "Note: Only works with the Charm family",
       "fieldConfig": {
@@ -485,7 +475,7 @@
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+            "uid": "${prometheusds}"
           }
         }
       ],
@@ -495,7 +485,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+        "uid": "${prometheusds}"
       },
       "fieldConfig": {
         "defaults": {
@@ -577,7 +567,7 @@
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+            "uid": "${prometheusds}"
           }
         }
       ],
@@ -594,7 +584,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+          "uid": "${prometheusds}"
         },
         "definition": "label_values(test_observer_test_results, family)",
         "includeAll": true,
@@ -611,7 +601,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+          "uid": "${prometheusds}"
         },
         "definition": "label_values(test_observer_test_results{family=~\"$family\"}, artefact_name)",
         "includeAll": true,
@@ -628,7 +618,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+          "uid": "${prometheusds}"
         },
         "definition": "label_values(test_observer_test_results{artefact_name=~\"$artefact\"}, artefact_stage)",
         "includeAll": true,
@@ -645,7 +635,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_JUJU_K8S-STG-SQA-COS-DEFAULT_7890C240-BA69-4086-8B7A-F74A7B750D45_MIMIR_1}"
+          "uid": "${prometheusds}"
         },
         "definition": "label_values(test_observer_test_results{artefact_name=~\"$artefact\"}, track)",
         "includeAll": true,
@@ -678,7 +668,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "Product & Artifact Deep Dive",
-  "uid": "04373d0d-2c85-467f-a2e5-71b0505b99eb",
   "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
Updates the exported grafana dashboard to use the legacy format as the COS grafana version is using version 12.0.X.