### PR TITLE
Charms - Don't Use Port to Determine Protocol

### DIFF
--- a/backend/charm/src/charm.py
+++ b/backend/charm/src/charm.py
@@ -499,22 +499,14 @@ class TestObserverBackendCharm(CharmBase):
 
     def _get_url(self) -> str:
         """Get the URL to use for this charm's service."""
-        # By default, we use the hostname and port from the config values,
-        # which is needed for the `nginx-route` relation.
-        port = int(self.config["port"])
-        if port == 443:
-            scheme = "https"
-        else:
-            scheme = "http"
-        url = f"{scheme}://{self.config['hostname']}"
-        if port not in (80, 443):
-            url = f"{url}:{port}"
-
         # If the ingress relation is present and provides a URL,
         # that is the authoritative URL, so we use that instead
         if self.model.get_relation(INGRESS_RELATION_NAME) and self.ingress.url is not None:
-            url = self.ingress.url
-        return url.rstrip("/")
+            return self.ingress.url.rstrip("/")
+
+        # For compatibility with older charm revisions and deployments,
+        # we default to HTTPS with the hostname
+        return f"https://{self.config['hostname']}".rstrip("/")
 
     def _get_frontend_url(self) -> str:
         """Get the URL of the connected frontend, if any. The frontend URL is needed for CORS checks."""

--- a/backend/charm/src/charm.py
+++ b/backend/charm/src/charm.py
@@ -506,7 +506,11 @@ class TestObserverBackendCharm(CharmBase):
 
         # For compatibility with older charm revisions and deployments,
         # we default to HTTPS with the hostname
-        return f"https://{self.config['hostname']}".rstrip("/")
+        port = int(self.config["port"])
+        url = f"https://{self.config['hostname']}".rstrip("/")
+        if port not in {80, 443}:
+            url = f"{url}:{port}"
+        return url
 
     def _get_frontend_url(self) -> str:
         """Get the URL of the connected frontend, if any. The frontend URL is needed for CORS checks."""

--- a/frontend/charm/src/charm.py
+++ b/frontend/charm/src/charm.py
@@ -324,7 +324,11 @@ class TestObserverFrontendCharm(ops.CharmBase):
 
         # For compatibility with older charm revisions and deployments,
         # we default to HTTPS with the hostname
-        return f"https://{self.config['hostname']}".rstrip("/")
+        port = int(self.config["port"])
+        url = f"https://{self.config['hostname']}".rstrip("/")
+        if port not in {80, 443}:
+            url = f"{url}:{port}"
+        return url
 
     def _update_backend_relation_data(self):
         if not self.unit.is_leader():

--- a/frontend/charm/src/charm.py
+++ b/frontend/charm/src/charm.py
@@ -317,22 +317,14 @@ class TestObserverFrontendCharm(ops.CharmBase):
 
     def _get_url(self) -> str:
         """Get the URL to use for this charm's service."""
-        # By default, we use the hostname and port from the config values,
-        # which is needed for the `nginx-route` relation.
-        port = int(self.config["port"])
-        if port == 443:
-            scheme = "https"
-        else:
-            scheme = "http"
-        url = f"{scheme}://{self.config['hostname']}"
-        if port not in (80, 443):
-            url = f"{url}:{port}"
-
         # If the ingress relation is present and provides a URL,
         # that is the authoritative URL, so we use that instead
         if self.model.get_relation(INGRESS_RELATION_NAME) and self.ingress.url is not None:
-            url = self.ingress.url
-        return url.rstrip("/")
+            return self.ingress.url.rstrip("/")
+
+        # For compatibility with older charm revisions and deployments,
+        # we default to HTTPS with the hostname
+        return f"https://{self.config['hostname']}".rstrip("/")
 
     def _update_backend_relation_data(self):
         if not self.unit.is_leader():


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

When using the `nginx-route` relation, the charm's don't have access to much information about how the ingress is being provided or how TLS termination is handled. The charms can be configured with `port=80` but still served on an HTTPS URL. Since the backend checks the frontend URL for CORS, this can cause a mismatch.

This PR resolves the issue by always assuming HTTPS. This is not ideal, but it is consistent with what was done before the introduction of `ingress` support and does at least support the needs of real deployments.
