### PR TITLE
[IQA-3586] Enable authentication requirement option in backend charm

### DIFF
--- a/backend/charm/charmcraft.yaml
+++ b/backend/charm/charmcraft.yaml
@@ -98,6 +98,10 @@ config:
       description: Whether to enable periodic syncing of issues from GitHub, Jira, and Launchpad
       type: boolean
       default: false
+    require_authentication:
+      description: Whether to require authentication for all API requests
+      type: boolean
+      default: false
 
 resources:
   api-image:

--- a/backend/charm/src/charm.py
+++ b/backend/charm/src/charm.py
@@ -266,6 +266,7 @@ class TestObserverBackendCharm(CharmBase):
             "SESSIONS_SECRET": self.config["sessions_secret"],
             "IGNORE_PERMISSIONS": self.config.get("ignore_permissions", ""),
             "ENABLE_ISSUE_SYNC": str(self.config.get("enable_issue_sync", "false")),
+            "REQUIRE_AUTHENTICATION": str(self.config.get("require_authentication", "false")),
         }
         # Only set SAML environment variables if IDP metadata URL is provided
         if self.config.get("saml_idp_metadata_url"):

--- a/backend/charm/src/charm.py
+++ b/backend/charm/src/charm.py
@@ -269,7 +269,9 @@ class TestObserverBackendCharm(CharmBase):
             "ENABLE_ISSUE_SYNC": str(self.config.get("enable_issue_sync", "false")),
             "METRICS_INIT_DAYS": str(self.config.get("metrics_init_days", 30)),
             "METRICS_INIT_ENABLED": str(self.config.get("metrics_init_enabled", True)).lower(),
-            "REQUIRE_AUTHENTICATION": str(self.config.get("require_authentication", False)).lower(),
+            "REQUIRE_AUTHENTICATION": str(
+                self.config.get("require_authentication", False)
+            ).lower(),
         }
         # Only set SAML environment variables if IDP metadata URL is provided
         if self.config.get("saml_idp_metadata_url"):

--- a/backend/charm/src/charm.py
+++ b/backend/charm/src/charm.py
@@ -269,7 +269,7 @@ class TestObserverBackendCharm(CharmBase):
             "ENABLE_ISSUE_SYNC": str(self.config.get("enable_issue_sync", "false")),
             "METRICS_INIT_DAYS": str(self.config.get("metrics_init_days", 30)),
             "METRICS_INIT_ENABLED": str(self.config.get("metrics_init_enabled", True)).lower(),
-            "REQUIRE_AUTHENTICATION": str(self.config.get("require_authentication", "false")),
+            "REQUIRE_AUTHENTICATION": str(self.config.get("require_authentication", False)).lower(),
         }
         # Only set SAML environment variables if IDP metadata URL is provided
         if self.config.get("saml_idp_metadata_url"):


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR allows the recently added `REQUIRE_AUTHENTICATION` environment variable in the backend to be configurable through the backend charm.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

IQA-3586