### PR TITLE
Delete renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

This PR deletes the `renovate.json` config, in an attempt to re-onboard renovate, as mentioned in https://github.com/canonical/test_observer/pull/781, and as described in [these docs](https://docs.renovatebot.com/getting-started/installing-onboarding/#nuke-config-and-re-onboard). 

I have already renamed the original PR: https://github.com/canonical/test_observer/pull/2

Renovate's docs are a bit confusing regarding how to properly use presets, so hopefully the onboarding process helps clarify things.
