### PR TITLE
Remove redundant risk from artefact

### DIFF
--- a/backend/migrations/versions/2026_05_26_1058-236cc88a9a64_remove_risk_from_artefact.py
+++ b/backend/migrations/versions/2026_05_26_1058-236cc88a9a64_remove_risk_from_artefact.py
@@ -1,4 +1,3 @@
-
 """Remove risk from Artefact
 
 Revision ID: 236cc88a9a64
@@ -6,28 +5,49 @@ Revises: 717189ad8f3f
 Create Date: 2026-05-26 10:58:42.183696+00:00
 
 """
-from alembic import op
-import sqlalchemy as sa
 
+import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = '236cc88a9a64'
-down_revision = '717189ad8f3f'
+revision = "236cc88a9a64"
+down_revision = "717189ad8f3f"
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
-    op.drop_index('unique_solution', table_name='artefact', postgresql_where="(family = 'solution'::familyname)")
-    op.create_index('unique_solution', 'artefact', ['name', 'source', 'version', 'track', 'bundled_builds_hash'], unique=True, postgresql_where=sa.text("family = 'solution'"))
+    op.drop_index("unique_solution", table_name="artefact", postgresql_where="(family = 'solution'::familyname)")
+    op.create_index(
+        "unique_solution",
+        "artefact",
+        ["name", "source", "version", "track", "bundled_builds_hash"],
+        unique=True,
+        postgresql_where=sa.text("family = 'solution'"),
+    )
     # write the risk value to stage if stage is not set (empty)
     op.execute("""UPDATE artefact SET stage = risk WHERE stage = ''""")
-    op.drop_column('artefact', 'risk')
+    op.drop_column("artefact", "risk")
 
 
 def downgrade() -> None:
-    op.add_column('artefact', sa.Column('risk', sa.VARCHAR(length=200), server_default=sa.text("''::character varying"), autoincrement=False, nullable=False))
+    op.add_column(
+        "artefact",
+        sa.Column(
+            "risk",
+            sa.VARCHAR(length=200),
+            server_default=sa.text("''::character varying"),
+            autoincrement=False,
+            nullable=False,
+        ),
+    )
     # write the stage value to risk
     op.execute("""UPDATE artefact SET risk = stage""")
-    op.drop_index('unique_solution', table_name='artefact', postgresql_where=sa.text("family = 'solution'"))
-    op.create_index('unique_solution', 'artefact', ['name', 'source', 'version', 'track', 'risk', 'bundled_builds_hash'], unique=True, postgresql_where="(family = 'solution'::familyname)")
+    op.drop_index("unique_solution", table_name="artefact", postgresql_where=sa.text("family = 'solution'"))
+    op.create_index(
+        "unique_solution",
+        "artefact",
+        ["name", "source", "version", "track", "risk", "bundled_builds_hash"],
+        unique=True,
+        postgresql_where="(family = 'solution'::familyname)",
+    )

--- a/backend/migrations/versions/2026_05_26_1058-236cc88a9a64_remove_risk_from_artefact.py
+++ b/backend/migrations/versions/2026_05_26_1058-236cc88a9a64_remove_risk_from_artefact.py
@@ -1,0 +1,33 @@
+
+"""Remove risk from Artefact
+
+Revision ID: 236cc88a9a64
+Revises: 717189ad8f3f
+Create Date: 2026-05-26 10:58:42.183696+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '236cc88a9a64'
+down_revision = '717189ad8f3f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_index('unique_solution', table_name='artefact', postgresql_where="(family = 'solution'::familyname)")
+    op.create_index('unique_solution', 'artefact', ['name', 'source', 'version', 'track', 'bundled_builds_hash'], unique=True, postgresql_where=sa.text("family = 'solution'"))
+    # write the risk value to stage if stage is not set (empty)
+    op.execute("""UPDATE artefact SET stage = risk WHERE stage = ''""")
+    op.drop_column('artefact', 'risk')
+
+
+def downgrade() -> None:
+    op.add_column('artefact', sa.Column('risk', sa.VARCHAR(length=200), server_default=sa.text("''::character varying"), autoincrement=False, nullable=False))
+    # write the stage value to risk
+    op.execute("""UPDATE artefact SET risk = stage""")
+    op.drop_index('unique_solution', table_name='artefact', postgresql_where=sa.text("family = 'solution'"))
+    op.create_index('unique_solution', 'artefact', ['name', 'source', 'version', 'track', 'risk', 'bundled_builds_hash'], unique=True, postgresql_where="(family = 'solution'::familyname)")

--- a/backend/migrations/versions/2026_05_26_1058-236cc88a9a64_remove_risk_from_artefact.py
+++ b/backend/migrations/versions/2026_05_26_1058-236cc88a9a64_remove_risk_from_artefact.py
@@ -21,7 +21,7 @@ def upgrade() -> None:
     op.create_index(
         "unique_solution",
         "artefact",
-        ["name", "source", "version", "track", "bundled_builds_hash"],
+        ["name", "source", "version", "track", "stage", "bundled_builds_hash"],
         unique=True,
         postgresql_where=sa.text("family = 'solution'"),
     )

--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -6076,17 +6076,6 @@
             ],
             "title": "Jira Issue"
           },
-          "risk": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Risk"
-          },
           "bundled_builds": {
             "anyOf": [
               {
@@ -6278,10 +6267,6 @@
             ],
             "title": "Jira Issue"
           },
-          "risk": {
-            "type": "string",
-            "title": "Risk"
-          },
           "all_environment_reviews_count": {
             "type": "integer",
             "title": "All Environment Reviews Count"
@@ -6336,7 +6321,6 @@
           "created_at",
           "bug_link",
           "jira_issue",
-          "risk",
           "all_environment_reviews_count",
           "completed_environment_reviews_count",
           "assignee"

--- a/backend/test_observer/controllers/artefacts/artefacts.py
+++ b/backend/test_observer/controllers/artefacts/artefacts.py
@@ -264,8 +264,6 @@ def patch_artefact(
         artefact.comment = request.comment
     if "jira_issue" in request.model_fields_set:
         artefact.jira_issue = request.jira_issue
-    if "risk" in request.model_fields_set:
-        artefact.risk = request.risk if request.risk is not None else ""
 
     reviewer_ids_set = hasattr(request, "reviewer_ids") and "reviewer_ids" in request.model_fields_set
     reviewer_emails_set = hasattr(request, "reviewer_emails") and "reviewer_emails" in request.model_fields_set
@@ -426,7 +424,6 @@ def get_artefact_versions(
         .where(Artefact.repo == artefact.repo)
         .where(Artefact.os == artefact.os)
         .where(Artefact.release == artefact.release)
-        .where(Artefact.risk == artefact.risk)
         .where(Artefact.source == artefact.source)
         .where(Artefact.bundled_builds_hash == artefact.bundled_builds_hash)
         .options(selectinload(Artefact.bundled_builds))

--- a/backend/test_observer/controllers/artefacts/models.py
+++ b/backend/test_observer/controllers/artefacts/models.py
@@ -77,7 +77,6 @@ class ArtefactResponse(BaseModel):
     created_at: datetime
     bug_link: str
     jira_issue: str | None
-    risk: str
     all_environment_reviews_count: int
     completed_environment_reviews_count: int
     bundled_builds: list["ArtefactBuildMinimalResponse"] = Field(default_factory=list)
@@ -153,7 +152,6 @@ class ArtefactPatch(BaseModel):
     stage: StageName | None = None
     comment: str | None = None
     jira_issue: str | None = None
-    risk: str | None = None
     bundled_builds: list[int] | None = Field(
         default=None,
         description="List of ArtefactBuild IDs to bundle with this artefact",

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -400,6 +400,7 @@ class Artefact(Base):
             "source",
             "version",
             "track",
+            "stage",
             "bundled_builds_hash",
             postgresql_where=column("family") == FamilyName.solution.name,
             unique=True,

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -343,9 +343,6 @@ class Artefact(Base):
     owner: Mapped[str] = mapped_column(String(200), default="")
     image_url: Mapped[str] = mapped_column(String(200), default="")
 
-    # Solution specific field
-    risk: Mapped[str] = mapped_column(String(200), default="")
-
     # Relationships
     builds: Mapped[list["ArtefactBuild"]] = relationship(back_populates="artefact", cascade="all, delete")
     bundled_builds: Mapped[list["ArtefactBuild"]] = relationship(
@@ -403,7 +400,6 @@ class Artefact(Base):
             "source",
             "version",
             "track",
-            "risk",
             "bundled_builds_hash",
             postgresql_where=column("family") == FamilyName.solution.name,
             unique=True,

--- a/backend/test_observer/data_access/repository.py
+++ b/backend/test_observer/data_access/repository.py
@@ -115,8 +115,8 @@ def get_artefacts_by_family(
 
             case FamilyName.solution:
                 subquery = (
-                    base_query.add_columns(Artefact.source, Artefact.track, Artefact.risk)
-                    .group_by(Artefact.source, Artefact.track, Artefact.risk)
+                    base_query.add_columns(Artefact.source, Artefact.track)
+                    .group_by(Artefact.source, Artefact.track)
                     .subquery()
                 )
 
@@ -128,7 +128,6 @@ def get_artefacts_by_family(
                         Artefact.created_at == subquery.c.max_created,
                         Artefact.source == subquery.c.source,
                         Artefact.track == subquery.c.track,
-                        Artefact.risk == subquery.c.risk,
                     ),
                 )
 

--- a/backend/tests/controllers/artefacts/test_artefacts.py
+++ b/backend/tests/controllers/artefacts/test_artefacts.py
@@ -1141,7 +1141,6 @@ def _assert_get_artefact_response(response: dict[str, Any], artefact: Artefact) 
         "due_date": (artefact.due_date.strftime("%Y-%m-%d") if artefact.due_date else None),
         "bug_link": artefact.bug_link,
         "jira_issue": artefact.jira_issue,
-        "risk": artefact.risk,
         "all_environment_reviews_count": artefact.all_environment_reviews_count,
         "completed_environment_reviews_count": artefact.completed_environment_reviews_count,  # noqa: E501
         "created_at": artefact.created_at.isoformat(),
@@ -1444,7 +1443,6 @@ def test_solution_artefacts_with_same_builds_in_different_order_cannot_be_create
         version="1.0",
         track="latest",
         source="my-source",
-        risk="stable",
         bundled_builds=[build2, build1],
     )
 
@@ -1458,7 +1456,6 @@ def test_solution_artefacts_with_same_builds_in_different_order_cannot_be_create
             version="1.0",
             track="latest",
             source="my-source",
-            risk="stable",
             bundled_builds=[build1, build2],
         )
 
@@ -1477,7 +1474,6 @@ def test_solution_artefacts_with_different_builds_are_created(generator: DataGen
         version="1.0",
         track="latest",
         source="my-source",
-        risk="stable",
         bundled_builds=[build1],
     )
 
@@ -1490,7 +1486,6 @@ def test_solution_artefacts_with_different_builds_are_created(generator: DataGen
         version="1.0",
         track="latest",
         source="my-source",
-        risk="stable",
         bundled_builds=[build2],
     )
 
@@ -1512,7 +1507,6 @@ def test_updating_solution_to_have_same_bundled_builds_as_another_is_blocked_by_
         version="1.0",
         track="latest",
         source="my-source",
-        risk="stable",
         bundled_builds=[build1],
     )
 
@@ -1523,7 +1517,6 @@ def test_updating_solution_to_have_same_bundled_builds_as_another_is_blocked_by_
         version="1.0",
         track="latest",
         source="my-source",
-        risk="stable",
         bundled_builds=[build2],
     )
 
@@ -1532,81 +1525,6 @@ def test_updating_solution_to_have_same_bundled_builds_as_another_is_blocked_by_
     with pytest.raises(IntegrityError):
         solution2.bundled_builds = [build1]
         generator._add_object(solution2)
-
-
-def test_artefact_response_includes_risk_field(generator: DataGenerator, test_client: TestClient):
-    """Test that the risk field is included in ArtefactResponse."""
-    # GIVEN a solution artefact with a risk field set
-    artefact = generator.gen_artefact(
-        family=FamilyName.solution,
-        name="test-solution",
-        version="1.0",
-        track="latest",
-        source="test-source",
-        risk="candidate",
-    )
-
-    # WHEN getting the artefact
-    response = make_authenticated_request(
-        lambda: test_client.get(f"/v1/artefacts/{artefact.id}"),
-        Permission.view_artefact,
-    )
-
-    # THEN the risk field is included in the response
-    assert response.status_code == 200
-    data = response.json()
-    assert "risk" in data
-    assert data["risk"] == "candidate"
-
-
-def test_artefact_patch_updates_risk_field(generator: DataGenerator, test_client: TestClient):
-    """Test that the risk field can be updated via PATCH."""
-    # GIVEN a solution artefact with a risk field
-    artefact = generator.gen_artefact(
-        family=FamilyName.solution,
-        name="test-solution",
-        version="1.0",
-        track="latest",
-        source="test-source",
-        risk="stable",
-    )
-
-    # WHEN patching the artefact with a new risk value
-    response = make_authenticated_request(
-        lambda: test_client.patch(
-            f"/v1/artefacts/{artefact.id}",
-            json={"risk": "candidate"},
-        ),
-        Permission.change_artefact,
-    )
-
-    # THEN the risk field is updated
-    assert response.status_code == 200
-    data = response.json()
-    assert data["risk"] == "candidate"
-
-
-def test_artefact_risk_field_defaults_to_empty_string(generator: DataGenerator, test_client: TestClient):
-    """Test that the risk field defaults to an empty string for non-solution artefacts."""
-    # GIVEN a non-solution artefact
-    artefact = generator.gen_artefact(
-        family=FamilyName.deb,
-        name="test-deb",
-        version="1.0",
-        series="noble",
-    )
-
-    # WHEN getting the artefact
-    response = make_authenticated_request(
-        lambda: test_client.get(f"/v1/artefacts/{artefact.id}"),
-        Permission.view_artefact,
-    )
-
-    # THEN the risk field defaults to an empty string
-    assert response.status_code == 200
-    data = response.json()
-    assert "risk" in data
-    assert data["risk"] == ""
 
 
 def test_patch_artefact_bundled_builds_set_valid_builds(generator: DataGenerator, test_client: TestClient):

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -145,7 +145,6 @@ def test_execution_to_pending_rerun(test_execution: TestExecution) -> dict:
             "store": test_execution.artefact_build.artefact.store,
             "branch": test_execution.artefact_build.artefact.branch,
             "series": test_execution.artefact_build.artefact.series,
-            "risk": test_execution.artefact_build.artefact.risk,
             "repo": test_execution.artefact_build.artefact.repo,
             "source": test_execution.artefact_build.artefact.source,
             "os": test_execution.artefact_build.artefact.os,

--- a/backend/tests/data_generator.py
+++ b/backend/tests/data_generator.py
@@ -147,7 +147,6 @@ class DataGenerator:
         bug_link: str = "",
         due_date: date | None = None,
         reviewers: list[User] | None = None,
-        risk: str = "",
         bundled_builds: list[ArtefactBuild] | None = None,
     ) -> Artefact:
         family = FamilyName(family)
@@ -183,7 +182,6 @@ class DataGenerator:
             bug_link=bug_link,
             due_date=due_date,
             reviewers=reviewers,
-            risk=risk,
             bundled_builds=bundled_builds,
         )
         self._add_object(artefact)


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

In a previous PR I added the `risk` field to `Artefact` to be used in artefacts of the `solution` family. I now realize we could have just used `stage` to store that information.

This PR removes the `risk` fields and populates unfilled `stage` values with the old `risk` values in the migration. `risk` is also removed from tests and the API

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->
