### PR TITLE
[IQA-3642] Add support for the `ingress` interface

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -31,7 +31,9 @@ SPDX-License-Identifier = "Apache-2.0"
 [[annotations]]
 path = [
     "backend/charm/lib/charms/nginx_ingress_integrator/v0/nginx_route.py",
-    "frontend/charm/lib/charms/nginx_ingress_integrator/v0/nginx_route.py"
+    "frontend/charm/lib/charms/nginx_ingress_integrator/v0/nginx_route.py",
+    "backend/charm/lib/charms/traefik_k8s/v2/ingress.py",
+    "frontend/charm/lib/charms/traefik_k8s/v2/ingress.py"
 ]
 SPDX-FileCopyrightText = "2024 Canonical Ltd."
 SPDX-License-Identifier = "Apache-2.0"

--- a/backend/charm/charmcraft.yaml
+++ b/backend/charm/charmcraft.yaml
@@ -138,10 +138,15 @@ charm-libs:
     version: "0"
   - lib: prometheus_k8s.prometheus_scrape
     version: "0"
+  - lib: traefik_k8s.ingress
+    version: "2"
 
 requires:
   database:
     interface: postgresql_client
+    limit: 1
+  ingress:
+    interface: ingress
     limit: 1
   nginx-route:
     interface: nginx-route

--- a/backend/charm/lib/charms/traefik_k8s/v2/ingress.py
+++ b/backend/charm/lib/charms/traefik_k8s/v2/ingress.py
@@ -1,0 +1,949 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+r"""# Interface Library for ingress.
+
+This library wraps relation endpoints using the `ingress` interface
+and provides a Python API for both requesting and providing per-application
+ingress, with load-balancing occurring across all units.
+
+## Getting Started
+
+To get started using the library, you just need to fetch the library using `charmcraft`.
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.traefik_k8s.v2.ingress
+```
+
+In the `metadata.yaml` of the charm, add the following:
+
+```yaml
+requires:
+    ingress:
+        interface: ingress
+        limit: 1
+```
+
+Then, to initialise the library:
+
+```python
+from charms.traefik_k8s.v2.ingress import (IngressPerAppRequirer,
+  IngressPerAppReadyEvent, IngressPerAppRevokedEvent)
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.ingress = IngressPerAppRequirer(self, port=80)
+    # The following event is triggered when the ingress URL to be used
+    # by this deployment of the `SomeCharm` is ready (or changes).
+    self.framework.observe(
+        self.ingress.on.ready, self._on_ingress_ready
+    )
+    self.framework.observe(
+        self.ingress.on.revoked, self._on_ingress_revoked
+    )
+
+    def _on_ingress_ready(self, event: IngressPerAppReadyEvent):
+        logger.info("This app's ingress URL: %s", event.url)
+
+    def _on_ingress_revoked(self, event: IngressPerAppRevokedEvent):
+        logger.info("This app no longer has ingress")
+"""
+
+import ipaddress
+import json
+import logging
+import socket
+import typing
+from dataclasses import dataclass
+from functools import partial
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
+
+import pydantic
+from ops import EventBase
+from ops.charm import CharmBase, RelationBrokenEvent, RelationEvent
+from ops.framework import EventSource, Object, ObjectEvents, StoredState
+from ops.model import ModelError, Relation, Unit
+from pydantic import AnyHttpUrl, BaseModel, Field
+
+# The unique Charmhub library identifier, never change it
+LIBID = "e6de2a5cd5b34422a204668f3b8f90d2"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 2
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 20
+
+PYDEPS = ["pydantic"]
+
+DEFAULT_RELATION_NAME = "ingress"
+RELATION_INTERFACE = "ingress"
+
+log = logging.getLogger(__name__)
+BUILTIN_JUJU_KEYS = {"ingress-address", "private-address", "egress-subnets"}
+
+PYDANTIC_IS_V1 = int(pydantic.version.VERSION.split(".")[0]) < 2
+if PYDANTIC_IS_V1:  # noqa
+    from pydantic import validator
+
+    input_validator = partial(validator, pre=True)
+
+    class DatabagModel(BaseModel):  # type: ignore
+        """Base databag model."""
+
+        class Config:
+            """Pydantic config."""
+
+            allow_population_by_field_name = True
+            """Allow instantiating this class by field name (instead of forcing alias)."""
+
+        _NEST_UNDER = None
+
+        # Annotating -> "DatabagModel" as the return type here doesn't sit well with pyright
+        # We are disabling this line for now and come back to it later.
+        @classmethod
+        def load(cls, databag: MutableMapping):  # type: ignore[no-untyped-def]
+            """Load this model from a Juju databag."""
+            if cls._NEST_UNDER:
+                return cls.parse_obj(json.loads(databag[cls._NEST_UNDER]))
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {f.alias for f in cls.__fields__.values()}  # type: ignore
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                log.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.parse_raw(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                log.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True) -> Any:
+            """Write the contents of this model to Juju databag.
+
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+
+            if self._NEST_UNDER:
+                databag[self._NEST_UNDER] = self.json(by_alias=True, exclude_defaults=True)
+                return databag
+
+            for key, value in self.dict(by_alias=True, exclude_defaults=True).items():  # type: ignore  # noqa
+                databag[key] = json.dumps(value)
+
+            return databag
+
+else:
+    from pydantic import ConfigDict, field_validator
+
+    input_validator = partial(field_validator, mode="before")  # type: ignore
+
+    class DatabagModel(BaseModel):  # type: ignore
+        """Base databag model."""
+
+        model_config = ConfigDict(
+            # tolerate additional keys in databag
+            extra="ignore",
+            # Allow instantiating this class by field name (instead of forcing alias).
+            populate_by_name=True,
+            # Custom config key: whether to nest the whole datastructure (as json)
+            # under a field or spread it out at the toplevel.
+            _NEST_UNDER=None,
+        )  # type: ignore
+        """Pydantic config."""
+
+        # Annotating -> "DatabagModel" as the return type here doesn't sit well with pyright
+        # We are disabling this line for now and come back to it later.
+        @classmethod
+        def load(cls, databag: MutableMapping):  # type: ignore[no-untyped-def]
+            """Load this model from a Juju databag."""
+            nest_under = cls.model_config.get("_NEST_UNDER")
+            if nest_under:
+                return cls.model_validate(json.loads(databag[nest_under]))  # type: ignore
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {(f.alias or n) for n, f in cls.model_fields.items()}  # type: ignore
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                log.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.model_validate_json(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                log.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True) -> Any:
+            """Write the contents of this model to Juju databag.
+
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+            nest_under = self.model_config.get("_NEST_UNDER")
+            if nest_under:
+                databag[nest_under] = self.model_dump_json(  # type: ignore
+                    by_alias=True,
+                    # skip keys whose values are default
+                    exclude_defaults=True,
+                )
+                return databag
+
+            dct = self.model_dump(
+                mode="json",
+                by_alias=True,
+                exclude_defaults=True,  # type: ignore
+            )
+            databag.update({k: json.dumps(v) for k, v in dct.items()})
+            return databag
+
+
+# todo: import these models from charm-relation-interfaces/ingress/v2 instead of redeclaring them
+class IngressUrl(BaseModel):
+    """Ingress url schema."""
+
+    url: AnyHttpUrl
+
+
+class IngressProviderAppData(DatabagModel):
+    """Ingress application databag schema."""
+
+    ingress: Optional[IngressUrl] = None
+
+
+class ProviderSchema(BaseModel):
+    """Provider schema for Ingress."""
+
+    app: IngressProviderAppData
+
+
+class IngressHealthCheck(BaseModel):
+    """HealthCheck schema for Ingress."""
+
+    path: str = Field(description="The health check endpoint path (required).")
+    scheme: Optional[str] = Field(
+        default=None, description="Replaces the server URL scheme for the health check endpoint."
+    )
+    hostname: Optional[str] = Field(
+        default=None, description="Hostname to be set in the health check request."
+    )
+    port: Optional[int] = Field(
+        default=None, description="Replaces the server URL port for the health check endpoint."
+    )
+    interval: str = Field(default="30s", description="Frequency of the health check calls.")
+    timeout: str = Field(default="5s", description="Maximum duration for a health check request.")
+
+
+class IngressRequirerAppData(DatabagModel):
+    """Ingress requirer application databag model."""
+
+    model: str = Field(description="The model the application is in.")
+    name: str = Field(description="the name of the app requesting ingress.")
+    port: int = Field(description="The port the app wishes to be exposed.")
+    healthcheck_params: Optional[IngressHealthCheck] = Field(
+        default=None, description="Optional health check configuration for ingress."
+    )
+
+    # fields on top of vanilla 'ingress' interface:
+    strip_prefix: Optional[bool] = Field(
+        default=False,
+        description="Whether to strip the prefix from the ingress url.",
+        alias="strip-prefix",
+    )
+    redirect_https: Optional[bool] = Field(
+        default=False,
+        description="Whether to redirect http traffic to https.",
+        alias="redirect-https",
+    )
+
+    scheme: Optional[str] = Field(
+        default="http", description="What scheme to use in the generated ingress url"
+    )
+
+    # pydantic wants 'cls' as first arg
+    @input_validator("scheme")
+    def validate_scheme(cls, scheme: str) -> str:  # noqa: N805
+        """Validate scheme arg."""
+        if scheme not in {"http", "https", "h2c"}:
+            raise ValueError("invalid scheme: should be one of `http|https|h2c`")
+        return scheme
+
+    # pydantic wants 'cls' as first arg
+    @input_validator("port")
+    def validate_port(cls, port: int) -> int:  # noqa: N805
+        """Validate port."""
+        assert isinstance(port, int), type(port)
+        assert 0 < port < 65535, "port out of TCP range"
+        return port
+
+
+class IngressRequirerUnitData(DatabagModel):
+    """Ingress requirer unit databag model."""
+
+    host: str = Field(description="Hostname at which the unit is reachable.")
+    ip: Optional[str] = Field(
+        None,
+        description="IP at which the unit is reachable, "
+        "IP can only be None if the IP information can't be retrieved from juju.",
+    )
+
+    # pydantic wants 'cls' as first arg
+    @input_validator("host")
+    def validate_host(cls, host: str) -> str:  # noqa: N805
+        """Validate host."""
+        assert isinstance(host, str), type(host)
+        return host
+
+    # pydantic wants 'cls' as first arg
+    @input_validator("ip")
+    def validate_ip(cls, ip: str) -> Optional[str]:  # noqa: N805
+        """Validate ip."""
+        if ip is None:
+            return None
+        if not isinstance(ip, str):
+            raise TypeError(f"got ip of type {type(ip)} instead of expected str")
+        try:
+            ipaddress.IPv4Address(ip)
+            return ip
+        except ipaddress.AddressValueError:
+            pass
+        try:
+            ipaddress.IPv6Address(ip)
+            return ip
+        except ipaddress.AddressValueError:
+            raise ValueError(f"{ip!r} is not a valid ip address")
+
+
+class RequirerSchema(BaseModel):
+    """Requirer schema for Ingress."""
+
+    app: IngressRequirerAppData
+    unit: IngressRequirerUnitData
+
+
+class IngressError(RuntimeError):
+    """Base class for custom errors raised by this library."""
+
+
+class NotReadyError(IngressError):
+    """Raised when a relation is not ready."""
+
+
+class DataValidationError(IngressError):
+    """Raised when data validation fails on IPU relation data."""
+
+
+class _IngressPerAppBase(Object):
+    """Base class for IngressPerUnit interface classes."""
+
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+        super().__init__(charm, relation_name)
+
+        self.charm: CharmBase = charm
+        self.relation_name = relation_name
+        self.app = self.charm.app
+        self.unit = self.charm.unit
+
+        observe = self.framework.observe
+        rel_events = charm.on[relation_name]
+        observe(rel_events.relation_changed, self._handle_relation)
+        observe(rel_events.relation_departed, self._handle_relation)
+        observe(rel_events.relation_broken, self._handle_relation_broken)
+        observe(charm.on.leader_elected, self._handle_upgrade_or_leader)  # type: ignore
+        observe(charm.on.upgrade_charm, self._handle_upgrade_or_leader)  # type: ignore
+
+    @property
+    def relations(self) -> List[Relation]:
+        """The list of Relation instances associated with this endpoint."""
+        return list(self.charm.model.relations[self.relation_name])
+
+    def _handle_relation(self, event: RelationEvent) -> None:
+        """Subclasses should implement this method to handle a relation update."""
+        pass
+
+    def _handle_relation_broken(self, event: RelationEvent) -> None:
+        """Subclasses should implement this method to handle a relation breaking."""
+        pass
+
+    def _handle_upgrade_or_leader(self, event: EventBase) -> None:
+        """Subclasses should implement this method to handle upgrades or leadership change."""
+        pass
+
+
+class _IPAEvent(RelationEvent):
+    __args__: Tuple[str, ...] = ()
+    __optional_kwargs__: Dict[str, Any] = {}
+
+    @classmethod
+    def __attrs__(cls):  # type: ignore
+        return cls.__args__ + tuple(cls.__optional_kwargs__.keys())
+
+    def __init__(self, handle, relation, *args, **kwargs):  # type: ignore
+        super().__init__(handle, relation)
+
+        if not len(self.__args__) == len(args):
+            raise TypeError("expected {} args, got {}".format(len(self.__args__), len(args)))
+
+        for attr, obj in zip(self.__args__, args):
+            setattr(self, attr, obj)
+        for attr, default in self.__optional_kwargs__.items():
+            obj = kwargs.get(attr, default)
+            setattr(self, attr, obj)
+
+    def snapshot(self) -> Dict[str, Any]:
+        dct = super().snapshot()
+        for attr in self.__attrs__():
+            obj = getattr(self, attr)
+            try:
+                dct[attr] = obj
+            except ValueError as e:
+                raise ValueError(
+                    "cannot automagically serialize {}: "
+                    "override this method and do it "
+                    "manually.".format(obj)
+                ) from e
+
+        return dct
+
+    def restore(self, snapshot: Any) -> None:
+        super().restore(snapshot)
+        for attr, obj in snapshot.items():
+            setattr(self, attr, obj)
+
+
+class IngressPerAppDataProvidedEvent(_IPAEvent):
+    """Event representing that ingress data has been provided for an app."""
+
+    __args__ = ("name", "model", "hosts", "strip_prefix", "redirect_https")
+
+    if typing.TYPE_CHECKING:
+        name: Optional[str] = None
+        model: Optional[str] = None
+        # sequence of hostname, port dicts
+        hosts: Sequence["IngressRequirerUnitData"] = ()
+        strip_prefix: bool = False
+        redirect_https: bool = False
+
+
+class IngressPerAppDataRemovedEvent(RelationEvent):
+    """Event representing that ingress data has been removed for an app."""
+
+
+class IngressPerAppEndpointsUpdatedEvent(RelationEvent):
+    """Event representing that the proxied endpoints have been updated."""
+
+
+class IngressPerAppProviderEvents(ObjectEvents):
+    """Container for IPA Provider events."""
+
+    data_provided = EventSource(IngressPerAppDataProvidedEvent)
+    data_removed = EventSource(IngressPerAppDataRemovedEvent)
+    endpoints_updated = EventSource(IngressPerAppEndpointsUpdatedEvent)
+
+
+@dataclass
+class IngressRequirerData:
+    """Data exposed by the ingress requirer to the provider."""
+
+    app: "IngressRequirerAppData"
+    units: List["IngressRequirerUnitData"]
+
+
+class IngressPerAppProvider(_IngressPerAppBase):
+    """Implementation of the provider of ingress."""
+
+    on = IngressPerAppProviderEvents()  # type: ignore
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = DEFAULT_RELATION_NAME,
+    ):
+        """Constructor for IngressPerAppProvider.
+
+        Args:
+            charm: The charm that is instantiating the instance.
+            relation_name: The name of the relation endpoint to bind to
+                (defaults to "ingress").
+        """
+        super().__init__(charm, relation_name)
+
+    def _handle_relation(self, event: RelationEvent) -> None:
+        # created, joined or changed: if remote side has sent the required data:
+        # notify listeners.
+        if self.is_ready(event.relation):
+            data = self.get_data(event.relation)
+            self.on.data_provided.emit(  # type: ignore
+                event.relation,
+                data.app.name,
+                data.app.model,
+                [
+                    unit.dict() if PYDANTIC_IS_V1 else unit.model_dump(mode="json")
+                    for unit in data.units
+                ],
+                data.app.strip_prefix or False,
+                data.app.redirect_https or False,
+            )
+
+    def _handle_relation_broken(self, event: RelationEvent) -> None:
+        self.on.data_removed.emit(event.relation, event.relation.app)  # type: ignore
+
+    def wipe_ingress_data(self, relation: Relation) -> None:
+        """Clear ingress data from relation."""
+        assert self.unit.is_leader(), "only leaders can do this"
+        try:
+            relation.data
+        except ModelError as e:
+            log.warning(
+                "error {} accessing relation data for {!r}. "
+                "Probably a ghost of a dead relation is still "
+                "lingering around.".format(e, relation.name)
+            )
+            return
+        del relation.data[self.app]["ingress"]
+        self.on.endpoints_updated.emit(relation=relation, app=relation.app)
+
+    def _get_requirer_units_data(self, relation: Relation) -> List["IngressRequirerUnitData"]:
+        """Fetch and validate the requirer's unit databag."""
+        out: List["IngressRequirerUnitData"] = []
+
+        unit: Unit
+        for unit in relation.units:
+            databag = relation.data[unit]
+            try:
+                data = IngressRequirerUnitData.load(databag)
+                out.append(cast(IngressRequirerUnitData, data))
+            except pydantic.ValidationError:
+                log.info(f"failed to validate remote unit data for {unit}")
+                raise
+        return out
+
+    @staticmethod
+    def _get_requirer_app_data(relation: Relation) -> "IngressRequirerAppData":
+        """Fetch and validate the requirer's app databag."""
+        app = relation.app
+        if app is None:
+            raise NotReadyError(relation)
+
+        databag = relation.data[app]
+        return cast(IngressRequirerAppData, IngressRequirerAppData.load(databag))
+
+    def get_data(self, relation: Relation) -> IngressRequirerData:
+        """Fetch the remote (requirer) app and units' databags."""
+        try:
+            return IngressRequirerData(
+                self._get_requirer_app_data(relation), self._get_requirer_units_data(relation)
+            )
+        except (pydantic.ValidationError, DataValidationError) as e:
+            raise DataValidationError(
+                "failed to validate ingress requirer data: %s" % str(e)
+            ) from e
+
+    def is_ready(self, relation: Optional[Relation] = None) -> bool:
+        """The Provider is ready if the requirer has sent valid data."""
+        if not relation:
+            return any(map(self.is_ready, self.relations))
+
+        try:
+            self.get_data(relation)
+        except (DataValidationError, NotReadyError) as e:
+            log.info("Provider not ready; validation error encountered: %s" % str(e))
+            return False
+        return True
+
+    def _published_url(self, relation: Relation) -> Optional["IngressProviderAppData"]:
+        """Fetch and validate this app databag; return the ingress url."""
+        if not self.is_ready(relation) or not self.unit.is_leader():
+            # Handle edge case where remote app name can be missing, e.g.,
+            # relation_broken events.
+            # Also, only leader units can read own app databags.
+            # FIXME https://github.com/canonical/traefik-k8s-operator/issues/34
+            return None
+
+        # fetch the provider's app databag
+        databag = relation.data[self.app]
+        if not databag.get("ingress"):
+            raise NotReadyError("This application did not `publish_url` yet.")
+
+        return IngressProviderAppData.load(databag)
+
+    def publish_url(self, relation: Relation, url: str) -> None:
+        """Publish to the app databag the ingress url."""
+        ingress_url = {"url": url}
+        try:
+            IngressProviderAppData(ingress=ingress_url).dump(relation.data[self.app])  # type: ignore
+            self.on.endpoints_updated.emit(relation=relation, app=relation.app)
+        except pydantic.ValidationError as e:
+            # If we cannot validate the url as valid, publish an empty databag and log the error.
+            log.error(f"Failed to validate ingress url '{url}' - got ValidationError {e}")
+            log.error(
+                (
+                    f"url was not published to ingress relation for {relation.app}."
+                    f"This error is likely due to an error or misconfiguration of the"
+                    "charm calling this library."
+                )
+            )
+            IngressProviderAppData(ingress=None).dump(relation.data[self.app])  # type: ignore
+
+    @property
+    def proxied_endpoints(self) -> Dict[str, Dict[str, str]]:
+        """Returns the ingress settings provided to applications by this IngressPerAppProvider.
+
+        For example, when this IngressPerAppProvider has provided the
+        `http://foo.bar/my-model.my-app` URL to the my-app application, the returned dictionary
+        will be:
+
+        ```
+        {
+            "my-app": {
+                "url": "http://foo.bar/my-model.my-app"
+            }
+        }
+        ```
+        """
+        results: Dict[str, Dict[str, str]] = {}
+
+        for ingress_relation in self.relations:
+            if not ingress_relation.app:
+                log.warning(
+                    (
+                        f"no app in relation {ingress_relation} when fetching proxied endpoints:"
+                        "skipping"
+                    )
+                )
+                continue
+            try:
+                ingress_data = self._published_url(ingress_relation)
+            except NotReadyError:
+                log.warning(
+                    f"no published url found in {ingress_relation}: "
+                    f"traefik didn't publish_url yet to this relation."
+                )
+                continue
+
+            if not ingress_data:
+                log.warning(f"relation {ingress_relation} not ready yet: try again in some time.")
+                continue
+
+            # Validation above means ingress cannot be None, but type checker doesn't know that.
+            ingress = cast(IngressProviderAppData, ingress_data.ingress)
+            if PYDANTIC_IS_V1:
+                results[ingress_relation.app.name] = ingress.dict()
+            else:
+                results[ingress_relation.app.name] = ingress.model_dump(mode="json")
+        return results
+
+
+class IngressPerAppReadyEvent(_IPAEvent):
+    """Event representing that ingress for an app is ready."""
+
+    __args__ = ("url",)
+    if typing.TYPE_CHECKING:
+        url: Optional[str] = None
+
+
+class IngressPerAppRevokedEvent(RelationEvent):
+    """Event representing that ingress for an app has been revoked."""
+
+
+class IngressPerAppRequirerEvents(ObjectEvents):
+    """Container for IPA Requirer events."""
+
+    ready = EventSource(IngressPerAppReadyEvent)
+    revoked = EventSource(IngressPerAppRevokedEvent)
+
+
+class IngressPerAppRequirer(_IngressPerAppBase):
+    """Implementation of the requirer of the ingress relation."""
+
+    on = IngressPerAppRequirerEvents()  # type: ignore
+
+    # used to prevent spurious urls to be sent out if the event we're currently
+    # handling is a relation-broken one.
+    _stored = StoredState()
+    _auto_data: Optional[Tuple[Optional[str], Optional[str], int]]
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = DEFAULT_RELATION_NAME,
+        *,
+        host: Optional[str] = None,
+        ip: Optional[str] = None,
+        port: Optional[int] = None,
+        strip_prefix: bool = False,
+        redirect_https: bool = False,
+        # fixme: this is horrible UX.
+        # shall we switch to manually calling provide_ingress_requirements with all args when
+        # ready?
+        scheme: Union[Callable[[], str], str] = lambda: "http",
+        healthcheck_params: Optional[Dict[str, Any]] = None,
+    ):
+        """Constructor for IngressRequirer.
+
+        The request args can be used to specify the ingress properties when the
+        instance is created. If any are set, at least `port` is required, and
+        they will be sent to the ingress provider as soon as it is available.
+        All request args must be given as keyword args.
+
+        Args:
+            charm: The charm that is instantiating the library.
+            relation_name: The name of the relation endpoint to bind to (defaults to "ingress");
+                the relation must be of interface type "ingress" and have a limit of 1.
+            host: Hostname to be used by the ingress provider to address the requiring
+                application; if unspecified, the default Kubernetes service name will be used.
+            ip: Alternative addressing method other than host to be used by the ingress provider;
+                if unspecified, the binding address from the Juju network API will be used.
+            healthcheck_params: Optional dictionary containing health check
+                configuration parameters conforming to the IngressHealthCheck schema.
+                The dictionary must include:
+                    - "path" (str): The health check endpoint path (required).
+                It may also include:
+                    - "scheme" (Optional[str]): Replaces the server URL scheme for the health check
+                        endpoint.
+                    - "hostname" (Optional[str]): Hostname to be set in the health check request.
+                    - "port" (Optional[int]): Replaces the server URL port for the health check
+                        endpoint.
+                    - "interval" (str): Frequency of the health check calls
+                        (defaults to "30s" if omitted).
+                    - "timeout" (str): Maximum duration for a health check request
+                        (defaults to "5s" if omitted).
+                If provided, "path" is required while "interval" and "timeout" will use Traefik's
+                    defaults when not specified.
+            strip_prefix: Configure Traefik to strip the path prefix.
+            redirect_https: Redirect incoming requests to HTTPS.
+            scheme: Either a callable that returns the scheme to use when constructing the ingress
+                URL, or a string if the scheme is known and stable at charm initialization.
+
+        Request Args:
+            port: the port of the service
+        """
+        super().__init__(charm, relation_name)
+        self.charm: CharmBase = charm
+        self.healthcheck_params = healthcheck_params
+        self.relation_name = relation_name
+        self._strip_prefix = strip_prefix
+        self._redirect_https = redirect_https
+        self._get_scheme = scheme if callable(scheme) else lambda: scheme
+
+        self._stored.set_default(current_url=None)  # type: ignore
+
+        # if instantiated with a port, and we are related, then
+        # we immediately publish our ingress data  to speed up the process.
+        if port:
+            self._auto_data = host, ip, port
+        else:
+            self._auto_data = None
+
+    def _handle_relation(self, event: RelationEvent) -> None:
+        # created, joined or changed: if we have auto data: publish it
+        self._publish_auto_data()
+        if self.is_ready():
+            # Avoid spurious events, emit only when there is a NEW URL available
+            new_url = (
+                None
+                if isinstance(event, RelationBrokenEvent)
+                else self._get_url_from_relation_data()
+            )
+            if self._stored.current_url != new_url:  # type: ignore
+                self._stored.current_url = new_url  # type: ignore
+                self.on.ready.emit(event.relation, new_url)  # type: ignore
+
+    def _handle_relation_broken(self, event: RelationEvent) -> None:
+        self._stored.current_url = None  # type: ignore
+        self.on.revoked.emit(relation=event.relation, app=event.relation.app)  # type: ignore
+
+    def _handle_upgrade_or_leader(self, event: EventBase) -> None:
+        """On upgrade/leadership change: ensure we publish the data we have."""
+        self._publish_auto_data()
+
+    def is_ready(self) -> bool:
+        """The Requirer is ready if the Provider has sent valid data."""
+        try:
+            return bool(self._get_url_from_relation_data())
+        except DataValidationError as e:
+            log.debug("Requirer not ready; validation error encountered: %s" % str(e))
+            return False
+
+    def _publish_auto_data(self) -> None:
+        if self._auto_data:
+            host, ip, port = self._auto_data
+            self.provide_ingress_requirements(host=host, ip=ip, port=port)
+
+    def provide_ingress_requirements(
+        self,
+        *,
+        scheme: Optional[str] = None,
+        host: Optional[str] = None,
+        ip: Optional[str] = None,
+        port: int,
+    ) -> None:
+        """Publishes the data that Traefik needs to provide ingress.
+
+        Args:
+            scheme: Scheme to be used; if unspecified, use the one used by __init__.
+            host: Hostname to be used by the ingress provider to address the
+             requirer unit; if unspecified, FQDN will be used instead
+            ip: Alternative addressing method other than host to be used by the ingress provider.
+                if unspecified, binding address from juju network API will be used.
+            port: the port of the service (required)
+        """
+        for relation in self.relations:
+            self._provide_ingress_requirements(scheme, host, ip, port, relation)
+
+    def _provide_ingress_requirements(
+        self,
+        scheme: Optional[str],
+        host: Optional[str],
+        ip: Optional[str],
+        port: int,
+        relation: Relation,
+    ) -> None:
+        if self.unit.is_leader():
+            self._publish_app_data(scheme, port, relation)
+
+        self._publish_unit_data(host, ip, relation)
+
+    def _publish_unit_data(
+        self,
+        host: Optional[str],
+        ip: Optional[str],
+        relation: Relation,
+    ) -> None:
+        if not host:
+            host = socket.getfqdn()
+
+        if ip is None:
+            network_binding = self.charm.model.get_binding(relation)
+            if (
+                network_binding is not None
+                and (bind_address := network_binding.network.bind_address) is not None
+            ):
+                ip = str(bind_address)
+            else:
+                log.error("failed to retrieve ip information from juju")
+
+        unit_databag = relation.data[self.unit]
+        try:
+            IngressRequirerUnitData(host=host, ip=ip).dump(unit_databag)
+        except pydantic.ValidationError as e:
+            msg = "failed to validate unit data"
+            log.info(msg, exc_info=True)  # log to INFO because this might be expected
+            raise DataValidationError(msg) from e
+
+    def _publish_app_data(
+        self,
+        scheme: Optional[str],
+        port: int,
+        relation: Relation,
+    ) -> None:
+        # assumes leadership!
+        app_databag = relation.data[self.app]
+
+        if not scheme:
+            # If scheme was not provided, use the one given to the constructor.
+            scheme = self._get_scheme()
+
+        try:
+            # Ignore pyright errors since pyright does not like aliases.
+            IngressRequirerAppData(  # type: ignore
+                model=self.model.name,
+                name=self.app.name,
+                scheme=scheme,
+                port=port,
+                strip_prefix=self._strip_prefix,  # type: ignore
+                redirect_https=self._redirect_https,  # type: ignore
+                healthcheck_params=(
+                    IngressHealthCheck(**self.healthcheck_params)
+                    if self.healthcheck_params
+                    else None
+                ),
+            ).dump(app_databag)
+        except pydantic.ValidationError as e:
+            msg = "failed to validate app data"
+            log.info(msg, exc_info=True)  # log to INFO because this might be expected
+            raise DataValidationError(msg) from e
+
+    @property
+    def relation(self) -> Optional[Relation]:
+        """The established Relation instance, or None."""
+        return self.relations[0] if self.relations else None
+
+    def _get_url_from_relation_data(self) -> Optional[str]:
+        """The full ingress URL to reach the charm application.
+
+        Returns None if the URL isn't available yet.
+        """
+        relation = self.relation
+        if not relation or not relation.app:
+            return None
+
+        # fetch the provider's app databag
+        try:
+            databag = relation.data[relation.app]
+        except ModelError as e:
+            log.debug(
+                f"Error {e} attempting to read remote app data; "
+                f"probably we are in a relation_departed hook"
+            )
+            return None
+
+        if not databag:  # not ready yet
+            return None
+
+        ingress = cast(IngressProviderAppData, IngressProviderAppData.load(databag)).ingress
+        if ingress is None:
+            return None
+
+        return str(ingress.url)
+
+    @property
+    def url(self) -> Optional[str]:
+        """The full ingress URL to reach the charm application.
+
+        Returns None if the URL isn't available yet.
+        """
+        data = (
+            typing.cast(Optional[str], self._stored.current_url)  # type: ignore
+            or self._get_url_from_relation_data()
+        )
+        return data

--- a/backend/charm/requirements.txt
+++ b/backend/charm/requirements.txt
@@ -17,3 +17,4 @@
 
 ops >= 2.8.0
 requests==2.34.2
+pydantic==2.13.3

--- a/backend/charm/src/charm.py
+++ b/backend/charm/src/charm.py
@@ -544,7 +544,9 @@ class TestObserverBackendCharm(CharmBase):
         data = {"hostname": hostname, "port": str(port), "url": url}
         logger.debug("Updating data bag for %s with\n: %s", self.app, data)
         for relation in self.model.relations["test-observer-rest-api"]:
-            relation.data[self.app].update(data)
+            bag = relation.data[self.app]
+            if any(bag.get(k) != v for k, v in data.items()):
+                bag.update(data)
 
     def _parse_url_host_and_port(self, url: str) -> tuple[str | None, int | None]:
         """Parse the hostname and port from a URL."""

--- a/backend/charm/src/charm.py
+++ b/backend/charm/src/charm.py
@@ -33,7 +33,6 @@ from charms.traefik_k8s.v2.ingress import (
     IngressPerAppRequirer,
     IngressPerAppRevokedEvent,
 )
-
 from ops import CollectStatusEvent, StoredState
 from ops.charm import CharmBase, RelationChangedEvent, RelationCreatedEvent
 from ops.main import main
@@ -287,7 +286,7 @@ class TestObserverBackendCharm(CharmBase):
         raise SystemExit(0)
 
     @property
-    def _app_environment(self):
+    def _app_environment(self) -> dict[str, str]:
         """This creates a dictionary of environment variables needed by the application."""
         # All environment variables must be strings, since they are passed to Pebble,
         # and the Pebble environment struct requires strings.
@@ -484,8 +483,9 @@ class TestObserverBackendCharm(CharmBase):
         or if there are conflicting relations.
         The ops framework triggers a CollectStatusEvent at the end of each hook.
         """
-
-        has_ingress_conflict = self.model.get_relation("ingress") and self.model.get_relation("nginx-route")
+        has_ingress_conflict = self.model.get_relation("ingress") and self.model.get_relation(
+            "nginx-route"
+        )
         if has_ingress_conflict:
             event.add_status(BlockedStatus(INGRESS_CONFLICT_MESSAGE))
             return
@@ -498,7 +498,7 @@ class TestObserverBackendCharm(CharmBase):
             return
 
     def _get_url(self) -> str:
-        """Get the URL to use for this charm's service"""
+        """Get the URL to use for this charm's service."""
         # By default, we use the hostname and port from the config values,
         # which is needed for the `nginx-route` relation.
         port = int(self.config["port"])
@@ -515,7 +515,7 @@ class TestObserverBackendCharm(CharmBase):
         if self.model.get_relation(INGRESS_RELATION_NAME) and self.ingress.url is not None:
             url = self.ingress.url
         return url.rstrip("/")
-    
+
     def _get_frontend_url(self) -> str:
         """Get the URL of the connected frontend, if any. The frontend URL is needed for CORS checks."""
         # Default to the config value for backwards compatibility with older charm version
@@ -523,10 +523,10 @@ class TestObserverBackendCharm(CharmBase):
         url = f"https://{self.config['frontend_hostname']}"
         if relation := self.model.get_relation("test-observer-rest-api"):
             url = relation.data[relation.app].get("url", url)
-        
+
         logger.info("Frontend URL: %s", url)
         return url.rstrip("/")
-    
+
     def _update_frontend_relation_data(self):
         if not self.unit.is_leader():
             return
@@ -534,7 +534,9 @@ class TestObserverBackendCharm(CharmBase):
         url = self._get_url()
         hostname, port = self._parse_url_host_and_port(url)
         if hostname is None or port is None:
-            logger.warning("Could not parse hostname and port from URL. Skipping relation data update.")
+            logger.warning(
+                "Could not parse hostname and port from URL. Skipping relation data update."
+            )
             return
 
         # We use hostname and port for backwards compatibility
@@ -569,8 +571,9 @@ class TestObserverBackendCharm(CharmBase):
             else:
                 logger.info("Could not determine port from URL scheme in URL: %s", url)
                 return (hostname, None)
-            
+
         return (hostname, port)
+
 
 if __name__ == "__main__":  # pragma: nocover
     main(TestObserverBackendCharm)

--- a/backend/charm/src/charm.py
+++ b/backend/charm/src/charm.py
@@ -20,6 +20,7 @@
 import logging
 import os
 import sys
+import urllib.parse
 from collections import ChainMap
 
 from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires
@@ -27,7 +28,13 @@ from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.nginx_ingress_integrator.v0.nginx_route import require_nginx_route
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from charms.redis_k8s.v0.redis import RedisRelationCharmEvents, RedisRequires
-from ops import StoredState
+from charms.traefik_k8s.v2.ingress import (
+    IngressPerAppReadyEvent,
+    IngressPerAppRequirer,
+    IngressPerAppRevokedEvent,
+)
+
+from ops import CollectStatusEvent, StoredState
 from ops.charm import CharmBase, RelationChangedEvent, RelationCreatedEvent
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
@@ -36,6 +43,9 @@ from requests import get
 
 # Log messages can be retrieved using juju debug-log
 logger = logging.getLogger(__name__)
+
+INGRESS_RELATION_NAME = "ingress"
+INGRESS_CONFLICT_MESSAGE = "Cannot have both ingress and nginx-route relations at the same time"
 
 
 class TestObserverBackendCharm(CharmBase):
@@ -71,6 +81,17 @@ class TestObserverBackendCharm(CharmBase):
             self._on_database_relation_broken,
         )
 
+        # Traefik will default to prefixing routes with <model-name>-<app-name>,
+        # so we need to use strip_prefix=True to remove that and keep the API working with expected routes
+        self.ingress = IngressPerAppRequirer(
+            charm=self,
+            relation_name=INGRESS_RELATION_NAME,
+            port=int(self.config["port"]),
+            strip_prefix=True,
+        )
+        self.framework.observe(self.ingress.on.ready, self._on_ingress_ready)
+        self.framework.observe(self.ingress.on.revoked, self._on_ingress_revoked)
+
         self.framework.observe(
             self.on.test_observer_rest_api_relation_joined,
             self._test_observer_rest_api_client_joined,
@@ -92,6 +113,22 @@ class TestObserverBackendCharm(CharmBase):
         self.framework.observe(
             self.on.promote_user_to_admin_action, self._on_promote_user_to_admin_action
         )
+
+        # The ops framework triggers a CollectStatusEvent at the end of each hook
+        self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
+
+    def _on_ingress_ready(self, event: IngressPerAppReadyEvent) -> None:
+        """Process the ingress URL and provide the hostname where needed."""
+        logger.info("Ingress is ready with url %s", event.url)
+        self._update_api_layer()
+        self._update_celery_layer()
+        self._update_frontend_relation_data()
+
+    def _on_ingress_revoked(self, event: IngressPerAppRevokedEvent) -> None:
+        logger.info("Ingress revoked")
+        self._update_api_layer()
+        self._update_celery_layer()
+        self._update_frontend_relation_data()
 
     def _setup_nginx(self):
         require_nginx_route(
@@ -189,16 +226,12 @@ class TestObserverBackendCharm(CharmBase):
             )
             return
 
-        if self.unit.is_leader():
-            for relation in self.model.relations["test-observer-rest-api"]:
-                host = self.config["hostname"]
-                port = str(self.config["port"])
-                relation.data[self.app].update({"hostname": host, "port": port})
-
+        self.ingress.provide_ingress_requirements(port=int(self.config["port"]))
+        self._update_frontend_relation_data()
         self._update_api_layer(event)
         self._update_celery_layer(event)
 
-    def _update_api_layer(self, event):
+    def _update_api_layer(self, _=None):
         if not self._validate_saml_config():
             self.unit.status = BlockedStatus(
                 "SAML config incomplete: if any SAML setting is provided, "
@@ -220,7 +253,7 @@ class TestObserverBackendCharm(CharmBase):
         else:
             self.unit.status = WaitingStatus("Waiting for Pebble for API")
 
-    def _update_celery_layer(self, _):
+    def _update_celery_layer(self, _=None):
         if not self._validate_saml_config():
             self.unit.status = BlockedStatus(
                 "SAML config incomplete: if any SAML setting is provided, "
@@ -263,9 +296,9 @@ class TestObserverBackendCharm(CharmBase):
         env: dict[str, str] = {
             "SENTRY_DSN": str(self.config["sentry_dsn"]),
             "CELERY_BROKER_URL": str(self._celery_broker_url),
-            "SAML_SP_BASE_URL": f"https://{self.config['hostname']}",
+            "SAML_SP_BASE_URL": self._get_url(),
             "ADDITIONAL_CORS_ORIGINS": str(self.config["additional_cors_origins"]),
-            "FRONTEND_URL": f"https://{self.config['frontend_hostname']}",
+            "FRONTEND_URL": self._get_frontend_url(),
             "SESSIONS_SECRET": str(self.config["sessions_secret"]),
             "IGNORE_PERMISSIONS": str(self.config.get("ignore_permissions", "")),
             "ENABLE_ISSUE_SYNC": str(self.config.get("enable_issue_sync", "false")),
@@ -302,14 +335,9 @@ class TestObserverBackendCharm(CharmBase):
         logger.info(f"Test Observer REST API client joined {event}")
 
     def _test_observer_rest_api_client_changed(self, event: RelationChangedEvent) -> None:
-        if self.unit.is_leader():
-            logger.debug(f"Setting hostname in data bag for {self.app}: {self.config['hostname']}")
-            event.relation.data[self.app].update(
-                {
-                    "hostname": str(self.config["hostname"]),
-                    "port": str(self.config["port"]),
-                }
-            )
+        self._update_frontend_relation_data()
+        self._update_api_layer()
+        self._update_celery_layer()
 
     @property
     def version(self) -> str | None:
@@ -446,6 +474,103 @@ class TestObserverBackendCharm(CharmBase):
         except ExecError as e:
             event.fail(e.stderr)
 
+    # TODO: This really needs to handle all possible states
+    # and should act as a state-reconciliation function.
+    # For now though, we only use it to handle ingress-related conflicts
+    def _on_collect_unit_status(self, event: CollectStatusEvent) -> None:
+        """Set the unit status based on the current state.
+
+        For example, this can be used to block the charm if config values are missing or invalid,
+        or if there are conflicting relations.
+        The ops framework triggers a CollectStatusEvent at the end of each hook.
+        """
+
+        has_ingress_conflict = self.model.get_relation("ingress") and self.model.get_relation("nginx-route")
+        if has_ingress_conflict:
+            event.add_status(BlockedStatus(INGRESS_CONFLICT_MESSAGE))
+            return
+
+        # For now, we don't want this function to overwrite any status other than BlockedStatus related to ingress conflicts
+        if self.unit.status == BlockedStatus(INGRESS_CONFLICT_MESSAGE):
+            # If the conflict is resolved, we can set the status to active again
+            if not has_ingress_conflict:
+                event.add_status(ActiveStatus())
+            return
+
+    def _get_url(self) -> str:
+        """Get the URL to use for this charm's service"""
+        # By default, we use the hostname and port from the config values,
+        # which is needed for the `nginx-route` relation.
+        port = int(self.config["port"])
+        if port == 443:
+            scheme = "https"
+        else:
+            scheme = "http"
+        url = f"{scheme}://{self.config['hostname']}"
+        if port not in (80, 443):
+            url = f"{url}:{port}"
+
+        # If the ingress relation is present and provides a URL,
+        # that is the authoritative URL, so we use that instead
+        if self.model.get_relation(INGRESS_RELATION_NAME) and self.ingress.url is not None:
+            url = self.ingress.url
+        return url.rstrip("/")
+    
+    def _get_frontend_url(self) -> str:
+        """Get the URL of the connected frontend, if any. The frontend URL is needed for CORS checks."""
+        # Default to the config value for backwards compatibility with older charm version
+        # Hardcoding the scheme to https is not ideal, but it is consistent with previous handling
+        url = f"https://{self.config['frontend_hostname']}"
+        if relation := self.model.get_relation("test-observer-rest-api"):
+            url = relation.data[relation.app].get("url", url)
+        
+        logger.info("Frontend URL: %s", url)
+        return url.rstrip("/")
+    
+    def _update_frontend_relation_data(self):
+        if not self.unit.is_leader():
+            return
+
+        url = self._get_url()
+        hostname, port = self._parse_url_host_and_port(url)
+        if hostname is None or port is None:
+            logger.warning("Could not parse hostname and port from URL. Skipping relation data update.")
+            return
+
+        # We use hostname and port for backwards compatibility
+        # with frontend charm revisions <= 242, but url is used in newer revisions
+        data = {"hostname": hostname, "port": str(port), "url": url}
+        logger.debug("Updating data bag for %s with\n: %s", self.app, data)
+        for relation in self.model.relations["test-observer-rest-api"]:
+            relation.data[self.app].update(data)
+
+    def _parse_url_host_and_port(self, url: str) -> tuple[str | None, int | None]:
+        """Parse the hostname and port from a URL."""
+        result = urllib.parse.urlsplit(url)
+        # If hostname is None, the likely candidate is that the scheme is missing,
+        # causing urlsplit to interpret the hostname as a path.
+        hostname = result.hostname
+        if hostname is None:
+            logger.info("No hostname found in URL: %s", url)
+            return (None, None)
+
+        # If port is invalid, e.g. 99999, accessing the .port attribute will raise a ValueError.
+        try:
+            port = result.port
+        except ValueError:
+            logger.info("Invalid port in URL: %s", url)
+            return (hostname, None)
+
+        if port is None:
+            if result.scheme == "http":
+                port = 80
+            elif result.scheme == "https":
+                port = 443
+            else:
+                logger.info("Could not determine port from URL scheme in URL: %s", url)
+                return (hostname, None)
+            
+        return (hostname, port)
 
 if __name__ == "__main__":  # pragma: nocover
     main(TestObserverBackendCharm)

--- a/frontend/charm/charmcraft.yaml
+++ b/frontend/charm/charmcraft.yaml
@@ -90,8 +90,13 @@ containers:
 charm-libs:
   - lib: nginx_ingress_integrator.nginx_route
     version: "0"
+  - lib: traefik_k8s.ingress
+    version: "2"
 
 requires:
+  ingress:
+    interface: ingress
+    limit: 1
   test-observer-rest-api:
     interface: http
     limit: 1

--- a/frontend/charm/lib/charms/traefik_k8s/v2/ingress.py
+++ b/frontend/charm/lib/charms/traefik_k8s/v2/ingress.py
@@ -1,0 +1,949 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+r"""# Interface Library for ingress.
+
+This library wraps relation endpoints using the `ingress` interface
+and provides a Python API for both requesting and providing per-application
+ingress, with load-balancing occurring across all units.
+
+## Getting Started
+
+To get started using the library, you just need to fetch the library using `charmcraft`.
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.traefik_k8s.v2.ingress
+```
+
+In the `metadata.yaml` of the charm, add the following:
+
+```yaml
+requires:
+    ingress:
+        interface: ingress
+        limit: 1
+```
+
+Then, to initialise the library:
+
+```python
+from charms.traefik_k8s.v2.ingress import (IngressPerAppRequirer,
+  IngressPerAppReadyEvent, IngressPerAppRevokedEvent)
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.ingress = IngressPerAppRequirer(self, port=80)
+    # The following event is triggered when the ingress URL to be used
+    # by this deployment of the `SomeCharm` is ready (or changes).
+    self.framework.observe(
+        self.ingress.on.ready, self._on_ingress_ready
+    )
+    self.framework.observe(
+        self.ingress.on.revoked, self._on_ingress_revoked
+    )
+
+    def _on_ingress_ready(self, event: IngressPerAppReadyEvent):
+        logger.info("This app's ingress URL: %s", event.url)
+
+    def _on_ingress_revoked(self, event: IngressPerAppRevokedEvent):
+        logger.info("This app no longer has ingress")
+"""
+
+import ipaddress
+import json
+import logging
+import socket
+import typing
+from dataclasses import dataclass
+from functools import partial
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
+
+import pydantic
+from ops import EventBase
+from ops.charm import CharmBase, RelationBrokenEvent, RelationEvent
+from ops.framework import EventSource, Object, ObjectEvents, StoredState
+from ops.model import ModelError, Relation, Unit
+from pydantic import AnyHttpUrl, BaseModel, Field
+
+# The unique Charmhub library identifier, never change it
+LIBID = "e6de2a5cd5b34422a204668f3b8f90d2"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 2
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 20
+
+PYDEPS = ["pydantic"]
+
+DEFAULT_RELATION_NAME = "ingress"
+RELATION_INTERFACE = "ingress"
+
+log = logging.getLogger(__name__)
+BUILTIN_JUJU_KEYS = {"ingress-address", "private-address", "egress-subnets"}
+
+PYDANTIC_IS_V1 = int(pydantic.version.VERSION.split(".")[0]) < 2
+if PYDANTIC_IS_V1:  # noqa
+    from pydantic import validator
+
+    input_validator = partial(validator, pre=True)
+
+    class DatabagModel(BaseModel):  # type: ignore
+        """Base databag model."""
+
+        class Config:
+            """Pydantic config."""
+
+            allow_population_by_field_name = True
+            """Allow instantiating this class by field name (instead of forcing alias)."""
+
+        _NEST_UNDER = None
+
+        # Annotating -> "DatabagModel" as the return type here doesn't sit well with pyright
+        # We are disabling this line for now and come back to it later.
+        @classmethod
+        def load(cls, databag: MutableMapping):  # type: ignore[no-untyped-def]
+            """Load this model from a Juju databag."""
+            if cls._NEST_UNDER:
+                return cls.parse_obj(json.loads(databag[cls._NEST_UNDER]))
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {f.alias for f in cls.__fields__.values()}  # type: ignore
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                log.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.parse_raw(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                log.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True) -> Any:
+            """Write the contents of this model to Juju databag.
+
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+
+            if self._NEST_UNDER:
+                databag[self._NEST_UNDER] = self.json(by_alias=True, exclude_defaults=True)
+                return databag
+
+            for key, value in self.dict(by_alias=True, exclude_defaults=True).items():  # type: ignore  # noqa
+                databag[key] = json.dumps(value)
+
+            return databag
+
+else:
+    from pydantic import ConfigDict, field_validator
+
+    input_validator = partial(field_validator, mode="before")  # type: ignore
+
+    class DatabagModel(BaseModel):  # type: ignore
+        """Base databag model."""
+
+        model_config = ConfigDict(
+            # tolerate additional keys in databag
+            extra="ignore",
+            # Allow instantiating this class by field name (instead of forcing alias).
+            populate_by_name=True,
+            # Custom config key: whether to nest the whole datastructure (as json)
+            # under a field or spread it out at the toplevel.
+            _NEST_UNDER=None,
+        )  # type: ignore
+        """Pydantic config."""
+
+        # Annotating -> "DatabagModel" as the return type here doesn't sit well with pyright
+        # We are disabling this line for now and come back to it later.
+        @classmethod
+        def load(cls, databag: MutableMapping):  # type: ignore[no-untyped-def]
+            """Load this model from a Juju databag."""
+            nest_under = cls.model_config.get("_NEST_UNDER")
+            if nest_under:
+                return cls.model_validate(json.loads(databag[nest_under]))  # type: ignore
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {(f.alias or n) for n, f in cls.model_fields.items()}  # type: ignore
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                log.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.model_validate_json(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                log.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True) -> Any:
+            """Write the contents of this model to Juju databag.
+
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+            nest_under = self.model_config.get("_NEST_UNDER")
+            if nest_under:
+                databag[nest_under] = self.model_dump_json(  # type: ignore
+                    by_alias=True,
+                    # skip keys whose values are default
+                    exclude_defaults=True,
+                )
+                return databag
+
+            dct = self.model_dump(
+                mode="json",
+                by_alias=True,
+                exclude_defaults=True,  # type: ignore
+            )
+            databag.update({k: json.dumps(v) for k, v in dct.items()})
+            return databag
+
+
+# todo: import these models from charm-relation-interfaces/ingress/v2 instead of redeclaring them
+class IngressUrl(BaseModel):
+    """Ingress url schema."""
+
+    url: AnyHttpUrl
+
+
+class IngressProviderAppData(DatabagModel):
+    """Ingress application databag schema."""
+
+    ingress: Optional[IngressUrl] = None
+
+
+class ProviderSchema(BaseModel):
+    """Provider schema for Ingress."""
+
+    app: IngressProviderAppData
+
+
+class IngressHealthCheck(BaseModel):
+    """HealthCheck schema for Ingress."""
+
+    path: str = Field(description="The health check endpoint path (required).")
+    scheme: Optional[str] = Field(
+        default=None, description="Replaces the server URL scheme for the health check endpoint."
+    )
+    hostname: Optional[str] = Field(
+        default=None, description="Hostname to be set in the health check request."
+    )
+    port: Optional[int] = Field(
+        default=None, description="Replaces the server URL port for the health check endpoint."
+    )
+    interval: str = Field(default="30s", description="Frequency of the health check calls.")
+    timeout: str = Field(default="5s", description="Maximum duration for a health check request.")
+
+
+class IngressRequirerAppData(DatabagModel):
+    """Ingress requirer application databag model."""
+
+    model: str = Field(description="The model the application is in.")
+    name: str = Field(description="the name of the app requesting ingress.")
+    port: int = Field(description="The port the app wishes to be exposed.")
+    healthcheck_params: Optional[IngressHealthCheck] = Field(
+        default=None, description="Optional health check configuration for ingress."
+    )
+
+    # fields on top of vanilla 'ingress' interface:
+    strip_prefix: Optional[bool] = Field(
+        default=False,
+        description="Whether to strip the prefix from the ingress url.",
+        alias="strip-prefix",
+    )
+    redirect_https: Optional[bool] = Field(
+        default=False,
+        description="Whether to redirect http traffic to https.",
+        alias="redirect-https",
+    )
+
+    scheme: Optional[str] = Field(
+        default="http", description="What scheme to use in the generated ingress url"
+    )
+
+    # pydantic wants 'cls' as first arg
+    @input_validator("scheme")
+    def validate_scheme(cls, scheme: str) -> str:  # noqa: N805
+        """Validate scheme arg."""
+        if scheme not in {"http", "https", "h2c"}:
+            raise ValueError("invalid scheme: should be one of `http|https|h2c`")
+        return scheme
+
+    # pydantic wants 'cls' as first arg
+    @input_validator("port")
+    def validate_port(cls, port: int) -> int:  # noqa: N805
+        """Validate port."""
+        assert isinstance(port, int), type(port)
+        assert 0 < port < 65535, "port out of TCP range"
+        return port
+
+
+class IngressRequirerUnitData(DatabagModel):
+    """Ingress requirer unit databag model."""
+
+    host: str = Field(description="Hostname at which the unit is reachable.")
+    ip: Optional[str] = Field(
+        None,
+        description="IP at which the unit is reachable, "
+        "IP can only be None if the IP information can't be retrieved from juju.",
+    )
+
+    # pydantic wants 'cls' as first arg
+    @input_validator("host")
+    def validate_host(cls, host: str) -> str:  # noqa: N805
+        """Validate host."""
+        assert isinstance(host, str), type(host)
+        return host
+
+    # pydantic wants 'cls' as first arg
+    @input_validator("ip")
+    def validate_ip(cls, ip: str) -> Optional[str]:  # noqa: N805
+        """Validate ip."""
+        if ip is None:
+            return None
+        if not isinstance(ip, str):
+            raise TypeError(f"got ip of type {type(ip)} instead of expected str")
+        try:
+            ipaddress.IPv4Address(ip)
+            return ip
+        except ipaddress.AddressValueError:
+            pass
+        try:
+            ipaddress.IPv6Address(ip)
+            return ip
+        except ipaddress.AddressValueError:
+            raise ValueError(f"{ip!r} is not a valid ip address")
+
+
+class RequirerSchema(BaseModel):
+    """Requirer schema for Ingress."""
+
+    app: IngressRequirerAppData
+    unit: IngressRequirerUnitData
+
+
+class IngressError(RuntimeError):
+    """Base class for custom errors raised by this library."""
+
+
+class NotReadyError(IngressError):
+    """Raised when a relation is not ready."""
+
+
+class DataValidationError(IngressError):
+    """Raised when data validation fails on IPU relation data."""
+
+
+class _IngressPerAppBase(Object):
+    """Base class for IngressPerUnit interface classes."""
+
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+        super().__init__(charm, relation_name)
+
+        self.charm: CharmBase = charm
+        self.relation_name = relation_name
+        self.app = self.charm.app
+        self.unit = self.charm.unit
+
+        observe = self.framework.observe
+        rel_events = charm.on[relation_name]
+        observe(rel_events.relation_changed, self._handle_relation)
+        observe(rel_events.relation_departed, self._handle_relation)
+        observe(rel_events.relation_broken, self._handle_relation_broken)
+        observe(charm.on.leader_elected, self._handle_upgrade_or_leader)  # type: ignore
+        observe(charm.on.upgrade_charm, self._handle_upgrade_or_leader)  # type: ignore
+
+    @property
+    def relations(self) -> List[Relation]:
+        """The list of Relation instances associated with this endpoint."""
+        return list(self.charm.model.relations[self.relation_name])
+
+    def _handle_relation(self, event: RelationEvent) -> None:
+        """Subclasses should implement this method to handle a relation update."""
+        pass
+
+    def _handle_relation_broken(self, event: RelationEvent) -> None:
+        """Subclasses should implement this method to handle a relation breaking."""
+        pass
+
+    def _handle_upgrade_or_leader(self, event: EventBase) -> None:
+        """Subclasses should implement this method to handle upgrades or leadership change."""
+        pass
+
+
+class _IPAEvent(RelationEvent):
+    __args__: Tuple[str, ...] = ()
+    __optional_kwargs__: Dict[str, Any] = {}
+
+    @classmethod
+    def __attrs__(cls):  # type: ignore
+        return cls.__args__ + tuple(cls.__optional_kwargs__.keys())
+
+    def __init__(self, handle, relation, *args, **kwargs):  # type: ignore
+        super().__init__(handle, relation)
+
+        if not len(self.__args__) == len(args):
+            raise TypeError("expected {} args, got {}".format(len(self.__args__), len(args)))
+
+        for attr, obj in zip(self.__args__, args):
+            setattr(self, attr, obj)
+        for attr, default in self.__optional_kwargs__.items():
+            obj = kwargs.get(attr, default)
+            setattr(self, attr, obj)
+
+    def snapshot(self) -> Dict[str, Any]:
+        dct = super().snapshot()
+        for attr in self.__attrs__():
+            obj = getattr(self, attr)
+            try:
+                dct[attr] = obj
+            except ValueError as e:
+                raise ValueError(
+                    "cannot automagically serialize {}: "
+                    "override this method and do it "
+                    "manually.".format(obj)
+                ) from e
+
+        return dct
+
+    def restore(self, snapshot: Any) -> None:
+        super().restore(snapshot)
+        for attr, obj in snapshot.items():
+            setattr(self, attr, obj)
+
+
+class IngressPerAppDataProvidedEvent(_IPAEvent):
+    """Event representing that ingress data has been provided for an app."""
+
+    __args__ = ("name", "model", "hosts", "strip_prefix", "redirect_https")
+
+    if typing.TYPE_CHECKING:
+        name: Optional[str] = None
+        model: Optional[str] = None
+        # sequence of hostname, port dicts
+        hosts: Sequence["IngressRequirerUnitData"] = ()
+        strip_prefix: bool = False
+        redirect_https: bool = False
+
+
+class IngressPerAppDataRemovedEvent(RelationEvent):
+    """Event representing that ingress data has been removed for an app."""
+
+
+class IngressPerAppEndpointsUpdatedEvent(RelationEvent):
+    """Event representing that the proxied endpoints have been updated."""
+
+
+class IngressPerAppProviderEvents(ObjectEvents):
+    """Container for IPA Provider events."""
+
+    data_provided = EventSource(IngressPerAppDataProvidedEvent)
+    data_removed = EventSource(IngressPerAppDataRemovedEvent)
+    endpoints_updated = EventSource(IngressPerAppEndpointsUpdatedEvent)
+
+
+@dataclass
+class IngressRequirerData:
+    """Data exposed by the ingress requirer to the provider."""
+
+    app: "IngressRequirerAppData"
+    units: List["IngressRequirerUnitData"]
+
+
+class IngressPerAppProvider(_IngressPerAppBase):
+    """Implementation of the provider of ingress."""
+
+    on = IngressPerAppProviderEvents()  # type: ignore
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = DEFAULT_RELATION_NAME,
+    ):
+        """Constructor for IngressPerAppProvider.
+
+        Args:
+            charm: The charm that is instantiating the instance.
+            relation_name: The name of the relation endpoint to bind to
+                (defaults to "ingress").
+        """
+        super().__init__(charm, relation_name)
+
+    def _handle_relation(self, event: RelationEvent) -> None:
+        # created, joined or changed: if remote side has sent the required data:
+        # notify listeners.
+        if self.is_ready(event.relation):
+            data = self.get_data(event.relation)
+            self.on.data_provided.emit(  # type: ignore
+                event.relation,
+                data.app.name,
+                data.app.model,
+                [
+                    unit.dict() if PYDANTIC_IS_V1 else unit.model_dump(mode="json")
+                    for unit in data.units
+                ],
+                data.app.strip_prefix or False,
+                data.app.redirect_https or False,
+            )
+
+    def _handle_relation_broken(self, event: RelationEvent) -> None:
+        self.on.data_removed.emit(event.relation, event.relation.app)  # type: ignore
+
+    def wipe_ingress_data(self, relation: Relation) -> None:
+        """Clear ingress data from relation."""
+        assert self.unit.is_leader(), "only leaders can do this"
+        try:
+            relation.data
+        except ModelError as e:
+            log.warning(
+                "error {} accessing relation data for {!r}. "
+                "Probably a ghost of a dead relation is still "
+                "lingering around.".format(e, relation.name)
+            )
+            return
+        del relation.data[self.app]["ingress"]
+        self.on.endpoints_updated.emit(relation=relation, app=relation.app)
+
+    def _get_requirer_units_data(self, relation: Relation) -> List["IngressRequirerUnitData"]:
+        """Fetch and validate the requirer's unit databag."""
+        out: List["IngressRequirerUnitData"] = []
+
+        unit: Unit
+        for unit in relation.units:
+            databag = relation.data[unit]
+            try:
+                data = IngressRequirerUnitData.load(databag)
+                out.append(cast(IngressRequirerUnitData, data))
+            except pydantic.ValidationError:
+                log.info(f"failed to validate remote unit data for {unit}")
+                raise
+        return out
+
+    @staticmethod
+    def _get_requirer_app_data(relation: Relation) -> "IngressRequirerAppData":
+        """Fetch and validate the requirer's app databag."""
+        app = relation.app
+        if app is None:
+            raise NotReadyError(relation)
+
+        databag = relation.data[app]
+        return cast(IngressRequirerAppData, IngressRequirerAppData.load(databag))
+
+    def get_data(self, relation: Relation) -> IngressRequirerData:
+        """Fetch the remote (requirer) app and units' databags."""
+        try:
+            return IngressRequirerData(
+                self._get_requirer_app_data(relation), self._get_requirer_units_data(relation)
+            )
+        except (pydantic.ValidationError, DataValidationError) as e:
+            raise DataValidationError(
+                "failed to validate ingress requirer data: %s" % str(e)
+            ) from e
+
+    def is_ready(self, relation: Optional[Relation] = None) -> bool:
+        """The Provider is ready if the requirer has sent valid data."""
+        if not relation:
+            return any(map(self.is_ready, self.relations))
+
+        try:
+            self.get_data(relation)
+        except (DataValidationError, NotReadyError) as e:
+            log.info("Provider not ready; validation error encountered: %s" % str(e))
+            return False
+        return True
+
+    def _published_url(self, relation: Relation) -> Optional["IngressProviderAppData"]:
+        """Fetch and validate this app databag; return the ingress url."""
+        if not self.is_ready(relation) or not self.unit.is_leader():
+            # Handle edge case where remote app name can be missing, e.g.,
+            # relation_broken events.
+            # Also, only leader units can read own app databags.
+            # FIXME https://github.com/canonical/traefik-k8s-operator/issues/34
+            return None
+
+        # fetch the provider's app databag
+        databag = relation.data[self.app]
+        if not databag.get("ingress"):
+            raise NotReadyError("This application did not `publish_url` yet.")
+
+        return IngressProviderAppData.load(databag)
+
+    def publish_url(self, relation: Relation, url: str) -> None:
+        """Publish to the app databag the ingress url."""
+        ingress_url = {"url": url}
+        try:
+            IngressProviderAppData(ingress=ingress_url).dump(relation.data[self.app])  # type: ignore
+            self.on.endpoints_updated.emit(relation=relation, app=relation.app)
+        except pydantic.ValidationError as e:
+            # If we cannot validate the url as valid, publish an empty databag and log the error.
+            log.error(f"Failed to validate ingress url '{url}' - got ValidationError {e}")
+            log.error(
+                (
+                    f"url was not published to ingress relation for {relation.app}."
+                    f"This error is likely due to an error or misconfiguration of the"
+                    "charm calling this library."
+                )
+            )
+            IngressProviderAppData(ingress=None).dump(relation.data[self.app])  # type: ignore
+
+    @property
+    def proxied_endpoints(self) -> Dict[str, Dict[str, str]]:
+        """Returns the ingress settings provided to applications by this IngressPerAppProvider.
+
+        For example, when this IngressPerAppProvider has provided the
+        `http://foo.bar/my-model.my-app` URL to the my-app application, the returned dictionary
+        will be:
+
+        ```
+        {
+            "my-app": {
+                "url": "http://foo.bar/my-model.my-app"
+            }
+        }
+        ```
+        """
+        results: Dict[str, Dict[str, str]] = {}
+
+        for ingress_relation in self.relations:
+            if not ingress_relation.app:
+                log.warning(
+                    (
+                        f"no app in relation {ingress_relation} when fetching proxied endpoints:"
+                        "skipping"
+                    )
+                )
+                continue
+            try:
+                ingress_data = self._published_url(ingress_relation)
+            except NotReadyError:
+                log.warning(
+                    f"no published url found in {ingress_relation}: "
+                    f"traefik didn't publish_url yet to this relation."
+                )
+                continue
+
+            if not ingress_data:
+                log.warning(f"relation {ingress_relation} not ready yet: try again in some time.")
+                continue
+
+            # Validation above means ingress cannot be None, but type checker doesn't know that.
+            ingress = cast(IngressProviderAppData, ingress_data.ingress)
+            if PYDANTIC_IS_V1:
+                results[ingress_relation.app.name] = ingress.dict()
+            else:
+                results[ingress_relation.app.name] = ingress.model_dump(mode="json")
+        return results
+
+
+class IngressPerAppReadyEvent(_IPAEvent):
+    """Event representing that ingress for an app is ready."""
+
+    __args__ = ("url",)
+    if typing.TYPE_CHECKING:
+        url: Optional[str] = None
+
+
+class IngressPerAppRevokedEvent(RelationEvent):
+    """Event representing that ingress for an app has been revoked."""
+
+
+class IngressPerAppRequirerEvents(ObjectEvents):
+    """Container for IPA Requirer events."""
+
+    ready = EventSource(IngressPerAppReadyEvent)
+    revoked = EventSource(IngressPerAppRevokedEvent)
+
+
+class IngressPerAppRequirer(_IngressPerAppBase):
+    """Implementation of the requirer of the ingress relation."""
+
+    on = IngressPerAppRequirerEvents()  # type: ignore
+
+    # used to prevent spurious urls to be sent out if the event we're currently
+    # handling is a relation-broken one.
+    _stored = StoredState()
+    _auto_data: Optional[Tuple[Optional[str], Optional[str], int]]
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = DEFAULT_RELATION_NAME,
+        *,
+        host: Optional[str] = None,
+        ip: Optional[str] = None,
+        port: Optional[int] = None,
+        strip_prefix: bool = False,
+        redirect_https: bool = False,
+        # fixme: this is horrible UX.
+        # shall we switch to manually calling provide_ingress_requirements with all args when
+        # ready?
+        scheme: Union[Callable[[], str], str] = lambda: "http",
+        healthcheck_params: Optional[Dict[str, Any]] = None,
+    ):
+        """Constructor for IngressRequirer.
+
+        The request args can be used to specify the ingress properties when the
+        instance is created. If any are set, at least `port` is required, and
+        they will be sent to the ingress provider as soon as it is available.
+        All request args must be given as keyword args.
+
+        Args:
+            charm: The charm that is instantiating the library.
+            relation_name: The name of the relation endpoint to bind to (defaults to "ingress");
+                the relation must be of interface type "ingress" and have a limit of 1.
+            host: Hostname to be used by the ingress provider to address the requiring
+                application; if unspecified, the default Kubernetes service name will be used.
+            ip: Alternative addressing method other than host to be used by the ingress provider;
+                if unspecified, the binding address from the Juju network API will be used.
+            healthcheck_params: Optional dictionary containing health check
+                configuration parameters conforming to the IngressHealthCheck schema.
+                The dictionary must include:
+                    - "path" (str): The health check endpoint path (required).
+                It may also include:
+                    - "scheme" (Optional[str]): Replaces the server URL scheme for the health check
+                        endpoint.
+                    - "hostname" (Optional[str]): Hostname to be set in the health check request.
+                    - "port" (Optional[int]): Replaces the server URL port for the health check
+                        endpoint.
+                    - "interval" (str): Frequency of the health check calls
+                        (defaults to "30s" if omitted).
+                    - "timeout" (str): Maximum duration for a health check request
+                        (defaults to "5s" if omitted).
+                If provided, "path" is required while "interval" and "timeout" will use Traefik's
+                    defaults when not specified.
+            strip_prefix: Configure Traefik to strip the path prefix.
+            redirect_https: Redirect incoming requests to HTTPS.
+            scheme: Either a callable that returns the scheme to use when constructing the ingress
+                URL, or a string if the scheme is known and stable at charm initialization.
+
+        Request Args:
+            port: the port of the service
+        """
+        super().__init__(charm, relation_name)
+        self.charm: CharmBase = charm
+        self.healthcheck_params = healthcheck_params
+        self.relation_name = relation_name
+        self._strip_prefix = strip_prefix
+        self._redirect_https = redirect_https
+        self._get_scheme = scheme if callable(scheme) else lambda: scheme
+
+        self._stored.set_default(current_url=None)  # type: ignore
+
+        # if instantiated with a port, and we are related, then
+        # we immediately publish our ingress data  to speed up the process.
+        if port:
+            self._auto_data = host, ip, port
+        else:
+            self._auto_data = None
+
+    def _handle_relation(self, event: RelationEvent) -> None:
+        # created, joined or changed: if we have auto data: publish it
+        self._publish_auto_data()
+        if self.is_ready():
+            # Avoid spurious events, emit only when there is a NEW URL available
+            new_url = (
+                None
+                if isinstance(event, RelationBrokenEvent)
+                else self._get_url_from_relation_data()
+            )
+            if self._stored.current_url != new_url:  # type: ignore
+                self._stored.current_url = new_url  # type: ignore
+                self.on.ready.emit(event.relation, new_url)  # type: ignore
+
+    def _handle_relation_broken(self, event: RelationEvent) -> None:
+        self._stored.current_url = None  # type: ignore
+        self.on.revoked.emit(relation=event.relation, app=event.relation.app)  # type: ignore
+
+    def _handle_upgrade_or_leader(self, event: EventBase) -> None:
+        """On upgrade/leadership change: ensure we publish the data we have."""
+        self._publish_auto_data()
+
+    def is_ready(self) -> bool:
+        """The Requirer is ready if the Provider has sent valid data."""
+        try:
+            return bool(self._get_url_from_relation_data())
+        except DataValidationError as e:
+            log.debug("Requirer not ready; validation error encountered: %s" % str(e))
+            return False
+
+    def _publish_auto_data(self) -> None:
+        if self._auto_data:
+            host, ip, port = self._auto_data
+            self.provide_ingress_requirements(host=host, ip=ip, port=port)
+
+    def provide_ingress_requirements(
+        self,
+        *,
+        scheme: Optional[str] = None,
+        host: Optional[str] = None,
+        ip: Optional[str] = None,
+        port: int,
+    ) -> None:
+        """Publishes the data that Traefik needs to provide ingress.
+
+        Args:
+            scheme: Scheme to be used; if unspecified, use the one used by __init__.
+            host: Hostname to be used by the ingress provider to address the
+             requirer unit; if unspecified, FQDN will be used instead
+            ip: Alternative addressing method other than host to be used by the ingress provider.
+                if unspecified, binding address from juju network API will be used.
+            port: the port of the service (required)
+        """
+        for relation in self.relations:
+            self._provide_ingress_requirements(scheme, host, ip, port, relation)
+
+    def _provide_ingress_requirements(
+        self,
+        scheme: Optional[str],
+        host: Optional[str],
+        ip: Optional[str],
+        port: int,
+        relation: Relation,
+    ) -> None:
+        if self.unit.is_leader():
+            self._publish_app_data(scheme, port, relation)
+
+        self._publish_unit_data(host, ip, relation)
+
+    def _publish_unit_data(
+        self,
+        host: Optional[str],
+        ip: Optional[str],
+        relation: Relation,
+    ) -> None:
+        if not host:
+            host = socket.getfqdn()
+
+        if ip is None:
+            network_binding = self.charm.model.get_binding(relation)
+            if (
+                network_binding is not None
+                and (bind_address := network_binding.network.bind_address) is not None
+            ):
+                ip = str(bind_address)
+            else:
+                log.error("failed to retrieve ip information from juju")
+
+        unit_databag = relation.data[self.unit]
+        try:
+            IngressRequirerUnitData(host=host, ip=ip).dump(unit_databag)
+        except pydantic.ValidationError as e:
+            msg = "failed to validate unit data"
+            log.info(msg, exc_info=True)  # log to INFO because this might be expected
+            raise DataValidationError(msg) from e
+
+    def _publish_app_data(
+        self,
+        scheme: Optional[str],
+        port: int,
+        relation: Relation,
+    ) -> None:
+        # assumes leadership!
+        app_databag = relation.data[self.app]
+
+        if not scheme:
+            # If scheme was not provided, use the one given to the constructor.
+            scheme = self._get_scheme()
+
+        try:
+            # Ignore pyright errors since pyright does not like aliases.
+            IngressRequirerAppData(  # type: ignore
+                model=self.model.name,
+                name=self.app.name,
+                scheme=scheme,
+                port=port,
+                strip_prefix=self._strip_prefix,  # type: ignore
+                redirect_https=self._redirect_https,  # type: ignore
+                healthcheck_params=(
+                    IngressHealthCheck(**self.healthcheck_params)
+                    if self.healthcheck_params
+                    else None
+                ),
+            ).dump(app_databag)
+        except pydantic.ValidationError as e:
+            msg = "failed to validate app data"
+            log.info(msg, exc_info=True)  # log to INFO because this might be expected
+            raise DataValidationError(msg) from e
+
+    @property
+    def relation(self) -> Optional[Relation]:
+        """The established Relation instance, or None."""
+        return self.relations[0] if self.relations else None
+
+    def _get_url_from_relation_data(self) -> Optional[str]:
+        """The full ingress URL to reach the charm application.
+
+        Returns None if the URL isn't available yet.
+        """
+        relation = self.relation
+        if not relation or not relation.app:
+            return None
+
+        # fetch the provider's app databag
+        try:
+            databag = relation.data[relation.app]
+        except ModelError as e:
+            log.debug(
+                f"Error {e} attempting to read remote app data; "
+                f"probably we are in a relation_departed hook"
+            )
+            return None
+
+        if not databag:  # not ready yet
+            return None
+
+        ingress = cast(IngressProviderAppData, IngressProviderAppData.load(databag)).ingress
+        if ingress is None:
+            return None
+
+        return str(ingress.url)
+
+    @property
+    def url(self) -> Optional[str]:
+        """The full ingress URL to reach the charm application.
+
+        Returns None if the URL isn't available yet.
+        """
+        data = (
+            typing.cast(Optional[str], self._stored.current_url)  # type: ignore
+            or self._get_url_from_relation_data()
+        )
+        return data

--- a/frontend/charm/requirements.txt
+++ b/frontend/charm/requirements.txt
@@ -16,3 +16,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ops >= 2.8.0
+pydantic==2.13.3

--- a/frontend/charm/src/charm.py
+++ b/frontend/charm/src/charm.py
@@ -25,6 +25,11 @@ from typing import Optional, Tuple
 import ops
 import yaml
 from charms.nginx_ingress_integrator.v0.nginx_route import require_nginx_route
+from charms.traefik_k8s.v2.ingress import (
+    IngressPerAppReadyEvent,
+    IngressPerAppRequirer,
+    IngressPerAppRevokedEvent,
+)
 from ops.model import (
     ActiveStatus,
     BlockedStatus,
@@ -38,6 +43,9 @@ from ops.pebble import Layer
 from nginx_config import html_503, nginx_503_config, nginx_config
 
 logger = logging.getLogger(__name__)
+
+INGRESS_RELATION_NAME = "ingress"
+INGRESS_CONFLICT_MESSAGE = "Cannot have both ingress and nginx-route relations at the same time"
 
 
 class TestObserverFrontendCharm(ops.CharmBase):
@@ -63,9 +71,32 @@ class TestObserverFrontendCharm(ops.CharmBase):
             self._on_rest_api_relation_broken,
         )
 
-        self._setup_ingress()
+        # Traefik will default to prefixing routes with <model-name>-<app-name>,
+        # so we need to use strip_prefix=True to remove that and keep the API working with expected routes
+        self.ingress = IngressPerAppRequirer(
+            charm=self,
+            relation_name=INGRESS_RELATION_NAME,
+            port=int(self.config["port"]),
+            strip_prefix=True,
+        )
+        self.framework.observe(self.ingress.on.ready, self._on_ingress_ready)
+        self.framework.observe(self.ingress.on.revoked, self._on_ingress_revoked)
 
-    def _setup_ingress(self):
+        self._setup_nginx()
+
+        # The ops framework triggers a CollectStatusEvent at the end of each hook
+        self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
+
+    def _on_ingress_ready(self, event: IngressPerAppReadyEvent) -> None:
+        """Process the ingress URL and provide the hostname where needed."""
+        logger.info("Ingress is ready with url %s", event.url)
+        self._update_backend_relation_data()
+
+    def _on_ingress_revoked(self, event: IngressPerAppRevokedEvent) -> None:
+        logger.info("Ingress revoked")
+        self._update_backend_relation_data()
+
+    def _setup_nginx(self):
         require_nginx_route(
             charm=self,
             service_hostname=self.config["hostname"],
@@ -73,14 +104,16 @@ class TestObserverFrontendCharm(ops.CharmBase):
             service_port=int(self.config["port"]),
         )
 
-    def _on_config_changed(self, event):
+    def _on_config_changed(self, _):
         is_valid, reason = self._config_is_valid(self.config)
 
         if not is_valid:
             self.unit.status = BlockedStatus(reason)
             return
 
-        self._update_layer_and_restart(event)
+        self.ingress.provide_ingress_requirements(port=int(self.config["port"]))
+        self._update_backend_relation_data()
+        self._update_layer_and_restart()
 
     def _config_is_valid(self, config: ConfigData) -> Tuple[bool, Optional[str]]:
         """Validate the provided config."""
@@ -105,10 +138,8 @@ class TestObserverFrontendCharm(ops.CharmBase):
         return True, None
 
     def _on_rest_api_relation_update(self, event):
-        api_hostname = event.relation.data[event.app].get("hostname")
-        api_port = event.relation.data[event.app].get("port")
-        logger.debug(f"API hostname: {api_hostname}, port: {api_port} (app: {event.app})")
-        self._update_layer_and_restart(event)
+        self._update_backend_relation_data()
+        self._update_layer_and_restart()
 
     def _update_frontend_config(self):
         """Update the frontend configuration file from the charm config's frontend-config option."""
@@ -182,7 +213,10 @@ class TestObserverFrontendCharm(ops.CharmBase):
                 self.container.add_layer(
                     self.pebble_service_name, self._pebble_layer, combine=True
                 )
-                self.container.replan()
+                # If only a file like the nginx config is updated, Pebble won't detect a change,
+                # so replan won't trigger a restart, and the new config won't be applied.
+                # As a result, we explicitly restart to ensure the new config is always applied.
+                self.container.restart(self.pebble_service_name)
                 self.unit.status = ActiveStatus()
             else:
                 self._handle_no_api_relation()
@@ -201,6 +235,11 @@ class TestObserverFrontendCharm(ops.CharmBase):
         if not relation_data:
             self.unit.status = WaitingStatus("Waiting for test observer api relation data")
             return None
+
+        # As of revision 351, the backend charm provides the URL directly in the relation data,
+        # so if that is available, we prioritize it
+        if "url" in relation_data:
+            return relation_data["url"]
 
         hostname = relation_data["hostname"]
         port = relation_data["port"]
@@ -251,6 +290,59 @@ class TestObserverFrontendCharm(ops.CharmBase):
                 },
             }
         )
+
+    # TODO: This really needs to handle all possible states
+    # and should act as a state-reconciliation function.
+    # For now though, we only use it to handle ingress-related conflicts
+    def _on_collect_unit_status(self, event: ops.CollectStatusEvent) -> None:
+        """Set the unit status based on the current state.
+
+        For example, this can be used to block the charm if config values are missing or invalid,
+        or if there are conflicting relations.
+        The ops framework triggers a CollectStatusEvent at the end of each hook.
+        """
+
+        has_ingress_conflict = self.model.get_relation("ingress") and self.model.get_relation("nginx-route")
+        if has_ingress_conflict:
+            event.add_status(BlockedStatus(INGRESS_CONFLICT_MESSAGE))
+            return
+
+        # For now, we don't want this function to overwrite any status other than BlockedStatus related to ingress conflicts
+        if self.unit.status == BlockedStatus(INGRESS_CONFLICT_MESSAGE):
+            # If the conflict is resolved, we can set the status to active again
+            if not has_ingress_conflict:
+                event.add_status(ActiveStatus())
+            return
+
+    def _get_url(self) -> str:
+        """Get the URL to use for this charm's service"""
+        # By default, we use the hostname and port from the config values,
+        # which is needed for the `nginx-route` relation.
+        port = int(self.config["port"])
+        if port == 443:
+            scheme = "https"
+        else:
+            scheme = "http"
+        url = f"{scheme}://{self.config['hostname']}"
+        if port not in (80, 443):
+            url = f"{url}:{port}"
+
+        # If the ingress relation is present and provides a URL,
+        # that is the authoritative URL, so we use that instead
+        if self.model.get_relation(INGRESS_RELATION_NAME) and self.ingress.url is not None:
+            url = self.ingress.url
+        return url.rstrip("/")
+
+    def _update_backend_relation_data(self):
+        if not self.unit.is_leader():
+            return
+
+        url = self._get_url()
+        # Prior to revision 242, this charm provided no relation data. Subsequent revisions provide the URL.
+        data = {"url": url}
+        logger.debug("Updating data bag for %s with\n: %s", self.app, data)
+        for relation in self.model.relations["test-observer-rest-api"]:
+            relation.data[self.app].update(data)
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/frontend/charm/src/charm.py
+++ b/frontend/charm/src/charm.py
@@ -301,8 +301,9 @@ class TestObserverFrontendCharm(ops.CharmBase):
         or if there are conflicting relations.
         The ops framework triggers a CollectStatusEvent at the end of each hook.
         """
-
-        has_ingress_conflict = self.model.get_relation("ingress") and self.model.get_relation("nginx-route")
+        has_ingress_conflict = self.model.get_relation("ingress") and self.model.get_relation(
+            "nginx-route"
+        )
         if has_ingress_conflict:
             event.add_status(BlockedStatus(INGRESS_CONFLICT_MESSAGE))
             return
@@ -315,7 +316,7 @@ class TestObserverFrontendCharm(ops.CharmBase):
             return
 
     def _get_url(self) -> str:
-        """Get the URL to use for this charm's service"""
+        """Get the URL to use for this charm's service."""
         # By default, we use the hostname and port from the config values,
         # which is needed for the `nginx-route` relation.
         port = int(self.config["port"])

--- a/frontend/charm/src/charm.py
+++ b/frontend/charm/src/charm.py
@@ -343,7 +343,9 @@ class TestObserverFrontendCharm(ops.CharmBase):
         data = {"url": url}
         logger.debug("Updating data bag for %s with\n: %s", self.app, data)
         for relation in self.model.relations["test-observer-rest-api"]:
-            relation.data[self.app].update(data)
+            bag = relation.data[self.app]
+            if any(bag.get(k) != v for k, v in data.items()):
+                bag.update(data)
 
 
 if __name__ == "__main__":  # pragma: nocover


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR adds support for the `ingress` interface using the `traefik-k8s` charm library. The `ingress` interface works differently from the `nginx-route` interface - in the case of `ingress`, the URL comes from the ingress provider, not from the charm's own config.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

IQA-3642

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Deployed to staging. The backend and frontend are both accessible at their ingress URLs, and the frontend points to the backend correctly
