### PR TITLE
fix(frontend): make bulk-review env list scrollable above max-height (#736)

### DIFF
--- a/frontend/lib/ui/artefact_page/bulk_environment_review_dialog.dart
+++ b/frontend/lib/ui/artefact_page/bulk_environment_review_dialog.dart
@@ -112,28 +112,34 @@ class _BulkEnvironmentReviewDialogState
                 border: Border.all(color: Colors.grey[300]!),
                 borderRadius: BorderRadius.circular(4),
               ),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  for (var i = 0; i < widget.environments.length; i++) ...[
-                    Padding(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: Spacing.level2,
-                        vertical: Spacing.level1,
-                      ),
-                      child: Align(
-                        alignment: Alignment.centerLeft,
-                        child: Text(
-                          '${widget.environments[i].environment.name} '
-                          '(${widget.environments[i].environment.architecture})',
-                          style: Theme.of(context).textTheme.bodySmall,
+              constraints: const BoxConstraints(maxHeight: 240),
+              child: Scrollbar(
+                thumbVisibility: true,
+                child: SingleChildScrollView(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      for (var i = 0; i < widget.environments.length; i++) ...[
+                        Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: Spacing.level2,
+                            vertical: Spacing.level1,
+                          ),
+                          child: Align(
+                            alignment: Alignment.centerLeft,
+                            child: Text(
+                              '${widget.environments[i].environment.name} '
+                              '(${widget.environments[i].environment.architecture})',
+                              style: Theme.of(context).textTheme.bodySmall,
+                            ),
+                          ),
                         ),
-                      ),
-                    ),
-                    if (i != widget.environments.length - 1)
-                      Divider(height: 1, color: Colors.grey[300]),
-                  ],
-                ],
+                        if (i != widget.environments.length - 1)
+                          Divider(height: 1, color: Colors.grey[300]),
+                      ],
+                    ],
+                  ),
+                ),
               ),
             ),
             const SizedBox(height: Spacing.level4),


### PR DESCRIPTION
Closes #736.

## Problem

`BulkEnvironmentReviewDialog` renders every selected environment in an unbounded `Column` inside the `AlertDialog`. With a large selection (e.g. 129 envs at 4k/100% scale, 50% browser zoom per the reporter's screenshot) the env list overflows the dialog and viewport — there is no scroll affordance and the **Cancel / Submit Reviews** buttons end up below the overflow, so the dialog is effectively unusable without zooming the browser out.

## Fix

Wrap the env list in `Scrollbar` + `SingleChildScrollView` and cap the container at `maxHeight: 240`. Once the list exceeds the cap it scrolls in place; everything else (border, dividers, decision checkboxes, comment field, action buttons) is untouched.

240px is roughly 10-11 rows at the existing `bodySmall` text + `Spacing.level1` vertical padding, which matches `motjuste`'s comment on the issue ("scrollable container of sorts beyond a maximum height").

## Notes

- Behavior with small selections is unchanged — the `Column` still uses `mainAxisSize: MainAxisSize.min` and the constraint only kicks in once content exceeds the cap.
- No frontend widget tests exist for this dialog (`frontend/test/ui/` has no `artefact_page/`), so this PR adds none. Happy to add one if you'd like a separate harness PR.
- DCO sign-off included on the commit.
