### PR TITLE
[IQA-3600] Add optional authentication requirement to frontend config

### DIFF
--- a/frontend/assets/config.yaml
+++ b/frontend/assets/config.yaml
@@ -1,3 +1,4 @@
+require_authentication: false
 tabs:
   - snaps
   - debs

--- a/frontend/lib/frontend_config.dart
+++ b/frontend/lib/frontend_config.dart
@@ -74,11 +74,13 @@ FrontendConfig parseFrontendConfig(String yamlString) {
   try {
     final decoded = loadYaml(yamlString);
     if (decoded is YamlMap) {
+      final requireAuthentication = decoded['require_authentication'] == true;
+      final tabs = decoded['tabs'] is YamlList
+          ? decoded['tabs'].map((tab) => tab.toString()).toList()
+          : null;
       final config = FrontendConfig(
-        requireAuthentication: decoded['require_authentication'] == true,
-        tabs: (decoded['tabs'] as YamlList?)
-            ?.map((tab) => tab.toString())
-            .toList(),
+        requireAuthentication: requireAuthentication,
+        tabs: tabs,
       );
       return config;
     }

--- a/frontend/lib/frontend_config.dart
+++ b/frontend/lib/frontend_config.dart
@@ -36,57 +36,64 @@
 import 'package:flutter/services.dart';
 import 'package:yaml/yaml.dart';
 
-import 'routing.dart';
+import 'models/family_name.dart';
 
-const _validTabs = {'snaps', 'debs', 'charms', 'images'};
+class FrontendConfig {
+  // Map 'snap' to 'snaps', 'deb' to 'debs', etc
+  static final List<String> _validTabs =
+      FamilyName.values.map((family) => '${family.name}s').toList();
 
-List<String> configuredTabs = [
-  AppRoutes.snaps,
-  AppRoutes.debs,
-  AppRoutes.charms,
-  AppRoutes.images,
-];
+  final bool requireAuthentication;
+  final List<String> tabs;
 
-String familyDisplayName(String route) {
-  switch (route) {
-    case AppRoutes.snaps:
-      return 'Snap Testing';
-    case AppRoutes.debs:
-      return 'Deb Testing';
-    case AppRoutes.charms:
-      return 'Charm Testing';
-    case AppRoutes.images:
-      return 'Image Testing';
-    default:
-      return '';
+  FrontendConfig._internal({
+    required this.requireAuthentication,
+    required this.tabs,
+  });
+
+  factory FrontendConfig({
+    bool requireAuthentication = false,
+    List<String>? tabs,
+  }) {
+    final bool tabsAreValid =
+        tabs != null && tabs.every((tab) => _validTabs.contains(tab));
+
+    // Default to the full set of valid tabs if the provided tabs are invalid or null
+    return FrontendConfig._internal(
+      requireAuthentication: requireAuthentication,
+      tabs: tabsAreValid ? tabs : _validTabs,
+    );
   }
 }
 
-List<String>? parseFrontendConfig(String yamlString) {
+// This gets loaded at runtime in main.dart
+late FrontendConfig frontendConfig;
+
+FrontendConfig parseFrontendConfig(String yamlString) {
   try {
     final decoded = loadYaml(yamlString);
-    if (decoded is! YamlMap) return null;
-
-    final tabs = decoded['tabs'];
-    if (tabs is! YamlList || tabs.isEmpty) return null;
-
-    final tabStrings = tabs.cast<String>();
-    if (!tabStrings.every((t) => _validTabs.contains(t))) return null;
-
-    return tabStrings.map<String>((t) => '/$t').toList();
-  } catch (_) {
-    return null;
-  }
-}
-
-Future<void> loadFrontendConfig() async {
-  try {
-    final yaml = await rootBundle.loadString('assets/config.yaml');
-    final parsed = parseFrontendConfig(yaml);
-    if (parsed != null) {
-      configuredTabs = parsed;
+    if (decoded is YamlMap) {
+      final config = FrontendConfig(
+        requireAuthentication: decoded['require_authentication'] == true,
+        tabs: (decoded['tabs'] as YamlList?)
+            ?.map((tab) => tab.toString())
+            .toList(),
+      );
+      return config;
     }
   } catch (_) {
+    // Fall through to default
+  }
+  return FrontendConfig();
+}
+
+Future<FrontendConfig> loadFrontendConfig() async {
+  try {
+    final yaml = await rootBundle.loadString('assets/config.yaml');
+    final config = parseFrontendConfig(yaml);
+    return config;
+  } catch (_) {
     // Keep default config
+    return FrontendConfig();
   }
 }

--- a/frontend/lib/frontend_config.dart
+++ b/frontend/lib/frontend_config.dart
@@ -55,13 +55,13 @@ class FrontendConfig {
     bool requireAuthentication = false,
     List<String>? tabs,
   }) {
-    final bool tabsAreValid =
-        tabs != null && tabs.every((tab) => _validTabs.contains(tab));
-
     // Default to the full set of valid tabs if the provided tabs are invalid or null
+    tabs =
+        (tabs != null && tabs.every(_validTabs.contains)) ? tabs : _validTabs;
+
     return FrontendConfig._internal(
       requireAuthentication: requireAuthentication,
-      tabs: tabsAreValid ? tabs : _validTabs,
+      tabs: List.unmodifiable(tabs),
     );
   }
 }

--- a/frontend/lib/frontend_config.dart
+++ b/frontend/lib/frontend_config.dart
@@ -66,8 +66,9 @@ class FrontendConfig {
   }
 }
 
-// This gets loaded at runtime in main.dart
-late FrontendConfig frontendConfig;
+// The actual YAML will get loaded at runtime in main.dart,
+// but we initialize with the default
+FrontendConfig frontendConfig = FrontendConfig();
 
 FrontendConfig parseFrontendConfig(String yamlString) {
   try {

--- a/frontend/lib/frontend_config.dart
+++ b/frontend/lib/frontend_config.dart
@@ -55,7 +55,9 @@ class FrontendConfig {
     bool requireAuthentication = false,
     List<String>? tabs,
   }) {
-    // Default to the full set of valid tabs if the provided tabs are invalid or null
+    // Default to the full set of valid tabs if the provided tabs are null
+    // or contain invalid values. An empty list is considered valid and can
+    // be used to hide all tabs
     tabs =
         (tabs != null && tabs.every(_validTabs.contains)) ? tabs : _validTabs;
 
@@ -76,7 +78,7 @@ FrontendConfig parseFrontendConfig(String yamlString) {
     if (decoded is YamlMap) {
       final requireAuthentication = decoded['require_authentication'] == true;
       final tabs = decoded['tabs'] is YamlList
-          ? decoded['tabs'].map((tab) => tab.toString()).toList()
+          ? decoded['tabs'].map<String>((tab) => tab.toString()).toList()
           : null;
       final config = FrontendConfig(
         requireAuthentication: requireAuthentication,

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -21,6 +21,6 @@ import 'frontend_config.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await loadFrontendConfig();
+  frontendConfig = await loadFrontendConfig();
   runApp(const ProviderScope(child: App()));
 }

--- a/frontend/lib/routing.dart
+++ b/frontend/lib/routing.dart
@@ -29,7 +29,9 @@ import 'ui/test_results_page/test_results_page.dart';
 
 final appRouter = GoRouter(
   routes: [
-    GoRoute(path: '/', redirect: (context, state) => configuredTabs.first),
+    GoRoute(
+        path: '/',
+        redirect: (context, state) => '/${frontendConfig.tabs.first}'),
     ShellRoute(
       builder: (_, __, dashboard) => Skeleton(
         body: dashboard,

--- a/frontend/lib/routing.dart
+++ b/frontend/lib/routing.dart
@@ -30,8 +30,9 @@ import 'ui/test_results_page/test_results_page.dart';
 final appRouter = GoRouter(
   routes: [
     GoRoute(
-        path: '/',
-        redirect: (context, state) => '/${frontendConfig.tabs.first}',),
+      path: '/',
+      redirect: (context, state) => '/${frontendConfig.tabs.first}',
+    ),
     ShellRoute(
       builder: (_, __, dashboard) => Skeleton(
         body: dashboard,

--- a/frontend/lib/routing.dart
+++ b/frontend/lib/routing.dart
@@ -31,7 +31,7 @@ final appRouter = GoRouter(
   routes: [
     GoRoute(
         path: '/',
-        redirect: (context, state) => '/${frontendConfig.tabs.first}'),
+        redirect: (context, state) => '/${frontendConfig.tabs.first}',),
     ShellRoute(
       builder: (_, __, dashboard) => Skeleton(
         body: dashboard,

--- a/frontend/lib/routing.dart
+++ b/frontend/lib/routing.dart
@@ -31,7 +31,9 @@ final appRouter = GoRouter(
   routes: [
     GoRoute(
       path: '/',
-      redirect: (context, state) => '/${frontendConfig.tabs.first}',
+      redirect: (context, state) => frontendConfig.tabs.isNotEmpty
+          ? '/${frontendConfig.tabs.first}'
+          : AppRoutes.testResults,
     ),
     ShellRoute(
       builder: (_, __, dashboard) => Skeleton(

--- a/frontend/lib/ui/navbar.dart
+++ b/frontend/lib/ui/navbar.dart
@@ -33,7 +33,7 @@ TextStyle? _navbarTextStyle(BuildContext context) {
   return Theme.of(context).textTheme.titleMedium?.apply(color: Colors.white);
 }
 
-String tabDisplayName(String tab) {
+String _tabDisplayName(String tab) {
   return switch (tab) {
     'snaps' => 'Snap Testing',
     'debs' => 'Deb Testing',
@@ -86,7 +86,7 @@ class Navbar extends ConsumerWidget {
                 children: [
                   ...frontendConfig.tabs.map(
                     (tab) => _NavbarEntry(
-                      title: tabDisplayName(tab),
+                      title: _tabDisplayName(tab),
                       route: '/$tab',
                     ),
                   ),

--- a/frontend/lib/ui/navbar.dart
+++ b/frontend/lib/ui/navbar.dart
@@ -33,6 +33,16 @@ TextStyle? _navbarTextStyle(BuildContext context) {
   return Theme.of(context).textTheme.titleMedium?.apply(color: Colors.white);
 }
 
+String tabDisplayName(String tab) {
+  return switch (tab) {
+    'snaps' => 'Snap Testing',
+    'debs' => 'Deb Testing',
+    'charms' => 'Charm Testing',
+    'images' => 'Image Testing',
+    _ => tab,
+  };
+}
+
 class Navbar extends ConsumerWidget {
   const Navbar({super.key});
 
@@ -74,10 +84,10 @@ class Navbar extends ConsumerWidget {
             Expanded(
               child: Row(
                 children: [
-                  ...configuredTabs.map(
-                    (route) => _NavbarEntry(
-                      title: familyDisplayName(route),
-                      route: route,
+                  ...frontendConfig.tabs.map(
+                    (tab) => _NavbarEntry(
+                      title: tabDisplayName(tab),
+                      route: '/$tab',
                     ),
                   ),
                   const Spacer(),

--- a/frontend/test/frontend_config_test.dart
+++ b/frontend/test/frontend_config_test.dart
@@ -111,5 +111,13 @@ void main() {
       expect(config.requireAuthentication, isTrue);
       expect(config.tabs, ['images']);
     });
+
+    test('preserves require_authentication when tabs has an invalid type', () {
+      final config = parseFrontendConfig(
+        'require_authentication: true\ntabs: snaps',
+      );
+      expect(config.requireAuthentication, isTrue);
+      expect(config.tabs, allTabs);
+    });
   });
 }

--- a/frontend/test/frontend_config_test.dart
+++ b/frontend/test/frontend_config_test.dart
@@ -15,51 +15,101 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:testcase_dashboard/frontend_config.dart';
+import 'package:testcase_dashboard/models/family_name.dart';
 
 void main() {
   group('parseFrontendConfig', () {
+    final allTabs =
+        FamilyName.values.map((family) => '${family.name}s').toList();
+
+    test('defaults for empty config', () {
+      final config = parseFrontendConfig('');
+
+      expect(config.requireAuthentication, isFalse);
+      expect(config.tabs, allTabs);
+    });
+
+    test('parses complete config', () {
+      final config = parseFrontendConfig(
+        'require_authentication: true\ntabs:\n  - snaps\n  - debs',
+      );
+
+      expect(config.requireAuthentication, isTrue);
+      expect(config.tabs, ['snaps', 'debs']);
+    });
+
+    test('parses only require_authentication', () {
+      final config = parseFrontendConfig('require_authentication: true');
+
+      expect(config.requireAuthentication, isTrue);
+      expect(config.tabs, allTabs);
+    });
+
     test('parses valid single tab', () {
-      expect(parseFrontendConfig('tabs:\n  - images'), ['/images']);
+      final config = parseFrontendConfig('tabs:\n  - images');
+
+      expect(config.requireAuthentication, isFalse);
+      expect(config.tabs, ['images']);
     });
 
     test('parses valid multiple tabs', () {
-      expect(
-        parseFrontendConfig(
-          'tabs:\n  - snaps\n  - debs\n  - charms\n  - images',
-        ),
-        ['/snaps', '/debs', '/charms', '/images'],
+      final config = parseFrontendConfig(
+        'tabs:\n  - snaps\n  - debs\n  - charms\n  - images',
       );
+
+      expect(config.requireAuthentication, isFalse);
+      expect(config.tabs, ['snaps', 'debs', 'charms', 'images']);
     });
 
-    test('returns null for malformed YAML', () {
-      expect(parseFrontendConfig(': [invalid'), isNull);
+    test('defaults for malformed YAML', () {
+      final config = parseFrontendConfig(': [invalid');
+
+      expect(config.requireAuthentication, isFalse);
+      expect(config.tabs, allTabs);
     });
 
-    test('returns null for invalid family name', () {
-      expect(parseFrontendConfig('tabs:\n  - foo'), isNull);
+    test('defaults for invalid family name', () {
+      final config = parseFrontendConfig('tabs:\n  - foo');
+
+      expect(config.requireAuthentication, isFalse);
+      expect(config.tabs, allTabs);
     });
 
-    test('returns null for empty tabs array', () {
-      expect(parseFrontendConfig('tabs: []'), isNull);
+    test('accepts empty tabs array', () {
+      final config = parseFrontendConfig('tabs: []');
+
+      expect(config.requireAuthentication, isFalse);
+      expect(config.tabs, <String>[]);
     });
 
-    test('returns null for plain list YAML', () {
-      expect(parseFrontendConfig('- images'), isNull);
+    test('defaults for plain list YAML', () {
+      final config = parseFrontendConfig('- images');
+
+      expect(config.requireAuthentication, isFalse);
+      expect(config.tabs, allTabs);
     });
 
-    test('returns null for missing tabs key', () {
-      expect(parseFrontendConfig('other:\n  - images'), isNull);
+    test('defaults tabs for missing tabs key', () {
+      final config = parseFrontendConfig('other:\n  - images');
+
+      expect(config.requireAuthentication, isFalse);
+      expect(config.tabs, allTabs);
     });
 
-    test('returns null when any entry is invalid', () {
-      expect(parseFrontendConfig('tabs:\n  - images\n  - invalid'), isNull);
+    test('defaults tabs when any entry is invalid', () {
+      final config = parseFrontendConfig('tabs:\n  - images\n  - invalid');
+
+      expect(config.requireAuthentication, isFalse);
+      expect(config.tabs, allTabs);
     });
 
-    test('parses subset of tabs', () {
-      expect(
-        parseFrontendConfig('tabs:\n  - snaps\n  - images'),
-        ['/snaps', '/images'],
+    test('parses require_authentication', () {
+      final config = parseFrontendConfig(
+        'require_authentication: true\ntabs:\n  - images',
       );
+
+      expect(config.requireAuthentication, isTrue);
+      expect(config.tabs, ['images']);
     });
   });
 }


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR updates the handling of the frontend config so that the config YAML can now also include a `require_authentication` field. To do so, it adds a new `FrontendConfig` class and tweaks some of the existing handling around the tabs. If a config with `tabs` explicitly set to an empty list is provided, the default page becomes the Test Results/search page.

Note that nothing uses the `require_authentication` option yet. That will be implemented in a future PR.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

IQA-3600

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Tests are updated to account for the new class structure. Some additional tests are added.