### PR TITLE
[IQA-3368] Add config-controlled login page

### DIFF
--- a/frontend/lib/helpers.dart
+++ b/frontend/lib/helpers.dart
@@ -42,7 +42,10 @@ String sanitizeReturnPath(String? returnPath) {
   }
 
   final uri = Uri.tryParse(returnPath);
-  if (uri == null || uri.hasScheme || uri.hasAuthority || !uri.path.startsWith('/')) {
+  if (uri == null ||
+      uri.hasScheme ||
+      uri.hasAuthority ||
+      !uri.path.startsWith('/')) {
     return '/';
   }
 

--- a/frontend/lib/helpers.dart
+++ b/frontend/lib/helpers.dart
@@ -29,3 +29,22 @@ String? validateIssueUrl(String? url) {
   }
   return null;
 }
+
+String sanitizeReturnPath(String? returnPath) {
+  if (returnPath == null || !returnPath.startsWith('/')) {
+    return '/';
+  }
+
+  // Reject protocol-relative paths (e.g. //example.com/path), which can
+  // otherwise resolve to an external URL in path-based routing.
+  if (returnPath.startsWith('//')) {
+    return '/';
+  }
+
+  final uri = Uri.tryParse(returnPath);
+  if (uri == null || uri.hasScheme || uri.hasAuthority || !uri.path.startsWith('/')) {
+    return '/';
+  }
+
+  return returnPath;
+}

--- a/frontend/lib/providers/api.dart
+++ b/frontend/lib/providers/api.dart
@@ -15,43 +15,21 @@
 
 // ignore_for_file: avoid_web_libraries_in_flutter
 
-import 'dart:js_interop';
-import 'dart:js_interop_unsafe';
-
-import 'package:web/web.dart' as web;
-
-import 'package:dio/dio.dart';
-import 'package:dio_smart_retry/dio_smart_retry.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../utils/dio.dart';
 import '../repositories/api_repository.dart';
 import 'global_error_message.dart';
 
 part 'api.g.dart';
 
-final apiUrl = web.window.getProperty('testObserverAPIBaseURI'.toJS).toString();
-
 @riverpod
 ApiRepository api(Ref ref) {
-  final dio = Dio(BaseOptions(baseUrl: apiUrl));
-  // Send cookies with requests
-  dio.options.extra['withCredentials'] = true;
-  dio.options.headers['X-CSRF-Token'] = '1';
-  dio.interceptors.add(RetryInterceptor(dio: dio));
-  dio.interceptors.add(
-    InterceptorsWrapper(
-      onError: (e, handler) {
-        final errorDetails = e.response?.data?['detail'];
-        if (errorDetails != null) {
-          ref
-              .read(globalErrorMessageProvider.notifier)
-              .set(errorDetails.toString());
-        } else {
-          return handler.next(e);
-        }
-      },
-    ),
+  final dio = createConfiguredDio(
+    onErrorDetails: (details) {
+      ref.read(globalErrorMessageProvider.notifier).set(details);
+    },
   );
   return ApiRepository(dio: dio);
 }

--- a/frontend/lib/providers/api.dart
+++ b/frontend/lib/providers/api.dart
@@ -13,8 +13,6 @@
 // SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
 // SPDX-License-Identifier: GPL-3.0-only
 
-// ignore_for_file: avoid_web_libraries_in_flutter
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 

--- a/frontend/lib/routing.dart
+++ b/frontend/lib/routing.dart
@@ -15,13 +15,11 @@
 
 import 'package:dartx/dartx.dart';
 import 'package:dio/dio.dart';
-import 'package:dio_smart_retry/dio_smart_retry.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import 'models/family_name.dart';
 import 'frontend_config.dart';
-import 'providers/api.dart';
 import 'ui/artefact_page/artefact_page.dart';
 import 'ui/dashboard/dashboard.dart';
 import 'ui/issue_page/issue_page.dart';
@@ -30,16 +28,12 @@ import 'ui/login.dart';
 import 'ui/notifications_page/notifications_page.dart';
 import 'ui/skeleton.dart';
 import 'ui/test_results_page/test_results_page.dart';
+import 'utils/dio.dart';
 
-final _authCheckDio = _createAuthCheckDio();
-
-Dio _createAuthCheckDio() {
-  final dio = Dio(BaseOptions(baseUrl: apiUrl));
-  dio.options.extra['withCredentials'] = true;
-  dio.options.headers['X-CSRF-Token'] = '1';
-  dio.interceptors.add(RetryInterceptor(dio: dio));
-  return dio;
-}
+// We create a separate Dio instance for auth checks
+// because routing runs outside a Riverpod provider context,
+// unlike the general API provider
+final _authCheckDio = createConfiguredDio();
 
 final appRouter = GoRouter(
   redirect: (context, state) async {
@@ -168,13 +162,9 @@ Future<bool> _isUserAuthenticated() async {
   try {
     final response = await _authCheckDio.get('/v1/users/me');
     return response.data != null;
-  } on DioException catch (error) {
-    if (error.response?.statusCode == 401) {
-      return false;
-    }
-
-    // Avoid trapping users on the login page for transient backend failures.
-    return true;
+  } on DioException catch (_) {
+    // Fail closed: if auth status cannot be determined, treat as unauthenticated.
+    return false;
   }
 }
 

--- a/frontend/lib/routing.dart
+++ b/frontend/lib/routing.dart
@@ -42,6 +42,8 @@ final appRouter = GoRouter(
       return null;
     }
 
+    // This will make a network request to the backend API every time
+    // a redirect is evaluated. If this becomes an issue, we can consider caching the auth status
     final isAuthenticated = await _isUserAuthenticated();
 
     return getAuthenticationRedirect(

--- a/frontend/lib/routing.dart
+++ b/frontend/lib/routing.dart
@@ -14,21 +14,58 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import 'package:dartx/dartx.dart';
+import 'package:dio/dio.dart';
+import 'package:dio_smart_retry/dio_smart_retry.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import 'models/family_name.dart';
 import 'frontend_config.dart';
+import 'providers/api.dart';
 import 'ui/artefact_page/artefact_page.dart';
 import 'ui/dashboard/dashboard.dart';
 import 'ui/issue_page/issue_page.dart';
 import 'ui/issues_page/issues_page.dart';
+import 'ui/login.dart';
 import 'ui/notifications_page/notifications_page.dart';
 import 'ui/skeleton.dart';
 import 'ui/test_results_page/test_results_page.dart';
 
+final _authCheckDio = _createAuthCheckDio();
+
+Dio _createAuthCheckDio() {
+  final dio = Dio(BaseOptions(baseUrl: apiUrl));
+  dio.options.extra['withCredentials'] = true;
+  dio.options.headers['X-CSRF-Token'] = '1';
+  dio.interceptors.add(RetryInterceptor(dio: dio));
+  return dio;
+}
+
 final appRouter = GoRouter(
+  redirect: (context, state) async {
+    if (!frontendConfig.requireAuthentication) {
+      return null;
+    }
+
+    final isAuthenticated = await _isUserAuthenticated();
+
+    return getAuthenticationRedirect(
+      requireAuthentication: frontendConfig.requireAuthentication,
+      isAuthenticated: isAuthenticated,
+      destinationUri: state.uri,
+    );
+  },
   routes: [
+    GoRoute(
+      path: AppRoutes.login,
+      pageBuilder: (_, state) => NoTransitionPage(
+        child: LoginPromptPage(
+          returnTo: _sanitizeInternalReturnTo(
+            state.uri.queryParameters[AppRoutes.returnToQueryParameter],
+          ),
+        ),
+      ),
+    ),
     GoRoute(
       path: '/',
       redirect: (context, state) => frontendConfig.tabs.isNotEmpty
@@ -127,6 +164,61 @@ final appRouter = GoRouter(
   ],
 );
 
+Future<bool> _isUserAuthenticated() async {
+  try {
+    final response = await _authCheckDio.get('/v1/users/me');
+    return response.data != null;
+  } on DioException catch (error) {
+    if (error.response?.statusCode == 401) {
+      return false;
+    }
+
+    // Avoid trapping users on the login page for transient backend failures.
+    return true;
+  }
+}
+
+String? getAuthenticationRedirect({
+  required bool requireAuthentication,
+  required bool isAuthenticated,
+  required Uri destinationUri,
+}) {
+  if (!requireAuthentication) {
+    return null;
+  }
+
+  if (!isAuthenticated && destinationUri.path != AppRoutes.login) {
+    final localReturnTo = destinationUri.toString();
+    return Uri(
+      path: AppRoutes.login,
+      queryParameters: {
+        AppRoutes.returnToQueryParameter: localReturnTo,
+      },
+    ).toString();
+  }
+
+  if (isAuthenticated && destinationUri.path == AppRoutes.login) {
+    return _sanitizeInternalReturnTo(
+          destinationUri.queryParameters[AppRoutes.returnToQueryParameter],
+        ) ??
+        '/';
+  }
+
+  return null;
+}
+
+String? _sanitizeInternalReturnTo(String? returnTo) {
+  if (returnTo == null || returnTo.isEmpty) {
+    return null;
+  }
+
+  if (!returnTo.startsWith('/')) {
+    return null;
+  }
+
+  return returnTo;
+}
+
 enum SortDirection {
   asc,
   desc,
@@ -139,7 +231,10 @@ class CommonQueryParameters {
   static const attachmentRule = 'attachmentRule';
 }
 
+// TODO: Remove family-specific routes
 class AppRoutes {
+  static const login = '/login';
+  static const returnToQueryParameter = 'returnTo';
   static const snaps = '/snaps';
   static const debs = '/debs';
   static const charms = '/charms';

--- a/frontend/lib/routing.dart
+++ b/frontend/lib/routing.dart
@@ -18,6 +18,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import 'helpers.dart';
 import 'models/family_name.dart';
 import 'frontend_config.dart';
 import 'ui/artefact_page/artefact_page.dart';
@@ -54,7 +55,7 @@ final appRouter = GoRouter(
       path: AppRoutes.login,
       pageBuilder: (_, state) => NoTransitionPage(
         child: LoginPromptPage(
-          returnTo: _sanitizeInternalReturnTo(
+          returnTo: sanitizeReturnPath(
             state.uri.queryParameters[AppRoutes.returnToQueryParameter],
           ),
         ),
@@ -188,25 +189,12 @@ String? getAuthenticationRedirect({
   }
 
   if (isAuthenticated && destinationUri.path == AppRoutes.login) {
-    return _sanitizeInternalReturnTo(
-          destinationUri.queryParameters[AppRoutes.returnToQueryParameter],
-        ) ??
-        '/';
+    return sanitizeReturnPath(
+      destinationUri.queryParameters[AppRoutes.returnToQueryParameter],
+    );
   }
 
   return null;
-}
-
-String? _sanitizeInternalReturnTo(String? returnTo) {
-  if (returnTo == null || returnTo.isEmpty) {
-    return null;
-  }
-
-  if (!returnTo.startsWith('/')) {
-    return null;
-  }
-
-  return returnTo;
 }
 
 enum SortDirection {

--- a/frontend/lib/ui/login.dart
+++ b/frontend/lib/ui/login.dart
@@ -16,7 +16,7 @@
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
-import '../providers/api.dart';
+import '../utils/dio.dart';
 
 class LoginPromptPage extends StatelessWidget {
   const LoginPromptPage({super.key, this.returnTo});
@@ -73,8 +73,7 @@ class LoginPromptPage extends StatelessWidget {
   }
 
   String _resolvedReturnTo() {
-    final localPath =
-        returnTo != null && returnTo!.startsWith('/') ? returnTo! : '/';
+    final localPath = sanitizeFrontendReturnPath(returnTo);
     return buildFrontendReturnToUrl(
       baseUri: Uri.base,
       localPath: localPath,
@@ -82,11 +81,30 @@ class LoginPromptPage extends StatelessWidget {
   }
 }
 
+String sanitizeFrontendReturnPath(String? returnPath) {
+  if (returnPath == null || !returnPath.startsWith('/')) {
+    return '/';
+  }
+
+  // Reject protocol-relative paths (e.g. //example.com/path), which can
+  // otherwise resolve to an external URL in path-based routing.
+  if (returnPath.startsWith('//')) {
+    return '/';
+  }
+
+  final uri = Uri.tryParse(returnPath);
+  if (uri == null || uri.hasScheme || uri.hasAuthority) {
+    return '/';
+  }
+
+  return returnPath;
+}
+
 String buildFrontendReturnToUrl({
   required Uri baseUri,
   required String localPath,
 }) {
-  final normalizedPath = localPath.startsWith('/') ? localPath : '/';
+  final normalizedPath = sanitizeFrontendReturnPath(localPath);
 
   // Flutter web uses hash URLs by default (e.g. /#/route). In that case,
   // return_to must keep the destination inside the fragment.

--- a/frontend/lib/ui/login.dart
+++ b/frontend/lib/ui/login.dart
@@ -16,6 +16,7 @@
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
+import '../helpers.dart';
 import '../utils/dio.dart';
 
 class LoginPromptPage extends StatelessWidget {
@@ -73,7 +74,7 @@ class LoginPromptPage extends StatelessWidget {
   }
 
   String _resolvedReturnTo() {
-    final localPath = sanitizeFrontendReturnPath(returnTo);
+    final localPath = sanitizeReturnPath(returnTo);
     return buildFrontendReturnToUrl(
       baseUri: Uri.base,
       localPath: localPath,
@@ -81,30 +82,11 @@ class LoginPromptPage extends StatelessWidget {
   }
 }
 
-String sanitizeFrontendReturnPath(String? returnPath) {
-  if (returnPath == null || !returnPath.startsWith('/')) {
-    return '/';
-  }
-
-  // Reject protocol-relative paths (e.g. //example.com/path), which can
-  // otherwise resolve to an external URL in path-based routing.
-  if (returnPath.startsWith('//')) {
-    return '/';
-  }
-
-  final uri = Uri.tryParse(returnPath);
-  if (uri == null || uri.hasScheme || uri.hasAuthority) {
-    return '/';
-  }
-
-  return returnPath;
-}
-
 String buildFrontendReturnToUrl({
   required Uri baseUri,
   required String localPath,
 }) {
-  final normalizedPath = sanitizeFrontendReturnPath(localPath);
+  final normalizedPath = sanitizeReturnPath(localPath);
 
   // Flutter web uses hash URLs by default (e.g. /#/route). In that case,
   // return_to must keep the destination inside the fragment.

--- a/frontend/lib/ui/login.dart
+++ b/frontend/lib/ui/login.dart
@@ -1,0 +1,100 @@
+// Copyright 2026 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher_string.dart';
+
+import '../providers/api.dart';
+
+class LoginPromptPage extends StatelessWidget {
+  const LoginPromptPage({super.key, this.returnTo});
+
+  final String? returnTo;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 420),
+          child: Card(
+            margin: const EdgeInsets.all(24),
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Login required',
+                    style: Theme.of(context).textTheme.headlineSmall,
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    'You need to log in before accessing this page.',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 24),
+                  FilledButton(
+                    onPressed: () {
+                      final uri = Uri.parse(apiUrl);
+                      final target = _resolvedReturnTo();
+                      final loginUri = uri.replace(
+                        path: '/v1/auth/saml/login',
+                        queryParameters: {'return_to': target},
+                      );
+
+                      launchUrlString(
+                        loginUri.toString(),
+                        webOnlyWindowName: '_self',
+                      );
+                    },
+                    child: const Text('Log in'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _resolvedReturnTo() {
+    final localPath =
+        returnTo != null && returnTo!.startsWith('/') ? returnTo! : '/';
+    return buildFrontendReturnToUrl(
+      baseUri: Uri.base,
+      localPath: localPath,
+    );
+  }
+}
+
+String buildFrontendReturnToUrl({
+  required Uri baseUri,
+  required String localPath,
+}) {
+  final normalizedPath = localPath.startsWith('/') ? localPath : '/';
+
+  // Flutter web uses hash URLs by default (e.g. /#/route). In that case,
+  // return_to must keep the destination inside the fragment.
+  if (baseUri.fragment.startsWith('/')) {
+    return baseUri
+        .replace(path: '/', queryParameters: null, fragment: normalizedPath)
+        .toString();
+  }
+
+  return baseUri.resolve(normalizedPath).toString();
+}

--- a/frontend/lib/ui/login.dart
+++ b/frontend/lib/ui/login.dart
@@ -99,5 +99,10 @@ String buildFrontendReturnToUrl({
         .toString();
   }
 
-  return baseUri.resolve(normalizedPath).toString();
+  // For path-based routing, preserve any non-root deployment prefix from the
+  // current URL (for example `/app/`) by resolving an app-local relative path
+  // instead of an origin-absolute one.
+  final relativePath =
+      normalizedPath == '/' ? '.' : normalizedPath.substring(1);
+  return baseUri.resolve(relativePath).toString();
 }

--- a/frontend/lib/ui/login.dart
+++ b/frontend/lib/ui/login.dart
@@ -92,7 +92,10 @@ String buildFrontendReturnToUrl({
   // return_to must keep the destination inside the fragment.
   if (baseUri.fragment.startsWith('/')) {
     return baseUri
-        .replace(path: '/', queryParameters: null, fragment: normalizedPath)
+        .replace(
+          queryParameters: null,
+          fragment: normalizedPath,
+        )
         .toString();
   }
 

--- a/frontend/lib/ui/navbar.dart
+++ b/frontend/lib/ui/navbar.dart
@@ -19,12 +19,12 @@ import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 import 'package:yaru/yaru.dart';
 
-import '../providers/api.dart';
 import '../providers/current_user.dart';
 import '../providers/notifications.dart';
 import '../routing.dart';
 import '../frontend_config.dart';
 import 'spacing.dart';
+import '../utils/dio.dart';
 
 const _navbarHeight = 57.0;
 final _navbarSelectedColor = YaruColors.titleBarDark.scale(lightness: 0.07);

--- a/frontend/lib/utils/dio.dart
+++ b/frontend/lib/utils/dio.dart
@@ -1,0 +1,48 @@
+// Copyright 2026 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:dio/dio.dart';
+import 'package:dio_smart_retry/dio_smart_retry.dart';
+import 'package:web/web.dart' as web;
+
+final apiUrl = web.window.getProperty('testObserverAPIBaseURI'.toJS).toString();
+
+Dio createConfiguredDio({void Function(String errorDetails)? onErrorDetails}) {
+  final dio = Dio(BaseOptions(baseUrl: apiUrl));
+  // Send cookies with requests
+  dio.options.extra['withCredentials'] = true;
+  dio.options.headers['X-CSRF-Token'] = '1';
+  dio.interceptors.add(RetryInterceptor(dio: dio));
+
+  if (onErrorDetails != null) {
+    dio.interceptors.add(
+      InterceptorsWrapper(
+        onError: (e, handler) {
+          final errorDetails = e.response?.data?['detail'];
+          if (errorDetails != null) {
+            onErrorDetails(errorDetails.toString());
+          } else {
+            return handler.next(e);
+          }
+        },
+      ),
+    );
+  }
+
+  return dio;
+}

--- a/frontend/lib/utils/dio.dart
+++ b/frontend/lib/utils/dio.dart
@@ -13,6 +13,8 @@
 // SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
 // SPDX-License-Identifier: GPL-3.0-only
 
+// ignore_for_file: avoid_web_libraries_in_flutter
+
 import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
 
@@ -36,9 +38,8 @@ Dio createConfiguredDio({void Function(String errorDetails)? onErrorDetails}) {
           final errorDetails = e.response?.data?['detail'];
           if (errorDetails != null) {
             onErrorDetails(errorDetails.toString());
-          } else {
-            return handler.next(e);
           }
+          return handler.next(e);
         },
       ),
     );

--- a/frontend/lib/utils/dio.dart
+++ b/frontend/lib/utils/dio.dart
@@ -35,9 +35,12 @@ Dio createConfiguredDio({void Function(String errorDetails)? onErrorDetails}) {
     dio.interceptors.add(
       InterceptorsWrapper(
         onError: (e, handler) {
-          final errorDetails = e.response?.data?['detail'];
-          if (errorDetails != null) {
-            onErrorDetails(errorDetails.toString());
+          final data = e.response?.data;
+          if (data is Map) {
+            final errorDetails = data['detail'];
+            if (errorDetails != null) {
+              onErrorDetails(errorDetails.toString());
+            }
           }
           return handler.next(e);
         },

--- a/frontend/test/routing_test.dart
+++ b/frontend/test/routing_test.dart
@@ -1,0 +1,72 @@
+// Copyright 2026 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:testcase_dashboard/routing.dart';
+
+void main() {
+  group('getAuthenticationRedirect', () {
+    test('returns null when authentication is not required', () {
+      final redirect = getAuthenticationRedirect(
+        requireAuthentication: false,
+        isAuthenticated: false,
+        destinationUri: Uri.parse('/snaps'),
+      );
+
+      expect(redirect, isNull);
+    });
+
+    test('redirects unauthenticated users to login prompt', () {
+      final redirect = getAuthenticationRedirect(
+        requireAuthentication: true,
+        isAuthenticated: false,
+        destinationUri: Uri.parse('/issues'),
+      );
+
+      expect(redirect, '/login?returnTo=%2Fissues');
+    });
+
+    test('does not redirect when already on login prompt', () {
+      final redirect = getAuthenticationRedirect(
+        requireAuthentication: true,
+        isAuthenticated: false,
+        destinationUri: Uri.parse('/login?returnTo=%2Fissues'),
+      );
+
+      expect(redirect, isNull);
+    });
+
+    test('sends authenticated user from login prompt to returnTo path', () {
+      final redirect = getAuthenticationRedirect(
+        requireAuthentication: true,
+        isAuthenticated: true,
+        destinationUri: Uri.parse('/login?returnTo=%2Fnotifications'),
+      );
+
+      expect(redirect, '/notifications');
+    });
+
+    test('drops unsafe returnTo values and redirects to root', () {
+      final redirect = getAuthenticationRedirect(
+        requireAuthentication: true,
+        isAuthenticated: true,
+        destinationUri: Uri.parse('/login?returnTo=https://example.com/path'),
+      );
+
+      expect(redirect, '/');
+    });
+  });
+}

--- a/frontend/test/routing_test.dart
+++ b/frontend/test/routing_test.dart
@@ -68,5 +68,15 @@ void main() {
 
       expect(redirect, '/');
     });
+
+    test('drops protocol-relative returnTo values and redirects to root', () {
+      final redirect = getAuthenticationRedirect(
+        requireAuthentication: true,
+        isAuthenticated: true,
+        destinationUri: Uri.parse('/login?returnTo=%2F%2Fevil.example%2Fpath'),
+      );
+
+      expect(redirect, '/');
+    });
   });
 }

--- a/frontend/test/ui/login_test.dart
+++ b/frontend/test/ui/login_test.dart
@@ -65,6 +65,15 @@ void main() {
 
       expect(returnTo, 'http://localhost:30001/');
     });
+
+    test('preserves non-root base path in hash routing mode', () {
+      final returnTo = buildFrontendReturnToUrl(
+        baseUri: Uri.parse('http://localhost:30001/app/#/login'),
+        localPath: '/test-results',
+      );
+
+      expect(returnTo, 'http://localhost:30001/app/#/test-results');
+    });
   });
 
   group('LoginPromptPage', () {

--- a/frontend/test/ui/login_test.dart
+++ b/frontend/test/ui/login_test.dart
@@ -47,6 +47,24 @@ void main() {
 
       expect(returnTo, 'http://localhost:30001/#/');
     });
+
+    test('falls back to root for protocol-relative path with hash routing', () {
+      final returnTo = buildFrontendReturnToUrl(
+        baseUri: Uri.parse('http://localhost:30001/#/login'),
+        localPath: '//example.com/path',
+      );
+
+      expect(returnTo, 'http://localhost:30001/#/');
+    });
+
+    test('falls back to root for protocol-relative path with path routing', () {
+      final returnTo = buildFrontendReturnToUrl(
+        baseUri: Uri.parse('http://localhost:30001/login'),
+        localPath: '//example.com/path',
+      );
+
+      expect(returnTo, 'http://localhost:30001/');
+    });
   });
 
   group('LoginPromptPage', () {

--- a/frontend/test/ui/login_test.dart
+++ b/frontend/test/ui/login_test.dart
@@ -1,0 +1,79 @@
+// Copyright 2026 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:testcase_dashboard/ui/login.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  group('buildFrontendReturnToUrl', () {
+    test('preserves hash routing when base uri uses fragment routes', () {
+      final returnTo = buildFrontendReturnToUrl(
+        baseUri:
+            Uri.parse('http://localhost:30001/#/login?returnTo=/test-results'),
+        localPath: '/test-results',
+      );
+
+      expect(returnTo, 'http://localhost:30001/#/test-results');
+    });
+
+    test('uses path routing when base uri does not use hash routes', () {
+      final returnTo = buildFrontendReturnToUrl(
+        baseUri:
+            Uri.parse('http://localhost:30001/login?returnTo=/test-results'),
+        localPath: '/test-results',
+      );
+
+      expect(returnTo, 'http://localhost:30001/test-results');
+    });
+
+    test('falls back to root for unsafe local path', () {
+      final returnTo = buildFrontendReturnToUrl(
+        baseUri: Uri.parse('http://localhost:30001/#/login'),
+        localPath: 'https://example.com/escape',
+      );
+
+      expect(returnTo, 'http://localhost:30001/#/');
+    });
+  });
+
+  group('LoginPromptPage', () {
+    testWidgets('renders login prompt content', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: LoginPromptPage(),
+        ),
+      );
+
+      expect(find.text('Login required'), findsOneWidget);
+      expect(
+        find.text('You need to log in before accessing this page.'),
+        findsOneWidget,
+      );
+      expect(find.text('Log in'), findsOneWidget);
+      expect(find.byType(FilledButton), findsOneWidget);
+    });
+
+    testWidgets('accepts an internal returnTo path', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: LoginPromptPage(returnTo: '/test-results'),
+        ),
+      );
+
+      expect(find.byType(LoginPromptPage), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR makes use of the recently-added `require_authentication` config option (https://github.com/canonical/test_observer/pull/732) to detect when a login is required.
If `require_authentication` is true, attempting to access any page of the frontend is redirected to a new login page. Upon logging in, users are redirected back to the page they originally attempted to access.

<img width="2014" height="1094" alt="Screenshot from 2026-05-01 14-05-48" src="https://github.com/user-attachments/assets/c215e9fb-7966-4110-9654-9badadd0887e" />


## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

[IQA-3368]

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Added some unit tests. I also manually tested the desired behavior.

[IQA-3368]: https://warthogs.atlassian.net/browse/IQA-3368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ