### PR TITLE
[IQA-3629] Only run URL docs check if docs are changed

### DIFF
--- a/.github/workflows/check-removed-urls.yml
+++ b/.github/workflows/check-removed-urls.yml
@@ -20,6 +20,9 @@ name: Check for removed URLs
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/check-removed-urls.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR tweaks the workflow that checks the docs for removed URLs to only run when either the `docs/` folder or the workflow itself is modified, rather than always running.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

IQA-3629
