### PR TITLE
[IQA-3646] Add charm-specific static analysis

### DIFF
--- a/.github/workflows/static-analysis-backend-charm.yml
+++ b/.github/workflows/static-analysis-backend-charm.yml
@@ -45,9 +45,10 @@ jobs:
           python-version: "3.10"
       - run: pip install ruff
       - run: pip install mypy
+      - run: pip install types-requests
       - if: ${{ !cancelled() }}
         run: ruff check
       - if: ${{ !cancelled() }}
         run: ruff format --check
       - if: ${{ !cancelled() }}
-        run: mypy .
+        run: mypy --ignore-missing-imports src

--- a/.github/workflows/static-analysis-backend-charm.yml
+++ b/.github/workflows/static-analysis-backend-charm.yml
@@ -1,3 +1,20 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 name: Static Analysis - Backend Charm
 
 on:
@@ -26,12 +43,11 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.10"
-      - run: pip install uv
-      - run: uv sync --all-groups
-      - run: uv pip install -e .
+      - run: pip install ruff
+      - run: pip install mypy
       - if: ${{ !cancelled() }}
-        run: uv run ruff check
+        run: ruff check
       - if: ${{ !cancelled() }}
-        run: uv run ruff format --check
+        run: ruff format --check
       - if: ${{ !cancelled() }}
-        run: uv run mypy .
+        run: mypy .

--- a/.github/workflows/static-analysis-backend-charm.yml
+++ b/.github/workflows/static-analysis-backend-charm.yml
@@ -1,0 +1,37 @@
+name: Static Analysis - Backend Charm
+
+on:
+  pull_request:
+    paths:
+      - 'backend/charm/**'
+      - '.github/workflows/static-analysis-backend-charm.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  analyze-backend-charm:
+    name: Analyze Backend Charm
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: backend/charm
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.10"
+      - run: pip install uv
+      - run: uv sync --all-groups
+      - run: uv pip install -e .
+      - if: ${{ !cancelled() }}
+        run: uv run ruff check
+      - if: ${{ !cancelled() }}
+        run: uv run ruff format --check
+      - if: ${{ !cancelled() }}
+        run: uv run mypy .

--- a/.github/workflows/static-analysis-backend-charm.yml
+++ b/.github/workflows/static-analysis-backend-charm.yml
@@ -47,8 +47,8 @@ jobs:
       - run: pip install mypy
       - run: pip install types-requests
       - if: ${{ !cancelled() }}
-        run: ruff check
+        run: ruff check src
       - if: ${{ !cancelled() }}
-        run: ruff format --check
+        run: ruff format --check src
       - if: ${{ !cancelled() }}
         run: mypy --ignore-missing-imports src

--- a/.github/workflows/static-analysis-backend.yml
+++ b/.github/workflows/static-analysis-backend.yml
@@ -21,6 +21,7 @@ on:
   pull_request:
     paths:
       - 'backend/**'
+      - '!backend/charm/**'
       - '.github/workflows/static-analysis-backend.yml'
 
 concurrency:

--- a/.github/workflows/static-analysis-frontend-charm.yml
+++ b/.github/workflows/static-analysis-frontend-charm.yml
@@ -46,8 +46,8 @@ jobs:
       - run: pip install ruff
       - run: pip install mypy
       - if: ${{ !cancelled() }}
-        run: ruff check
+        run: ruff check src
       - if: ${{ !cancelled() }}
-        run: ruff format --check
+        run: ruff format --check src
       - if: ${{ !cancelled() }}
         run: mypy --ignore-missing-imports src

--- a/.github/workflows/static-analysis-frontend-charm.yml
+++ b/.github/workflows/static-analysis-frontend-charm.yml
@@ -1,3 +1,20 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 name: Static Analysis - Frontend Charm
 
 on:
@@ -26,12 +43,11 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.10"
-      - run: pip install uv
-      - run: uv sync --all-groups
-      - run: uv pip install -e .
+      - run: pip install ruff
+      - run: pip install mypy
       - if: ${{ !cancelled() }}
-        run: uv run ruff check
+        run: ruff check
       - if: ${{ !cancelled() }}
-        run: uv run ruff format --check
+        run: ruff format --check
       - if: ${{ !cancelled() }}
-        run: uv run mypy .
+        run: mypy .

--- a/.github/workflows/static-analysis-frontend-charm.yml
+++ b/.github/workflows/static-analysis-frontend-charm.yml
@@ -50,4 +50,4 @@ jobs:
       - if: ${{ !cancelled() }}
         run: ruff format --check
       - if: ${{ !cancelled() }}
-        run: mypy .
+        run: mypy --ignore-missing-imports src

--- a/.github/workflows/static-analysis-frontend-charm.yml
+++ b/.github/workflows/static-analysis-frontend-charm.yml
@@ -1,0 +1,37 @@
+name: Static Analysis - Frontend Charm
+
+on:
+  pull_request:
+    paths:
+      - 'frontend/charm/**'
+      - '.github/workflows/static-analysis-frontend-charm.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  analyze-frontend-charm:
+    name: Analyze Frontend Charm
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: frontend/charm
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.10"
+      - run: pip install uv
+      - run: uv sync --all-groups
+      - run: uv pip install -e .
+      - if: ${{ !cancelled() }}
+        run: uv run ruff check
+      - if: ${{ !cancelled() }}
+        run: uv run ruff format --check
+      - if: ${{ !cancelled() }}
+        run: uv run mypy .

--- a/.github/workflows/static-analysis-frontend.yml
+++ b/.github/workflows/static-analysis-frontend.yml
@@ -21,6 +21,7 @@ on:
   pull_request:
     paths:
       - 'frontend/**'
+      - '!frontend/charm/**'
       - '.github/workflows/static-analysis-frontend.yml'
 
 concurrency:

--- a/.github/workflows/test-frontend-charm.yml
+++ b/.github/workflows/test-frontend-charm.yml
@@ -19,15 +19,17 @@ name: Run charm tests
 
 on:
   pull_request:
-    branches:
-      - main
-    paths:
-        - 'frontend/charm/**'
-  push:
-    branches: ["main"]
-    tags: ["v*.*.*"]
     paths:
       - 'frontend/charm/**'
+      - '.github/workflows/test-frontend-charm.yml'
+  push:
+    branches:
+      - main
+    tags: 
+      - 'v*.*.*'
+    paths:
+      - 'frontend/charm/**'
+      - '.github/workflows/test-frontend-charm.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -36,36 +38,6 @@ concurrency:
 permissions: {}
 
 jobs:
-  lint-report:
-    name: Lint and format report
-    runs-on: [self-hosted, linux, large, jammy, x64]
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-      - name: Install tox
-        run: pip install tox
-      - name: Run tests using tox
-        run: tox -e lint
-    defaults:
-      run:
-        working-directory: ./frontend/charm
-
-  static-analysis:
-    name: Static analysis
-    runs-on: [self-hosted, linux, jammy, x64]
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-      - name: Install tox
-        run: pip install tox
-      - name: Run tests using tox
-        run: tox -e static
-    defaults:
-      run:
-        working-directory: ./frontend/charm
-
   unit-tests-with-coverage:
     name: Unit tests
     runs-on: [self-hosted, linux, jammy, x64]

--- a/backend/charm/src/charm.py
+++ b/backend/charm/src/charm.py
@@ -289,7 +289,7 @@ class TestObserverBackendCharm(CharmBase):
             logger.debug(f"Setting hostname in data bag for {self.app}: {self.config['hostname']}")
             event.relation.data[self.app].update(
                 {
-                    "hostname": self.config["hostname"],
+                    "hostname": str(self.config["hostname"]),
                     "port": str(self.config["port"]),
                 }
             )

--- a/frontend/charm/src/nginx_config.py
+++ b/frontend/charm/src/nginx_config.py
@@ -17,6 +17,7 @@
 
 """Module for generating a NGINX configuration allows for the frontend application to connect to the backend."""
 
+
 def nginx_config(base_uri: str) -> str:
     """Generate nginx configuration for the frontend."""
     return f"""


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR adds new static analysis workflows that specifically target the charms. It adjusts the workflows that analyze the non-charm backend and frontend to not run on charm changes. It removes static analysis from the existing frontend charm test workflow and leaves that for testing exclusively. Finally, it applies a few linting/formatting fixes to some charm code.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

IQA-3646

