### PR TITLE
TO-388: team permissions should be enough when there are no AMRs with the required permissions

### DIFF
--- a/backend/test_observer/common/permissions.py
+++ b/backend/test_observer/common/permissions.py
@@ -175,6 +175,9 @@ def check_artefact_permission(
     if app and required_permission in app.permissions:
         return
 
+    if user and any(required_permission in t.permissions for t in user.teams):
+        return
+
     check_amr_permission(db, user, artefact, required_permission)
 
 

--- a/backend/test_observer/common/permissions.py
+++ b/backend/test_observer/common/permissions.py
@@ -172,6 +172,9 @@ def check_artefact_permission(
     if required_permission.value in IGNORE_PERMISSIONS:
         return
 
+    if user and user.is_admin:
+        return
+
     if app and required_permission in app.permissions:
         return
 

--- a/backend/tests/common/test_amr_permissions.py
+++ b/backend/tests/common/test_amr_permissions.py
@@ -271,7 +271,7 @@ class TestCheckArtefactPermission:
 
     def test_team_permission_grants_access_without_amr(self, generator: DataGenerator, db_session: Session):
         """A user whose team has the required permission should be granted access even with no matching AMR"""
-        team = generator.gen_team(name="privileged-team", permissions=[Permission.change_artefact.value])
+        team = generator.gen_team(name="privileged-team", permissions=[Permission.change_artefact])
         artefact = generator.gen_artefact(
             name="test-snap",
             family=FamilyName.snap,

--- a/backend/tests/common/test_amr_permissions.py
+++ b/backend/tests/common/test_amr_permissions.py
@@ -18,7 +18,7 @@ from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from test_observer.common.enums import Permission
-from test_observer.common.permissions import check_amr_permission
+from test_observer.common.permissions import check_amr_permission, check_artefact_permission
 from test_observer.data_access.models_enums import FamilyName, StageName
 from tests.data_generator import DataGenerator
 
@@ -261,6 +261,29 @@ class TestCheckAMRPermission:
         check_amr_permission(
             db_session,
             admin_user,
+            artefact,
+            Permission.change_artefact,
+        )
+
+
+class TestCheckArtefactPermission:
+    """Test that direct team permissions override the AMR requirement"""
+
+    def test_team_permission_grants_access_without_amr(self, generator: DataGenerator, db_session: Session):
+        """A user whose team has the required permission should be granted access even with no matching AMR"""
+        team = generator.gen_team(name="privileged-team", permissions=[Permission.change_artefact.value])
+        artefact = generator.gen_artefact(
+            name="test-snap",
+            family=FamilyName.snap,
+            stage=StageName.stable,
+        )
+        user = generator.gen_user(name="frank", teams=[team])
+
+        # No AMR exists, but the team has the permission directly — should pass
+        check_artefact_permission(
+            db_session,
+            user,
+            None,
             artefact,
             Permission.change_artefact,
         )

--- a/backend/tests/common/test_amr_permissions.py
+++ b/backend/tests/common/test_amr_permissions.py
@@ -287,3 +287,28 @@ class TestCheckArtefactPermission:
             artefact,
             Permission.change_artefact,
         )
+
+    def test_amr_grants_access_without_team_permission(self, generator: DataGenerator, db_session: Session):
+        """A user whose team has a matching AMR granting the permission should be granted access even with no direct team permissions"""
+        team = generator.gen_team(name="amr-team")
+        generator.gen_artefact_matching_rule(
+            family=FamilyName.snap,
+            stage="stable",
+            teams=[team],
+            grant_permissions=[Permission.change_artefact],
+        )
+        artefact = generator.gen_artefact(
+            name="test-snap",
+            family=FamilyName.snap,
+            stage=StageName.stable,
+        )
+        user = generator.gen_user(name="grace", teams=[team])
+
+        # Team has no direct permissions, but the AMR grants the permission — should pass
+        check_artefact_permission(
+            db_session,
+            user,
+            None,
+            artefact,
+            Permission.change_artefact,
+        )

--- a/backend/tests/common/test_amr_permissions.py
+++ b/backend/tests/common/test_amr_permissions.py
@@ -289,7 +289,8 @@ class TestCheckArtefactPermission:
         )
 
     def test_amr_grants_access_without_team_permission(self, generator: DataGenerator, db_session: Session):
-        """A user whose team has a matching AMR granting the permission should be granted access even with no direct team permissions"""
+        """A user whose team has a matching AMR granting the permission should be granted access
+        even with no direct team permissions"""
         team = generator.gen_team(name="amr-team")
         generator.gen_artefact_matching_rule(
             family=FamilyName.snap,


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

There was a bug where a user belonging to a team with the required permission to access some artefact would not be able to access that if there were no AMRs giving them the permission. This PR fixes that with a simple check for that case.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->
Resolves TO-388

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Added a regression test and one test for the reverse case.