### PR TITLE
Spread Again

### DIFF
--- a/spread/integration/task.yaml
+++ b/spread/integration/task.yaml
@@ -44,7 +44,10 @@ execute: |
     --config test-observer-api-scheme='http://' \
     --resource frontend-image="${frontend_oci_image}"
 
+  # These two waits are temporary until the charm
+  # is updated to handle the relations and app environment variables more gracefully
   juju wait-for application db --timeout=10m
+  juju wait-for application redis --timeout=10m
 
   juju relate backend db
   juju relate backend redis

--- a/spread/integration/task.yaml
+++ b/spread/integration/task.yaml
@@ -18,7 +18,7 @@
 summary: Run the charm integration test
 
 execute: |
-  set -e
+  set -o pipefail
 
   function crashdump() {
     trap - ERR
@@ -44,13 +44,13 @@ execute: |
     --config test-observer-api-scheme='http://' \
     --resource frontend-image="${frontend_oci_image}"
 
-  # These two waits are temporary until the charm
+  # We seem to need to relate redis before the database until the charm
   # is updated to handle the relations and app environment variables more gracefully
+  juju relate backend redis
+
   juju wait-for application db --timeout=10m
-  juju wait-for application redis --timeout=10m
 
   juju relate backend db
-  juju relate backend redis
   juju relate backend frontend
 
   juju wait-for application backend --timeout=5m

--- a/spread/integration/task.yaml
+++ b/spread/integration/task.yaml
@@ -18,50 +18,40 @@
 summary: Run the charm integration test
 
 execute: |
+  set -e
+
+  function crashdump() {
+    trap - ERR
+
+    microk8s config > kube-config
+    pipx run --spec git+https://github.com/canonical/juju-k8s-crashdump.git juju-k8s-crashdump \
+      ./kube-config concierge-microk8s -o juju-k8s-crashdump.tar.gz
+  }
+
+  trap crashdump ERR
+
   backend_oci_image="$(cat "${SPREAD_PATH}"/backend/charm/charmcraft.yaml | yq '.resources.api-image.upstream-source')"
   frontend_oci_image="$(cat "${SPREAD_PATH}"/frontend/charm/charmcraft.yaml | yq '.resources.frontend-image.upstream-source')"
 
   juju deploy --trust postgresql-k8s --channel=14/stable --revision=774 db
   juju deploy redis-k8s --channel=latest/edge --revision=27 redis
-
-  # metrics_init_enabled=false is apparently necessary for the database to initialize correctly
-  # It seems like the metrics server is trying to query while the migrations are still applying,
-  # which causes some silent failure that leaves charms active and idle but the database empty.
-  # As a result, the add-user action fails in this scenario.
   juju deploy "${SPREAD_PATH}"/backend/charm/*.charm backend \
     --config hostname=test-observer-api.test \
     --config sessions_secret="$(openssl rand -base64 32)" \
-    --config metrics_init_enabled=false \
     --resource api-image="${backend_oci_image}"
   juju deploy "${SPREAD_PATH}"/frontend/charm/*.charm frontend \
     --config hostname=test-observer-frontend.test \
     --config test-observer-api-scheme='http://' \
     --resource frontend-image="${frontend_oci_image}"
 
-  if ! juju wait-for application db --timeout=10m; then
-    microk8s config > kube-config
-    pipx run --spec git+https://github.com/canonical/juju-k8s-crashdump.git juju-k8s-crashdump \
-      ./kube-config concierge-microk8s -o juju-k8s-crashdump.tar.gz
-    exit 1
-  fi
+  juju wait-for application db --timeout=10m
 
-  juju relate backend redis
   juju relate backend db
+  juju relate backend redis
   juju relate backend frontend
 
-  if ! juju wait-for application backend --timeout=5m; then
-    microk8s config > kube-config
-    pipx run --spec git+https://github.com/canonical/juju-k8s-crashdump.git juju-k8s-crashdump \
-      ./kube-config concierge-microk8s -o juju-k8s-crashdump.tar.gz
-    exit 1
-  fi
-
-  if ! juju wait-for application frontend --timeout=5m; then
-    microk8s config > kube-config
-    pipx run --spec git+https://github.com/canonical/juju-k8s-crashdump.git juju-k8s-crashdump \
-      ./kube-config concierge-microk8s -o juju-k8s-crashdump.tar.gz
-    exit 1
-  fi
+  juju wait-for application backend --timeout=5m
+  juju wait-for application frontend --timeout=5m
 
   juju run backend/leader add-user launchpad-email=solutions-qa@lists.canonical.com
 


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This is a follow-up to https://github.com/canonical/test_observer/pull/729, which misidentified the source of the problem. It seems that it's actually a race condition between the redis and database relations, due to how the charm updates the app environment. The charm needs to be updated, but in the meantime, relating to redis first, before waiting for the database, seems to help. I ran the job three times in a row without it failing, so let's hope this works for now.

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

I ran the CI job three times in a row, and it passed all three times. The fail rate was >50% prior to this (maybe closer to 90%), so I think this helps. 