### PR TITLE
[TO-381] Fix scroll jump from text

### DIFF
--- a/frontend/lib/ui/artefact_page/artefact_page.dart
+++ b/frontend/lib/ui/artefact_page/artefact_page.dart
@@ -73,7 +73,9 @@ class ArtefactPage extends ConsumerWidget {
                     Visibility(
                       visible: showSide,
                       maintainState: true,
-                      child: ArtefactPageSide(artefact: artefact),
+                      child: SelectionContainer.disabled(
+                        child: ArtefactPageSide(artefact: artefact),
+                      ),
                     ),
                     Expanded(child: ArtefactPageBody(artefact: artefact)),
                   ],

--- a/frontend/lib/ui/artefact_page/artefact_page.dart
+++ b/frontend/lib/ui/artefact_page/artefact_page.dart
@@ -55,30 +55,38 @@ class ArtefactPage extends ConsumerWidget {
               ArtefactPageHeader(artefact: artefact),
               const SizedBox(height: Spacing.level4),
               Expanded(
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Badge(
-                      isLabelVisible: hasActiveFilters,
-                      smallSize: 8,
-                      backgroundColor: YaruColors.orange,
-                      child: YaruOptionButton(
-                        child: const Icon(Icons.filter_alt),
-                        onPressed: () => ref
-                            .read(artefactPageSideVisibilityProvider.notifier)
-                            .set(!showSide),
+                // Split selection into independent sidebar/body regions so drag
+                // selection in one pane does not include text from the other.
+                child: SelectionContainer.disabled(
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Badge(
+                        isLabelVisible: hasActiveFilters,
+                        smallSize: 8,
+                        backgroundColor: YaruColors.orange,
+                        child: YaruOptionButton(
+                          child: const Icon(Icons.filter_alt),
+                          onPressed: () => ref
+                              .read(artefactPageSideVisibilityProvider.notifier)
+                              .set(!showSide),
+                        ),
                       ),
-                    ),
-                    const SizedBox(width: Spacing.level2),
-                    Visibility(
-                      visible: showSide,
-                      maintainState: true,
-                      child: SelectionContainer.disabled(
-                        child: ArtefactPageSide(artefact: artefact),
+                      const SizedBox(width: Spacing.level2),
+                      Visibility(
+                        visible: showSide,
+                        maintainState: true,
+                        child: SelectionArea(
+                          child: ArtefactPageSide(artefact: artefact),
+                        ),
                       ),
-                    ),
-                    Expanded(child: ArtefactPageBody(artefact: artefact)),
-                  ],
+                      Expanded(
+                        child: SelectionArea(
+                          child: ArtefactPageBody(artefact: artefact),
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ],

--- a/frontend/lib/ui/artefact_page/test_result_expandable.dart
+++ b/frontend/lib/ui/artefact_page/test_result_expandable.dart
@@ -66,6 +66,7 @@ class TestResultExpandable extends ConsumerWidget {
         testResultIdToExpand != null && testResult.id == testResultIdToExpand;
 
     return Expandable(
+      storageKey: 'test_result_${testResult.id}',
       initiallyExpanded: initiallyExpanded,
       title: Row(
         children: [
@@ -107,6 +108,7 @@ class _TestResultOutputExpandable extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Expandable(
+      storageKey: 'test_result_details_${testResult.id}',
       title: const Text('Details'),
       initiallyExpanded: initiallyExpanded,
       children: [

--- a/frontend/lib/ui/artefact_page/test_result_expandable.dart
+++ b/frontend/lib/ui/artefact_page/test_result_expandable.dart
@@ -123,7 +123,7 @@ class _TestResultOutputExpandable extends StatelessWidget {
         if (testResult.ioLog != '')
           YaruTile(
             title: const Text('IO Log'),
-            subtitle: SelectableText(
+            subtitle: Text(
               testResult.ioLog,
               style: const TextStyle(
                 fontFamily: 'UbuntuMono',

--- a/frontend/lib/ui/expandable.dart
+++ b/frontend/lib/ui/expandable.dart
@@ -25,6 +25,7 @@ class Expandable extends StatelessWidget {
     this.initiallyExpanded = false,
     this.tilePadding,
     this.childrenPadding = const EdgeInsets.only(left: Spacing.level4),
+    this.storageKey,
   });
 
   final List<Widget> children;
@@ -33,9 +34,14 @@ class Expandable extends StatelessWidget {
   final EdgeInsetsGeometry? tilePadding;
   final EdgeInsetsGeometry childrenPadding;
 
+  /// When provided, the expansion state is saved to [PageStorage] under this
+  /// key, so it survives the widget being scrolled out of a lazy list.
+  final Object? storageKey;
+
   @override
   Widget build(BuildContext context) {
     return ExpansionTile(
+      key: storageKey != null ? PageStorageKey(storageKey) : null,
       tilePadding: tilePadding,
       expansionAnimationStyle: AnimationStyle.noAnimation,
       controlAffinity: ListTileControlAffinity.leading,


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR fixes an issue where trying to select text from the IO Log of a test result would cause the scroll bar to jump to the very bottom of the page, effectively making it impossible to actually select text. The cause of this issue seems to be the use of `SelectableText` while already within a `SelectableArea`. Changing it to `Text` (which is consistent with how the `Category` and `Comment` areas are implemented) resolved the problem. 

Once that was fixed, it exposed a different issue, which was that the text selection would overflow and mix in the filter titles from the filter side bar if it was expanded. As a result, I split the filter sidebar and the main body into two separate `SelectionArea`s. 

Finally, I changed the expansion behavior slightly, as scrolling down past an expanded entry would cause it to collapse, resulting in a jarring scrolling effect as the page size instantaneously changed, and which is not intuitive behavior in my opinion. However, that is a separate commit which can easily be removed from this PR if desired.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

TO-381

## Testing

Manual testing confirms that text selection behaves as expected, and the page no longer jumps to the bottom when clicking within the IO Log.
