### PR TITLE
Fix frontend charm build

### DIFF
--- a/frontend/charm/charmcraft.yaml
+++ b/frontend/charm/charmcraft.yaml
@@ -46,6 +46,16 @@ parts:
     charm-entrypoint: src/charm.py
     charm-requirements:
       - requirements.txt
+    build-packages: [pkg-config, libffi-dev, libssl-dev, build-essential]
+    build-snaps: [rustup]
+    override-build: |
+      # pydantic requires a higher version of rustc than what is in the archive
+      # for 22.04
+      # Install rustc and cargo using rustup instead of the Ubuntu archive
+      rustup set profile minimal
+      rustup default 1.93.0  # renovate: charmcraft-rust-latest
+
+      craftctl default
 
 assumes:
   - juju >= 2.9


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR fixes an issue where the frontend charm can fail to build due to the new `pydantic` dependency introduced by the `traefik-k8s` ingress library. It copies what already existed in the backend's `charmcraft.yaml`.

Example failed build:
https://github.com/canonical/test_observer/actions/runs/26774292692/job/78929560559

Passing build from this PR (which ran because the PR branch has the `testing` prefix):
https://github.com/canonical/test_observer/actions/runs/26776867729/job/78931765217

