### PR TITLE
Tweak spread task

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -146,7 +146,7 @@ prepare: |
     systemctl mask unattended-upgrades.service
   fi
 
-  apt update
+  apt update -o DPkg::Lock::Timeout=300
   apt install -y pipx
   snap install --classic concierge
   concierge prepare --trace --preset microk8s

--- a/spread.yaml
+++ b/spread.yaml
@@ -146,7 +146,7 @@ prepare: |
     systemctl mask unattended-upgrades.service
   fi
 
-  apt update -o DPkg::Lock::Timeout=300
+  apt update
   apt install -y pipx
   snap install --classic concierge
   concierge prepare --trace --preset microk8s

--- a/spread/integration/task.yaml
+++ b/spread/integration/task.yaml
@@ -55,9 +55,20 @@ execute: |
   PGHOST=$(juju show-unit db/0 | grep address | tail -n 1 | awk '{print $2;}')
   PGUSER=operator
   PGDATABASE=test_observer_db
-  juju ssh --container postgresql db/leader \
-    "PGPASSWORD=$PGPASSWORD PGHOST=$PGHOST PGUSER=$PGUSER PGDATABASE=$PGDATABASE psql -c \"select launchpad_handle from app_user where email='solutions-qa@lists.canonical.com'\"" \
-    | grep oil-ci-bot
+  # For some reason, it's possible that the relation data isn't fully propagated by the time we run this command,
+  # even though the application is active. So we retry it a few times with a delay.
+  for i in {1..3}; do
+    if juju ssh --container postgresql db/leader \
+      "PGPASSWORD=$PGPASSWORD PGHOST=$PGHOST PGUSER=$PGUSER PGDATABASE=$PGDATABASE psql -c \"select launchpad_handle from app_user where email='solutions-qa@lists.canonical.com'\"" \
+      | grep oil-ci-bot; then
+      break
+    fi
+    if [ "$i" -eq 3 ]; then
+      echo "Failed to find oil-ci-bot after 3 attempts"
+      exit 1
+    fi
+    sleep 30
+  done
 
 artifacts:
   - juju-k8s-crashdump.tar.gz

--- a/spread/integration/task.yaml
+++ b/spread/integration/task.yaml
@@ -34,6 +34,7 @@ execute: |
   juju deploy "${SPREAD_PATH}"/backend/charm/*.charm backend \
     --config hostname=test-observer-api.test \
     --config sessions_secret="$(openssl rand -base64 32)" \
+    --config metrics_init_enabled=false \
     --resource api-image="${backend_oci_image}"
   juju deploy "${SPREAD_PATH}"/frontend/charm/*.charm frontend \
     --config hostname=test-observer-frontend.test \

--- a/spread/integration/task.yaml
+++ b/spread/integration/task.yaml
@@ -18,19 +18,16 @@
 summary: Run the charm integration test
 
 execute: |
-  function crashdump() {
-    microk8s config > kube-config
-    pipx run --spec git+https://github.com/canonical/juju-k8s-crashdump.git juju-k8s-crashdump \
-      ./kube-config concierge-microk8s -o juju-k8s-crashdump.tar.gz
-  }
-
-  trap crashdump ERR
-
   backend_oci_image="$(cat "${SPREAD_PATH}"/backend/charm/charmcraft.yaml | yq '.resources.api-image.upstream-source')"
   frontend_oci_image="$(cat "${SPREAD_PATH}"/frontend/charm/charmcraft.yaml | yq '.resources.frontend-image.upstream-source')"
 
   juju deploy --trust postgresql-k8s --channel=14/stable --revision=774 db
   juju deploy redis-k8s --channel=latest/edge --revision=27 redis
+
+  # metrics_init_enabled=false is apparently necessary for the database to initialize correctly
+  # It seems like the metrics server is trying to query while the migrations are still applying,
+  # which causes some silent failure that leaves charms active and idle but the database empty.
+  # As a result, the add-user action fails in this scenario.
   juju deploy "${SPREAD_PATH}"/backend/charm/*.charm backend \
     --config hostname=test-observer-api.test \
     --config sessions_secret="$(openssl rand -base64 32)" \
@@ -41,14 +38,30 @@ execute: |
     --config test-observer-api-scheme='http://' \
     --resource frontend-image="${frontend_oci_image}"
 
-  juju wait-for application db --timeout=10m
+  if ! juju wait-for application db --timeout=10m; then
+    microk8s config > kube-config
+    pipx run --spec git+https://github.com/canonical/juju-k8s-crashdump.git juju-k8s-crashdump \
+      ./kube-config concierge-microk8s -o juju-k8s-crashdump.tar.gz
+    exit 1
+  fi
 
   juju relate backend redis
   juju relate backend db
   juju relate backend frontend
 
-  juju wait-for application backend --timeout=5m
-  juju wait-for application frontend --timeout=5m
+  if ! juju wait-for application backend --timeout=5m; then
+    microk8s config > kube-config
+    pipx run --spec git+https://github.com/canonical/juju-k8s-crashdump.git juju-k8s-crashdump \
+      ./kube-config concierge-microk8s -o juju-k8s-crashdump.tar.gz
+    exit 1
+  fi
+
+  if ! juju wait-for application frontend --timeout=5m; then
+    microk8s config > kube-config
+    pipx run --spec git+https://github.com/canonical/juju-k8s-crashdump.git juju-k8s-crashdump \
+      ./kube-config concierge-microk8s -o juju-k8s-crashdump.tar.gz
+    exit 1
+  fi
 
   juju run backend/leader add-user launchpad-email=solutions-qa@lists.canonical.com
 
@@ -56,20 +69,9 @@ execute: |
   PGHOST=$(juju show-unit db/0 | grep address | tail -n 1 | awk '{print $2;}')
   PGUSER=operator
   PGDATABASE=test_observer_db
-  # For some reason, it's possible that the relation data isn't fully propagated by the time we run this command,
-  # even though the application is active. So we retry it a few times with a delay.
-  for i in {1..3}; do
-    if juju ssh --container postgresql db/leader \
-      "PGPASSWORD=$PGPASSWORD PGHOST=$PGHOST PGUSER=$PGUSER PGDATABASE=$PGDATABASE psql -c \"select launchpad_handle from app_user where email='solutions-qa@lists.canonical.com'\"" \
-      | grep oil-ci-bot; then
-      break
-    fi
-    if [ "$i" -eq 3 ]; then
-      echo "Failed to find oil-ci-bot after 3 attempts"
-      exit 1
-    fi
-    sleep 30
-  done
+  juju ssh --container postgresql db/leader \
+    "PGPASSWORD=$PGPASSWORD PGHOST=$PGHOST PGUSER=$PGUSER PGDATABASE=$PGDATABASE psql -c \"select launchpad_handle from app_user where email='solutions-qa@lists.canonical.com'\"" \
+    | grep oil-ci-bot
 
 artifacts:
   - juju-k8s-crashdump.tar.gz

--- a/spread/integration/task.yaml
+++ b/spread/integration/task.yaml
@@ -18,10 +18,18 @@
 summary: Run the charm integration test
 
 execute: |
+  function crashdump() {
+    microk8s config > kube-config
+    pipx run --spec git+https://github.com/canonical/juju-k8s-crashdump.git juju-k8s-crashdump \
+      ./kube-config concierge-microk8s -o juju-k8s-crashdump.tar.gz
+  }
+
+  trap crashdump ERR
+
   backend_oci_image="$(cat "${SPREAD_PATH}"/backend/charm/charmcraft.yaml | yq '.resources.api-image.upstream-source')"
   frontend_oci_image="$(cat "${SPREAD_PATH}"/frontend/charm/charmcraft.yaml | yq '.resources.frontend-image.upstream-source')"
 
-  juju deploy --trust postgresql-k8s --channel=14/stable --revision=281 db
+  juju deploy --trust postgresql-k8s --channel=14/stable --revision=774 db
   juju deploy redis-k8s --channel=latest/edge --revision=27 redis
   juju deploy "${SPREAD_PATH}"/backend/charm/*.charm backend \
     --config hostname=test-observer-api.test \
@@ -32,30 +40,14 @@ execute: |
     --config test-observer-api-scheme='http://' \
     --resource frontend-image="${frontend_oci_image}"
 
-  if ! juju wait-for application db --timeout=5m; then
-    microk8s config > kube-config
-    pipx run --spec git+https://github.com/canonical/juju-k8s-crashdump.git juju-k8s-crashdump \
-      ./kube-config concierge-microk8s -o juju-k8s-crashdump.tar.gz
-    exit 1
-  fi
+  juju wait-for application db --timeout=10m
 
   juju relate backend redis
   juju relate backend db
   juju relate backend frontend
 
-  if ! juju wait-for application backend --timeout=5m; then
-    microk8s config > kube-config
-    pipx run --spec git+https://github.com/canonical/juju-k8s-crashdump.git juju-k8s-crashdump \
-      ./kube-config concierge-microk8s -o juju-k8s-crashdump.tar.gz
-    exit 1
-  fi
-
-  if ! juju wait-for application frontend --timeout=5m; then
-    microk8s config > kube-config
-    pipx run --spec git+https://github.com/canonical/juju-k8s-crashdump.git juju-k8s-crashdump \
-      ./kube-config concierge-microk8s -o juju-k8s-crashdump.tar.gz
-    exit 1
-  fi
+  juju wait-for application backend --timeout=5m
+  juju wait-for application frontend --timeout=5m
 
   juju run backend/leader add-user launchpad-email=solutions-qa@lists.canonical.com
 


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR attempts to fix some issues that were repeatedly causing the `spread` CI checks to fail in other cases. The core of the fix here seems to be disabling the metrics on the backend charm when deploying. I don't know what was going wrong exactly, but since the metrics are generally the first things that connect to the database, I think they were racing the migrations and erroring, which then for some reason was really messing with the database.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

Spread CI very reliably failing on recent PRs

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

This fixes a test