### PR TITLE
Fix `ImportError` from `sentry-sdk`

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pg8000>=1.29.4,<2.0.0",
     "alembic>=1.10.3,<2.0.0",
     "requests>=2.33.0,<3.0.0",
-    "sentry-sdk==2.8.0",
+    "sentry-sdk>=2.56.0,<3.0.0",
     "launchpadlib>=1.11.0,<2.0.0",
     "PyGithub>=2.0.0,<3.0.0",
     "jira>=3.10.0,<4.0.0",

--- a/backend/tests/test_sentry.py
+++ b/backend/tests/test_sentry.py
@@ -23,6 +23,9 @@ def test_sentry_initializes_without_error():
     as that would require integration testing with a real Sentry instance.
 
     This test was added after `sentry_sdk.init` broke in a staging deployment following dependency updates.
-    All tests ran without SENTRY_DSN set, which means sentry_sdk.init() was not excercised by tests.
+    All tests ran without SENTRY_DSN set, which means sentry_sdk.init() was not exercised by tests.
     """
-    sentry_sdk.init("https://abc123xyz@o0.ingest.sentry.io/123456")
+    try:
+        sentry_sdk.init("https://abc123xyz@o0.ingest.sentry.io/123456")
+    finally:
+        sentry_sdk.get_client().close()

--- a/backend/tests/test_sentry.py
+++ b/backend/tests/test_sentry.py
@@ -1,0 +1,28 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import sentry_sdk
+
+
+def test_sentry_initializes_without_error():
+    """
+    This test simply checks that the Sentry SDK can be initialized with the provided DSN
+    without raising any exceptions. It does not check for successful event sending,
+    as that would require integration testing with a real Sentry instance.
+
+    This test was added after `sentry_sdk.init` broke in a staging deployment following dependency updates.
+    All tests ran without SENTRY_DSN set, which means sentry_sdk.init() was not excercised by tests.
+    """
+    sentry_sdk.init("https://abc123xyz@o0.ingest.sentry.io/123456")

--- a/backend/tests/test_sentry.py
+++ b/backend/tests/test_sentry.py
@@ -26,6 +26,6 @@ def test_sentry_initializes_without_error():
     All tests ran without SENTRY_DSN set, which means sentry_sdk.init() was not exercised by tests.
     """
     try:
-        sentry_sdk.init("https://abc123xyz@o0.ingest.sentry.io/123456")
+        sentry_sdk.init("https://abc123xyz@test.example/123456")
     finally:
         sentry_sdk.get_client().close()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1422,15 +1422,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.8.0"
+version = "2.61.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/9d/d61d64819ecb0481647229c3ee8ddc00887552acc23745fd65d0d4d066f3/sentry_sdk-2.8.0.tar.gz", hash = "sha256:aa4314f877d9cd9add5a0c9ba18e3f27f99f7de835ce36bd150e48a41c7c646f", size = 273663, upload-time = "2024-07-08T08:11:38.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/3b/4bc6b348bbd331daa14d4babe9f2b99bc854f4da41560eefb9488d78481d/sentry_sdk-2.61.1.tar.gz", hash = "sha256:9c6adccb3feefa9ba032c8d295ca477575c2f11896046a2b0ad686c47c4af555", size = 459429, upload-time = "2026-06-01T07:24:18.875Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/f4/8e1be145ce63c4ef4e126ee362992ae1ada5e716723883912b74829583e7/sentry_sdk-2.8.0-py2.py3-none-any.whl", hash = "sha256:6051562d2cfa8087bb8b4b8b79dc44690f8a054762a29c07e22588b1f619bfb5", size = 300617, upload-time = "2024-07-08T08:11:33.904Z" },
+    { url = "https://files.pythonhosted.org/packages/df/54/c9218db183846e08efaf68534889ef42e499dde432778881104a42f7071b/sentry_sdk-2.61.1-py3-none-any.whl", hash = "sha256:fa36eaf4b8ad708f718500d4bdcc1532637526a22beb874d88cbc0a46458b5ae", size = 483735, upload-time = "2026-06-01T07:24:17.027Z" },
 ]
 
 [[package]]
@@ -1567,7 +1567,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.20,<0.1.0" },
     { name = "python3-saml", specifier = ">=1.16.0" },
     { name = "requests", specifier = ">=2.33.0,<3.0.0" },
-    { name = "sentry-sdk", specifier = "==2.8.0" },
+    { name = "sentry-sdk", specifier = ">=2.56.0,<3.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.16,<3.0.0" },
     { name = "starlette", specifier = ">=1.0.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.47.0,<0.48.0" },


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This is a follow-up to https://github.com/canonical/test_observer/pull/791.
As a result of the Starlette version upgrade, `sentry_sdk.init()` began erroring by trying to import a Jinja2 template, despite not listing `jinja2` as a dependency, resulting in an `ImportError`. This was fixed in `sentry-sdk` version 2.56.0, so the version requirements for `sentry-sdk` are updated.

Since this issue was caught as part of a staging deployment and not CI, I have also added a test that calls `sentry_sdk.init()` to ensure this method is exercised in tests.

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

A unit test was added. I confirmed that the unit test failed with the previous version of `sentry-sdk`, which also errored when deployed, but now passes with the updated version of `sentry-sdk`.