### PR TITLE
Address Starlette BadHost CVE

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "python-multipart>=0.0.20,<0.1.0",
     "itsdangerous>=2.2.0",
     "prometheus-fastapi-instrumentator>=7.1.0",
-    "starlette==1.0.1",
+    "starlette>=1.0.1",
 ]
 
 [dependency-groups]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,7 +21,7 @@ dynamic = ["version"] # uv-dynamic-versioning used
 requires-python = ">=3.12"
 
 dependencies = [
-    "fastapi>=0.120.0,<0.121.0",
+    "fastapi>=0.133.0,<0.134.0",
     "uvicorn[standard]>=0.47.0,<0.48.0",
     "sqlalchemy>=2.0.16,<3.0.0",
     "pg8000>=1.29.4,<2.0.0",
@@ -38,6 +38,7 @@ dependencies = [
     "python-multipart>=0.0.20,<0.1.0",
     "itsdangerous>=2.2.0",
     "prometheus-fastapi-instrumentator>=7.1.0",
+    "starlette==1.0.1",
 ]
 
 [dependency-groups]

--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -9243,6 +9243,13 @@
           "type": {
             "type": "string",
             "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
           }
         },
         "type": "object",

--- a/backend/test_observer/controllers/auth/saml.py
+++ b/backend/test_observer/controllers/auth/saml.py
@@ -198,8 +198,11 @@ async def _prepare_from_fastapi_request(request: Request) -> dict[str, Any]:
     result: dict[str, Any] = {
         "http_host": request.url.hostname,
         "server_port": request.url.port,
-        # request.url reconstructs the full URL using the Host header; avoid relying on it for security checks.
-        # Using request.scope["path"] ensures the script_name is based on the ASGI path (independent of Host).
+        # We use request.scope["path"] instead of request.url.path
+        # because request.scope["path"] ensures the script_name is based on the ASGI path
+        # request.url reconstructs the URL using the Host header
+        # and should be avoided for auth/security checks
+        # See CVE-2026-48710
         "script_name": request.scope["path"],
         "post_data": {},
         "get_data": {},

--- a/backend/test_observer/controllers/auth/saml.py
+++ b/backend/test_observer/controllers/auth/saml.py
@@ -198,8 +198,8 @@ async def _prepare_from_fastapi_request(request: Request) -> dict[str, Any]:
     result: dict[str, Any] = {
         "http_host": request.url.hostname,
         "server_port": request.url.port,
-        # request.url is constructed from the Host header, which can be manipulated if proper validation is missing.
-        # Thus, it is more secure to use request.scope["path"] instead, as it cannot be manipulated by the Host header.
+         # request.url reconstructs the full URL using the Host header; avoid relying on it for security checks.
+         # Using request.scope["path"] ensures the script_name is based on the ASGI path (independent of Host).
         "script_name": request.scope["path"],
         "post_data": {},
         "get_data": {},

--- a/backend/test_observer/controllers/auth/saml.py
+++ b/backend/test_observer/controllers/auth/saml.py
@@ -198,8 +198,8 @@ async def _prepare_from_fastapi_request(request: Request) -> dict[str, Any]:
     result: dict[str, Any] = {
         "http_host": request.url.hostname,
         "server_port": request.url.port,
-         # request.url reconstructs the full URL using the Host header; avoid relying on it for security checks.
-         # Using request.scope["path"] ensures the script_name is based on the ASGI path (independent of Host).
+        # request.url reconstructs the full URL using the Host header; avoid relying on it for security checks.
+        # Using request.scope["path"] ensures the script_name is based on the ASGI path (independent of Host).
         "script_name": request.scope["path"],
         "post_data": {},
         "get_data": {},

--- a/backend/test_observer/controllers/auth/saml.py
+++ b/backend/test_observer/controllers/auth/saml.py
@@ -198,7 +198,9 @@ async def _prepare_from_fastapi_request(request: Request) -> dict[str, Any]:
     result: dict[str, Any] = {
         "http_host": request.url.hostname,
         "server_port": request.url.port,
-        "script_name": request.url.path,
+        # request.url is constructed from the Host header, which can be manipulated if proper validation is missing.
+        # Thus, it is more secure to use request.scope["path"] instead, as it cannot be manipulated by the Host header.
+        "script_name": request.scope["path"],
         "post_data": {},
         "get_data": {},
     }

--- a/backend/test_observer/controllers/docs/docs.py
+++ b/backend/test_observer/controllers/docs/docs.py
@@ -40,9 +40,7 @@ async def custom_openapi(request: Request):
         # Get security scopes for all dependencies
         security_scopes: list[Permission] = []
         for dep in route.dependant.dependencies:
-            if hasattr(dep, "security_requirements"):
-                for security_requirement in dep.security_requirements:
-                    security_scopes.extend(security_requirement.scopes)
+            security_scopes.extend(dep.oauth_scopes)
 
         if len(security_scopes) == 0:
             continue

--- a/backend/test_observer/controllers/docs/docs.py
+++ b/backend/test_observer/controllers/docs/docs.py
@@ -40,7 +40,10 @@ async def custom_openapi(request: Request):
         # Get security scopes for all dependencies
         security_scopes: list[Permission] = []
         for dep in route.dependant.dependencies:
-            security_scopes.extend(dep.security_scopes)
+            if hasattr(dep, "security_requirements"):
+                for security_requirement in dep.security_requirements:
+                    security_scopes.extend(security_requirement.scopes)
+
         if len(security_scopes) == 0:
             continue
 

--- a/backend/test_observer/controllers/execution_metadata/execution_metadata.py
+++ b/backend/test_observer/controllers/execution_metadata/execution_metadata.py
@@ -22,11 +22,9 @@ from test_observer.common.permissions import permission_checker
 from test_observer.data_access.models import TestExecutionMetadata
 from test_observer.data_access.setup import get_db
 
-from . import execution_metadata
 from .models import ExecutionMetadata, ExecutionMetadataGetResponse
 
 router = APIRouter(tags=["execution-metadata"])
-router.include_router(execution_metadata.router)
 
 
 @router.get(

--- a/backend/test_observer/users/user_injection.py
+++ b/backend/test_observer/users/user_injection.py
@@ -59,8 +59,11 @@ def get_user_session_browser_friendly(request: Request, db: Session = Depends(ge
     """
 
     # Enforce that this dependency is only used for the /docs endpoint
-    # request.url reconstructs the full URL using the Host header; avoid relying on it for security checks.
-    # Using request.scope["path"] ensures the script_name is based on the ASGI path (independent of Host).
+    # We use request.scope["path"] instead of request.url.path
+    # because request.scope["path"] ensures the script_name is based on the ASGI path
+    # request.url reconstructs the URL using the Host header
+    # and should be avoided for auth/security checks
+    # See CVE-2026-48710
     if request.scope["path"] != "/docs":
         return None
 

--- a/backend/test_observer/users/user_injection.py
+++ b/backend/test_observer/users/user_injection.py
@@ -59,8 +59,8 @@ def get_user_session_browser_friendly(request: Request, db: Session = Depends(ge
     """
 
     # Enforce that this dependency is only used for the /docs endpoint
-    # request.url is constructed from the Host header, which can be manipulated if proper validation is missing.
-    # Thus, it is more secure to use request.scope["path"] instead, as it cannot be manipulated by the Host header.
+    # request.url reconstructs the full URL using the Host header; avoid relying on it for security checks.
+    # Using request.scope["path"] ensures the script_name is based on the ASGI path (independent of Host).
     if request.scope["path"] != "/docs":
         return None
 

--- a/backend/test_observer/users/user_injection.py
+++ b/backend/test_observer/users/user_injection.py
@@ -59,7 +59,9 @@ def get_user_session_browser_friendly(request: Request, db: Session = Depends(ge
     """
 
     # Enforce that this dependency is only used for the /docs endpoint
-    if request.url.path != "/docs":
+    # request.url is constructed from the Host header, which can be manipulated if proper validation is missing.
+    # Thus, it is more secure to use request.scope["path"] instead, as it cannot be manipulated by the Host header.
+    if request.scope["path"] != "/docs":
         return None
 
     if request.method != "GET" and "X-CSRF-Token" not in request.headers:

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1569,7 +1569,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.33.0,<3.0.0" },
     { name = "sentry-sdk", specifier = "==2.8.0" },
     { name = "sqlalchemy", specifier = ">=2.0.16,<3.0.0" },
-    { name = "starlette", specifier = "==1.0.1" },
+    { name = "starlette", specifier = ">=1.0.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.47.0,<0.48.0" },
 ]
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -472,17 +472,18 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.120.4"
+version = "0.133.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/3a/0bf90d5189d7f62dc2bd0523899629ca59b58ff4290d631cd3bb5c8889d4/fastapi-0.120.4.tar.gz", hash = "sha256:2d856bc847893ca4d77896d4504ffdec0fb04312b705065fca9104428eca3868", size = 339716, upload-time = "2025-10-31T18:37:28.81Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/6f/0eafed8349eea1fa462238b54a624c8b408cd1ba2795c8e64aa6c34f8ab7/fastapi-0.133.1.tar.gz", hash = "sha256:ed152a45912f102592976fde6cbce7dae1a8a1053da94202e51dd35d184fadd6", size = 378741, upload-time = "2026-02-25T18:18:17.398Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/47/14a76b926edc3957c8a8258423db789d3fa925d2fed800102fce58959413/fastapi-0.120.4-py3-none-any.whl", hash = "sha256:9bdf192308676480d3593e10fd05094e56d6fdc7d9283db26053d8104d5f82a0", size = 108235, upload-time = "2025-10-31T18:37:27.038Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/c9/a175a7779f3599dfa4adfc97a6ce0e157237b3d7941538604aadaf97bfb6/fastapi-0.133.1-py3-none-any.whl", hash = "sha256:658f34ba334605b1617a65adf2ea6461901bdb9af3a3080d63ff791ecf7dc2e2", size = 109029, upload-time = "2026-02-25T18:18:18.578Z" },
 ]
 
 [[package]]
@@ -1006,15 +1007,15 @@ wheels = [
 
 [[package]]
 name = "prometheus-fastapi-instrumentator"
-version = "7.1.0"
+version = "8.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "prometheus-client" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/6d/24d53033cf93826aa7857699a4450c1c67e5b9c710e925b1ed2b320c04df/prometheus_fastapi_instrumentator-7.1.0.tar.gz", hash = "sha256:be7cd61eeea4e5912aeccb4261c6631b3f227d8924542d79eaf5af3f439cbe5e", size = 20220, upload-time = "2025-03-19T19:35:05.351Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/7a/fe49b7060e585e2cfa28cc1d13ebfe9c2904dcd80cf11071d5de0f622ff2/prometheus_fastapi_instrumentator-8.0.0.tar.gz", hash = "sha256:c31ed192db077e75467b28b2fe5055362517f53369b798cb8dac9ff85f3f1c38", size = 20357, upload-time = "2026-05-29T13:04:43.327Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/72/0824c18f3bc75810f55dacc2dd933f6ec829771180245ae3cc976195dec0/prometheus_fastapi_instrumentator-7.1.0-py3-none-any.whl", hash = "sha256:978130f3c0bb7b8ebcc90d35516a6fe13e02d2eb358c8f83887cdef7020c31e9", size = 19296, upload-time = "2025-03-19T19:35:04.323Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ad/b14ed2fe73bb1d37bcc947e75afae018f795526415d5b849aeb99c403cd1/prometheus_fastapi_instrumentator-8.0.0-py3-none-any.whl", hash = "sha256:e3c967c402124dfe81cf5aad35208d9f96db5452c6cb752350d9358ca0a96198", size = 19411, upload-time = "2026-05-29T13:04:44.17Z" },
 ]
 
 [[package]]
@@ -1502,15 +1503,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.49.1"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/3f/507c21db33b66fb027a332f2cb3abbbe924cc3a79ced12f01ed8645955c9/starlette-0.49.1.tar.gz", hash = "sha256:481a43b71e24ed8c43b11ea02f5353d77840e01480881b8cb5a26b8cae64a8cb", size = 2654703, upload-time = "2025-10-28T17:34:10.928Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/da/545b75d420bb23b5d494b0517757b351963e974e79933f01e05c929f20a6/starlette-0.49.1-py3-none-any.whl", hash = "sha256:d92ce9f07e4a3caa3ac13a79523bd18e3bc0042bb8ff2d759a8e7dd0e1859875", size = 74175, upload-time = "2025-10-28T17:34:09.13Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
 ]
 
 [[package]]
@@ -1533,6 +1534,7 @@ dependencies = [
     { name = "requests" },
     { name = "sentry-sdk" },
     { name = "sqlalchemy" },
+    { name = "starlette" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -1555,7 +1557,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.10.3,<2.0.0" },
     { name = "celery", extras = ["redis"], specifier = ">=5.3.6,<6.0.0" },
     { name = "email-validator", specifier = ">=2.1.0.post1,<3.0.0" },
-    { name = "fastapi", specifier = ">=0.120.0,<0.121.0" },
+    { name = "fastapi", specifier = ">=0.133.0,<0.134.0" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "jira", specifier = ">=3.10.0,<4.0.0" },
     { name = "launchpadlib", specifier = ">=1.11.0,<2.0.0" },
@@ -1567,6 +1569,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.33.0,<3.0.0" },
     { name = "sentry-sdk", specifier = "==2.8.0" },
     { name = "sqlalchemy", specifier = ">=2.0.16,<3.0.0" },
+    { name = "starlette", specifier = "==1.0.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.47.0,<0.48.0" },
 ]
 
@@ -1606,14 +1609,14 @@ wheels = [
 
 [[package]]
 name = "typing-inspection"
-version = "0.4.0"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/82/5c/e6082df02e215b846b4b8c0b887a64d7d08ffaba30605502639d44c06b82/typing_inspection-0.4.0.tar.gz", hash = "sha256:9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122", size = 76222, upload-time = "2025-02-25T17:27:59.638Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl", hash = "sha256:50e72559fcd2a6367a19f7a7e610e6afcb9fac940c650290eed893d61386832f", size = 14125, upload-time = "2025-02-25T17:27:57.754Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR pins `starlette>=1.0.1`, which is the minimum Starlette version required to address [BadHost / CVE-2026-48710](https://badhost.org/). Updating FastAPI to 0.133.0 is required to accommodate Starlette >= 1.0. This PR then fixes a few things that broke as a result of the updates and tweaks some handling of `request.url.path` just to be extra safe.

