### PR TITLE
[TO-388] Fix permission checks

### DIFF
--- a/backend/test_observer/common/permissions.py
+++ b/backend/test_observer/common/permissions.py
@@ -175,6 +175,9 @@ def check_artefact_permission(
     if app and required_permission in app.permissions:
         return
 
+    if user and any(required_permission in t.permissions for t in user.teams):
+        return
+
     check_amr_permission(db, user, artefact, required_permission)
 
 

--- a/backend/test_observer/common/permissions.py
+++ b/backend/test_observer/common/permissions.py
@@ -111,7 +111,7 @@ def has_general_permission(
 
     if ignored_permissions is None:
         ignored_permissions = IGNORE_PERMISSIONS
-    return required_permission in ignored_permissions
+    return required_permission.value in ignored_permissions
 
 
 def check_general_permission(
@@ -123,14 +123,13 @@ def check_general_permission(
     """
     Centralized permission check for general operations.
 
-    Respects IGNORE_PERMISSIONS config and checks in order:
-    1. App has the permission (usually a testing codepath)
-    2. User is an admin or has the permission via their teams
-
     Args:
         user: The User to check (can be None)
         app: The Application to check (can be None)
         required_permission: Permission to check for
+        ignored_permissions:
+            Optional set of permissions to ignore.
+            If None, defaults to IGNORE_PERMISSIONS from config.
 
     Raises:
         HTTPException(403): If user is not authorized

--- a/backend/test_observer/common/permissions.py
+++ b/backend/test_observer/common/permissions.py
@@ -23,7 +23,7 @@ from test_observer.controllers.applications.application_injection import (
     get_current_application,
 )
 from test_observer.data_access.models import Application, Artefact, ArtefactMatchingRule, User
-from test_observer.data_access.queries import match_artefact
+from test_observer.data_access.queries import batch_match_artefacts
 from test_observer.users.user_injection import get_current_user, get_current_user_browser_friendly
 
 
@@ -87,14 +87,66 @@ def permission_checker(
         raise HTTPException(status_code=403, detail="Insufficient permissions")
 
 
-def check_amr_permission(
-    db: Session,
+def has_general_permission(
     user: User | None,
-    artefact: Artefact,
+    app: Application | None,
     required_permission: Permission,
+    ignored_permissions: set[str] | None = None,
+) -> bool:
+    """
+    Determine whether a user or application has the required permission.
+
+    Args:
+        user: The User to check (can be None)
+        app: The Application to check (can be None)
+        required_permission: Permission to check for
+        ignored_permissions:
+            Optional set of permissions to ignore.
+            If None, defaults to IGNORE_PERMISSIONS from config.
+    """
+    if user and (user.is_admin or any(required_permission in t.permissions for t in user.teams)):
+        return True
+    if app and required_permission in app.permissions:
+        return True
+
+    if ignored_permissions is None:
+        ignored_permissions = IGNORE_PERMISSIONS
+    return required_permission in ignored_permissions
+
+
+def check_general_permission(
+    user: User | None,
+    app: Application | None,
+    required_permission: Permission,
+    ignored_permissions: set[str] | None = None,
 ) -> None:
     """
-    Check if a user has the required permission for an artefact based on AMR matching.
+    Centralized permission check for general operations.
+
+    Respects IGNORE_PERMISSIONS config and checks in order:
+    1. App has the permission (usually a testing codepath)
+    2. User is an admin or has the permission via their teams
+
+    Args:
+        user: The User to check (can be None)
+        app: The Application to check (can be None)
+        required_permission: Permission to check for
+
+    Raises:
+        HTTPException(403): If user is not authorized
+    """
+    if not has_general_permission(user, app, required_permission, ignored_permissions):
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
+
+
+def has_amr_permissions(
+    db: Session,
+    user: User | None,
+    artefacts: list[Artefact],
+    required_permission: Permission,
+) -> bool:
+    """
+    Determine whether a user has the required permission for a list of artefacts based on AMR matching.
 
     Uses the match_artefact query to find the matching AMR(s) for the artefact,
     then checks if the user is in one of the teams associated with those AMRs and
@@ -109,39 +161,74 @@ def check_amr_permission(
     Raises:
         HTTPException(403): If user is not authorized
     """
-    if user is None:
-        raise HTTPException(status_code=403, detail="Insufficient permissions")
+    if not user:
+        return False
 
-    if user.is_admin:
-        return
+    # If no affected artefacts, no permissions to check (e.g., invalid test_execution_ids)
+    if not artefacts:
+        return True
 
-    # Query for matching AMR IDs using the centralized matching logic
-    matching_amr_ids = db.execute(match_artefact(artefact)).scalars().all()
+    batch_match_result = db.execute(batch_match_artefacts(list(artefacts))).all()
 
-    if not matching_amr_ids:
-        raise HTTPException(status_code=403, detail="Insufficient permissions")
+    # Build map: artefact_id → set of matching AMR IDs
+    artefact_to_amrs: dict[int, set[int]] = {}
+    matched_amr_ids: set[int] = set()
+    for artefact_id, amr_id in batch_match_result:
+        artefact_to_amrs.setdefault(artefact_id, set()).add(amr_id)
+        matched_amr_ids.add(amr_id)
 
-    matching_rules = (
-        db.query(ArtefactMatchingRule)
-        .filter(ArtefactMatchingRule.id.in_(matching_amr_ids))
-        .options(selectinload(ArtefactMatchingRule.teams))
-        .all()
-    )
+    # Fetch all matching AMRs with teams in a single query
+    if matched_amr_ids:
+        matching_rules = (
+            db.query(ArtefactMatchingRule)
+            .filter(ArtefactMatchingRule.id.in_(matched_amr_ids))
+            .options(selectinload(ArtefactMatchingRule.teams))
+            .all()
+        )
+    else:
+        matching_rules = []
 
-    # Check if user is in any of the teams from matching AMRs
-    # and if those AMRs grant the required permission
+    # Build map: AMR ID → rule with teams
+    amr_rules = {rule.id: rule for rule in matching_rules}
+
+    # Check permission for each affected artefact using all-or-nothing semantics
     user_team_ids = {team.id for team in user.teams}
 
-    for rule in matching_rules:
-        rule_team_ids = {team.id for team in rule.teams}
+    for artefact in artefacts:
+        matching_amr_ids = artefact_to_amrs.get(artefact.id, set())
 
-        user_in_rule_team = user_team_ids & rule_team_ids
-        rule_grants_permission = required_permission in rule.grant_permissions
-        if user_in_rule_team and rule_grants_permission:
-            return
+        if not matching_amr_ids:
+            # No AMRs match this artefact
+            return False
 
-    # If we get here, user doesn't have permission
-    raise HTTPException(status_code=403, detail="Insufficient permissions")
+        # Check if user is in a team with a matching AMR that grants the permission
+        has_permission = False
+        for amr_id in matching_amr_ids:
+            rule = amr_rules.get(amr_id)
+            if rule is not None and required_permission in rule.grant_permissions:
+                rule_team_ids = {team.id for team in rule.teams}
+                if user_team_ids & rule_team_ids:
+                    has_permission = True
+                    break
+
+        if not has_permission:
+            return False
+
+    return True
+
+
+def check_amr_permissions(
+    db: Session,
+    user: User | None,
+    artefacts: list[Artefact],
+    required_permission: Permission,
+) -> None:
+    """
+    Centralized permission check for artefact operations based on AMR matching.
+    Errors with HTTP 403 if the user does not have the required permission.
+    """
+    if not has_amr_permissions(db, user, artefacts, required_permission):
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
 
 
 def check_artefact_permission(
@@ -150,13 +237,10 @@ def check_artefact_permission(
     app: Application | None,
     artefact: Artefact,
     required_permission: Permission,
+    ignored_permissions: set[str] | None = None,
 ) -> None:
     """
     Centralized permission check for artefact operations.
-
-    Respects IGNORE_PERMISSIONS config and checks in order:
-    1. App has the permission (usually a testing codepath)
-    2. User matches AMR for the artefact with the permission
 
     Args:
         db: Database session
@@ -164,24 +248,20 @@ def check_artefact_permission(
         app: Current application (can be None)
         artefact: Artefact being accessed
         required_permission: Permission to check for
+        ignored_permissions:
+            Optional set of permissions to ignore.
+            If None, defaults to IGNORE_PERMISSIONS from config.
 
     Raises:
         HTTPException(403): If user is not authorized
     """
-    # Honor IGNORE_PERMISSIONS config (aligned with permission_checker)
-    if required_permission.value in IGNORE_PERMISSIONS:
+
+    if has_general_permission(user, app, required_permission, ignored_permissions) or has_amr_permissions(
+        db, user, [artefact], required_permission
+    ):
         return
 
-    if user and user.is_admin:
-        return
-
-    if app and required_permission in app.permissions:
-        return
-
-    if user and any(required_permission in t.permissions for t in user.teams):
-        return
-
-    check_amr_permission(db, user, artefact, required_permission)
+    raise HTTPException(status_code=403, detail="Insufficient permissions")
 
 
 def openapi_scope_declaration() -> None:

--- a/backend/test_observer/common/permissions.py
+++ b/backend/test_observer/common/permissions.py
@@ -13,6 +13,8 @@
 # SPDX-FileCopyrightText: Copyright 2025 Canonical Ltd.
 # SPDX-License-Identifier: AGPL-3.0-only
 
+from collections.abc import Sequence
+
 from fastapi import Depends, HTTPException
 from fastapi.security import SecurityScopes
 from sqlalchemy.orm import Session, selectinload
@@ -141,7 +143,7 @@ def check_general_permission(
 def has_amr_permissions(
     db: Session,
     user: User | None,
-    artefacts: list[Artefact],
+    artefacts: Sequence[Artefact],
     required_permission: Permission,
 ) -> bool:
     """
@@ -160,7 +162,7 @@ def has_amr_permissions(
     if not artefacts:
         return True
 
-    batch_match_result = db.execute(batch_match_artefacts(list(artefacts))).all()
+    batch_match_result = db.execute(batch_match_artefacts(artefacts)).all()
 
     # Build map: artefact_id → set of matching AMR IDs
     artefact_to_amrs: dict[int, set[int]] = {}
@@ -212,7 +214,7 @@ def has_amr_permissions(
 def check_amr_permissions(
     db: Session,
     user: User | None,
-    artefacts: list[Artefact],
+    artefacts: Sequence[Artefact],
     required_permission: Permission,
 ) -> None:
     """

--- a/backend/test_observer/common/permissions.py
+++ b/backend/test_observer/common/permissions.py
@@ -172,6 +172,9 @@ def check_artefact_permission(
     if required_permission.value in IGNORE_PERMISSIONS:
         return
 
+    if user and user.is_admin:
+        return
+
     if app and required_permission in app.permissions:
         return
 

--- a/backend/test_observer/common/permissions.py
+++ b/backend/test_observer/common/permissions.py
@@ -148,18 +148,11 @@ def has_amr_permissions(
     """
     Determine whether a user has the required permission for a list of artefacts based on AMR matching.
 
-    Uses the match_artefact query to find the matching AMR(s) for the artefact,
-    then checks if the user is in one of the teams associated with those AMRs and
-    if the AMR grants the required permission.
-
     Args:
         db: Database session
         user: Current user (can be None)
-        artefact: Artefact being accessed
+        artefacts: List of artefacts being accessed
         required_permission: Permission to check for
-
-    Raises:
-        HTTPException(403): If user is not authorized
     """
     if not user:
         return False

--- a/backend/test_observer/controllers/test_executions/reruns.py
+++ b/backend/test_observer/controllers/test_executions/reruns.py
@@ -201,7 +201,7 @@ def _validate_amr_permissions_for_request(
     )
 
     affected_artefacts = db.scalars(affected_artefacts_query).all()
-    if not has_amr_permissions(db, user, list(affected_artefacts), permission):
+    if not has_amr_permissions(db, user, affected_artefacts, permission):
         raise HTTPException(status_code=403, detail="Insufficient permissions")
 
 

--- a/backend/test_observer/controllers/test_executions/reruns.py
+++ b/backend/test_observer/controllers/test_executions/reruns.py
@@ -22,9 +22,10 @@ from sqlalchemy import asc, delete, or_, select, tuple_
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session, selectinload
 
-from test_observer.common.config import IGNORE_PERMISSIONS
 from test_observer.common.enums import Permission
 from test_observer.common.permissions import (
+    has_amr_permissions,
+    has_general_permission,
     openapi_scope_declaration,
     permission_checker,
 )
@@ -38,7 +39,6 @@ from test_observer.data_access.models import (
     Application,
     Artefact,
     ArtefactBuild,
-    ArtefactMatchingRule,
     Environment,
     FamilyName,
     TestExecution,
@@ -46,7 +46,6 @@ from test_observer.data_access.models import (
     TestResult,
     User,
 )
-from test_observer.data_access.queries import batch_match_artefacts
 from test_observer.data_access.repository import get_or_create
 from test_observer.data_access.setup import get_db
 from test_observer.users.user_injection import get_current_user
@@ -178,15 +177,12 @@ def _validate_amr_permissions_for_request(
     Raises:
         HTTPException(403): If any affected artefact is unauthorized
     """
-    # Early exits
-    ignored_permission = permission.value in IGNORE_PERMISSIONS
-    app_has_permission = app is not None and permission in app.permissions
-    if ignored_permission or app_has_permission:
+    if has_general_permission(user, app, permission):
         return
+
+    # If user is None, we cannot check AMR permissions, so raise 403
     if user is None:
         raise HTTPException(status_code=403, detail="Insufficient permissions")
-    elif user.is_admin:
-        return
 
     # Collect conditions to find affected TestExecutions
     conditions = _build_rerun_conditions(request)
@@ -195,7 +191,6 @@ def _validate_amr_permissions_for_request(
     if not conditions:
         return
 
-    # Check user authorization
     # Query for all unique artefacts affected by the request
     affected_artefacts_query = (
         select(Artefact)
@@ -206,56 +201,8 @@ def _validate_amr_permissions_for_request(
     )
 
     affected_artefacts = db.scalars(affected_artefacts_query).all()
-
-    # If no affected artefacts, no permissions to check (e.g., invalid test_execution_ids)
-    if not affected_artefacts:
-        return
-
-    batch_match_result = db.execute(batch_match_artefacts(list(affected_artefacts))).all()
-
-    # Build map: artefact_id → set of matching AMR IDs
-    artefact_to_amrs: dict[int, set[int]] = {}
-    matched_amr_ids = set()
-    for artefact_id, amr_id in batch_match_result:
-        artefact_to_amrs.setdefault(artefact_id, set()).add(amr_id)
-        matched_amr_ids.add(amr_id)
-
-    # Fetch all matching AMRs with teams in a single query
-    if matched_amr_ids:
-        matching_rules = (
-            db.query(ArtefactMatchingRule)
-            .filter(ArtefactMatchingRule.id.in_(matched_amr_ids))
-            .options(selectinload(ArtefactMatchingRule.teams))
-            .all()
-        )
-    else:
-        matching_rules = []
-
-    # Build map: AMR ID → rule with teams
-    amr_rules = {rule.id: rule for rule in matching_rules}
-
-    # Check permission for each affected artefact using all-or-nothing semantics
-    user_team_ids = {team.id for team in user.teams}
-
-    for artefact in affected_artefacts:
-        matching_amr_ids = artefact_to_amrs.get(artefact.id, set())
-
-        if not matching_amr_ids:
-            # No AMRs match this artefact
-            raise HTTPException(status_code=403, detail="Insufficient permissions")
-
-        # Check if user is in a team with a matching AMR that grants the permission
-        has_permission = False
-        for amr_id in matching_amr_ids:
-            rule = amr_rules.get(amr_id)
-            if rule is not None and permission in rule.grant_permissions:
-                rule_team_ids = {team.id for team in rule.teams}
-                if user_team_ids & rule_team_ids:
-                    has_permission = True
-                    break
-
-        if not has_permission:
-            raise HTTPException(status_code=403, detail="Insufficient permissions")
+    if not has_amr_permissions(db, user, list(affected_artefacts), permission):
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
 
 
 @router.post(

--- a/backend/test_observer/data_access/queries.py
+++ b/backend/test_observer/data_access/queries.py
@@ -13,6 +13,8 @@
 # SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
 # SPDX-License-Identifier: AGPL-3.0-only
 
+from collections.abc import Sequence
+
 from sqlalchemy import Integer, Select, and_, case, false, func, literal, or_, select, union_all
 
 from test_observer.data_access.models import Artefact, ArtefactBuild, ArtefactMatchingRule
@@ -150,7 +152,7 @@ def match_artefact(artefact: Artefact) -> Select[tuple[int]]:
     return select_rules
 
 
-def batch_match_artefacts(artefacts: list[Artefact]) -> Select[tuple[int, int]]:
+def batch_match_artefacts(artefacts: Sequence[Artefact]) -> Select[tuple[int, int]]:
     """Match multiple artefacts to their AMRs in a single query.
 
     Returns a query that produces (artefact_id, amr_id) tuples for all matching pairs.

--- a/backend/tests/common/test_amr_permissions.py
+++ b/backend/tests/common/test_amr_permissions.py
@@ -271,7 +271,7 @@ class TestCheckArtefactPermission:
 
     def test_team_permission_grants_access_without_amr(self, generator: DataGenerator, db_session: Session):
         """A user whose team has the required permission should be granted access even with no matching AMR"""
-        team = generator.gen_team(name="privileged-team", permissions=[Permission.change_artefact.value])
+        team = generator.gen_team(name="privileged-team", permissions=[Permission.change_artefact])
         artefact = generator.gen_artefact(
             name="test-snap",
             family=FamilyName.snap,

--- a/backend/tests/common/test_amr_permissions.py
+++ b/backend/tests/common/test_amr_permissions.py
@@ -18,7 +18,7 @@ from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from test_observer.common.enums import Permission
-from test_observer.common.permissions import check_amr_permission
+from test_observer.common.permissions import check_amr_permission, check_artefact_permission
 from test_observer.data_access.models_enums import FamilyName, StageName
 from tests.data_generator import DataGenerator
 
@@ -261,6 +261,29 @@ class TestCheckAMRPermission:
         check_amr_permission(
             db_session,
             admin_user,
+            artefact,
+            Permission.change_artefact,
+        )
+
+
+class TestCheckArtefactPermission:
+    """Test that direct team permissions override the AMR requirement"""
+
+    def test_team_permission_grants_access_without_amr(self, generator: DataGenerator, db_session: Session):
+        """A user whose team has the required permission should be granted access even with no matching AMR"""
+        team = generator.gen_team(name="privileged-team", permissions=[Permission.change_artefact.value])
+        artefact = generator.gen_artefact(
+            name="test-snap",
+            family=FamilyName.snap,
+            stage=StageName.stable,
+        )
+        user = generator.gen_user(name="frank", teams=[team])
+
+        # No AMR exists, but the team has the permission directly — should pass
+        check_artefact_permission(
+            db_session,
+            user,
+            None,
             artefact,
             Permission.change_artefact,
         )

--- a/backend/tests/common/test_amr_permissions.py
+++ b/backend/tests/common/test_amr_permissions.py
@@ -287,3 +287,28 @@ class TestCheckArtefactPermission:
             artefact,
             Permission.change_artefact,
         )
+
+    def test_amr_grants_access_without_team_permission(self, generator: DataGenerator, db_session: Session):
+        """A user whose team has a matching AMR granting the permission should be granted access even with no direct team permissions"""
+        team = generator.gen_team(name="amr-team")
+        generator.gen_artefact_matching_rule(
+            family=FamilyName.snap,
+            stage="stable",
+            teams=[team],
+            grant_permissions=[Permission.change_artefact],
+        )
+        artefact = generator.gen_artefact(
+            name="test-snap",
+            family=FamilyName.snap,
+            stage=StageName.stable,
+        )
+        user = generator.gen_user(name="grace", teams=[team])
+
+        # Team has no direct permissions, but the AMR grants the permission — should pass
+        check_artefact_permission(
+            db_session,
+            user,
+            None,
+            artefact,
+            Permission.change_artefact,
+        )

--- a/backend/tests/common/test_amr_permissions.py
+++ b/backend/tests/common/test_amr_permissions.py
@@ -18,7 +18,7 @@ from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from test_observer.common.enums import Permission
-from test_observer.common.permissions import check_amr_permission, check_artefact_permission
+from test_observer.common.permissions import check_amr_permissions, check_artefact_permission
 from test_observer.data_access.models_enums import FamilyName, StageName
 from tests.data_generator import DataGenerator
 
@@ -50,10 +50,10 @@ class TestCheckAMRPermission:
         generator._add_object(user)
 
         # Should not raise when user is in matching team
-        check_amr_permission(
+        check_amr_permissions(
             db_session,
             user,
-            artefact,
+            [artefact],
             Permission.change_artefact,
         )
 
@@ -85,10 +85,10 @@ class TestCheckAMRPermission:
 
         # Should raise 403 when user is not in matching team
         with pytest.raises(HTTPException) as exc_info:
-            check_amr_permission(
+            check_amr_permissions(
                 db_session,
                 user,
-                artefact,
+                [artefact],
                 Permission.change_artefact,
             )
         assert exc_info.value.status_code == 403
@@ -118,10 +118,10 @@ class TestCheckAMRPermission:
 
         # Should raise 403
         with pytest.raises(HTTPException) as exc_info:
-            check_amr_permission(
+            check_amr_permissions(
                 db_session,
                 user,
-                artefact,
+                [artefact],
                 Permission.change_artefact,
             )
         assert exc_info.value.status_code == 403
@@ -151,10 +151,10 @@ class TestCheckAMRPermission:
 
         # Should raise 403 because no AMR matches this artefact
         with pytest.raises(HTTPException) as exc_info:
-            check_amr_permission(
+            check_amr_permissions(
                 db_session,
                 user,
-                artefact,
+                [artefact],
                 Permission.change_artefact,
             )
         assert exc_info.value.status_code == 403
@@ -184,10 +184,10 @@ class TestCheckAMRPermission:
 
         # Should raise 403 because change_artefact is not granted
         with pytest.raises(HTTPException) as exc_info:
-            check_amr_permission(
+            check_amr_permissions(
                 db_session,
                 user,
-                artefact,
+                [artefact],
                 Permission.change_artefact,
             )
         assert exc_info.value.status_code == 403
@@ -203,10 +203,10 @@ class TestCheckAMRPermission:
 
         # Should raise 403 when user is None
         with pytest.raises(HTTPException) as exc_info:
-            check_amr_permission(
+            check_amr_permissions(
                 db_session,
                 None,
-                artefact,
+                [artefact],
                 Permission.change_artefact,
             )
         assert exc_info.value.status_code == 403
@@ -225,13 +225,22 @@ class TestCheckAMRPermission:
         admin_user.is_admin = True
         generator._add_object(admin_user)
 
-        # Should not raise even though no AMR matches
-        check_amr_permission(
+        # The admin user should be allowed due to admin privileges, so this should not raise
+        check_artefact_permission(
             db_session,
             admin_user,
+            None,
             artefact,
             Permission.change_artefact,
         )
+        # But the permission should not come from an AMR, since there isn't one
+        with pytest.raises(HTTPException):
+            check_amr_permissions(
+                db_session,
+                admin_user,
+                [artefact],
+                Permission.change_artefact,
+            )
 
     def test_admin_user_bypass_with_non_granting_amr(self, generator: DataGenerator, db_session: Session):
         """Admin user should be allowed even when AMR doesn't grant the required permission"""
@@ -257,13 +266,23 @@ class TestCheckAMRPermission:
         admin_user.teams = []
         generator._add_object(admin_user)
 
-        # Should not raise even though AMR doesn't grant change_artefact
-        check_amr_permission(
+        # The admin user should be allowed due to admin privileges, so this should not raise
+        check_artefact_permission(
             db_session,
             admin_user,
+            None,
             artefact,
             Permission.change_artefact,
         )
+
+        # But the permission should not come from an AMR, since it doesn't apply to the admin user
+        with pytest.raises(HTTPException):
+            check_amr_permissions(
+                db_session,
+                admin_user,
+                [artefact],
+                Permission.change_artefact,
+            )
 
 
 class TestCheckArtefactPermission:

--- a/backend/tests/common/test_amr_permissions.py
+++ b/backend/tests/common/test_amr_permissions.py
@@ -289,7 +289,8 @@ class TestCheckArtefactPermission:
         )
 
     def test_amr_grants_access_without_team_permission(self, generator: DataGenerator, db_session: Session):
-        """A user whose team has a matching AMR granting the permission should be granted access even with no direct team permissions"""
+        """A user whose team has a matching AMR granting the permission should be granted access
+        even with no direct team permissions"""
         team = generator.gen_team(name="amr-team")
         generator.gen_artefact_matching_rule(
             family=FamilyName.snap,

--- a/backend/tests/controllers/artefacts/test_artefacts.py
+++ b/backend/tests/controllers/artefacts/test_artefacts.py
@@ -517,7 +517,7 @@ def test_update_artefact_comment_as_user_with_permission(
     rather than having permission denied due to AMR checks.
     """
     artefact = generator.gen_artefact()
-    team = generator.gen_team(name="test-team", permissions=[Permission.change_rerun, Permission.change_rerun_bulk])
+    team = generator.gen_team(name="test-team", permissions=[Permission.change_artefact])
     user = generator.gen_user(name="user", teams=[team])
     authenticate_user(test_client, user, generator, create_session_cookie)
     response = test_client.patch(

--- a/backend/tests/controllers/artefacts/test_artefacts.py
+++ b/backend/tests/controllers/artefacts/test_artefacts.py
@@ -13,6 +13,7 @@
 # SPDX-FileCopyrightText: Copyright 2023 Canonical Ltd.
 # SPDX-License-Identifier: AGPL-3.0-only
 
+from collections.abc import Callable
 from datetime import date, timedelta
 from operator import itemgetter
 from typing import Any
@@ -33,7 +34,7 @@ from test_observer.data_access.models_enums import (
 )
 from test_observer.main import app
 from test_observer.users.user_injection import get_current_user
-from tests.conftest import make_authenticated_request
+from tests.conftest import authenticate_user, make_authenticated_request
 from tests.data_generator import DataGenerator
 
 
@@ -505,6 +506,28 @@ def test_update_artefact_comment(test_client: TestClient, generator: DataGenerat
 
     assert response.status_code == 200
     assert a.comment == comment
+
+
+def test_update_artefact_comment_as_user_with_permission(
+    test_client: TestClient,
+    generator: DataGenerator,
+    create_session_cookie: Callable[[int], str],
+):
+    """Test that a user with the appropriate permission as determined by their teams can update an artefact's comment,
+    rather than having permission denied due to AMR checks.
+    """
+    artefact = generator.gen_artefact()
+    team = generator.gen_team(name="test-team", permissions=[Permission.change_rerun, Permission.change_rerun_bulk])
+    user = generator.gen_user(name="user", teams=[team])
+    authenticate_user(test_client, user, generator, create_session_cookie)
+    response = test_client.patch(
+        f"/v1/artefacts/{artefact.id}",
+        headers={"X-CSRF-Token": "1"},
+        json={"comment": "Updated comment"},
+    )
+
+    assert response.status_code == 200
+    assert artefact.comment == "Updated comment"
 
 
 def test_update_artefact_jira_issue(test_client: TestClient, generator: DataGenerator):

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -34,7 +34,7 @@ from test_observer.data_access.models_enums import (
 )
 from test_observer.main import app
 from test_observer.users.user_injection import get_current_user
-from tests.conftest import make_authenticated_request
+from tests.conftest import authenticate_user, make_authenticated_request
 from tests.data_generator import DataGenerator
 
 reruns_url = "/v1/test-executions/reruns"
@@ -942,6 +942,34 @@ def test_delete_bulk_permission_not_required_for_single_id(
 
     assert response.status_code == 200
     assert len(get().json()) == 0
+
+
+def test_user_team_permission_respected_for_post(
+    test_client: TestClient, generator: DataGenerator, create_session_cookie: Callable[[int], str]
+):
+    """Test that team permissions are respected for POST and not ignored by AMR permission checks.
+    If no AMR exists, but the user has the required team permissions, the request should succeed.
+    """
+    a = generator.gen_artefact(StageName.beta)
+    ab = generator.gen_artefact_build(a)
+    e = generator.gen_environment("test-env")
+    te_1 = generator.gen_test_execution(ab, e, ci_link="http://ci1")
+    te_2 = generator.gen_test_execution(ab, e, ci_link="http://ci2")
+    te_3 = generator.gen_test_execution(ab, e, ci_link="http://ci3")
+
+    team = generator.gen_team(name="test-team", permissions=[Permission.change_rerun, Permission.change_rerun_bulk])
+    user = generator.gen_user(name="user", teams=[team])
+    authenticate_user(test_client, user, generator, create_session_cookie)
+
+    response = test_client.post(
+        "/v1/test-executions/reruns", headers={"X-CSRF-Token": "1"}, json={"test_execution_ids": [te_1.id]}
+    )
+    assert response.status_code == 200
+
+    response = test_client.post(
+        "/v1/test-executions/reruns", headers={"X-CSRF-Token": "1"}, json={"test_execution_ids": [te_2.id, te_3.id]}
+    )
+    assert response.status_code == 200
 
 
 # ==============================================================================


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR introduces some changes to permission checking to address some problems where team permissions were not respected. It refactors some permission helpers to be more generally useful, and then applies fixes to some of the broken methods. It builds on and expands what @almeidaraul got to a great start in https://github.com/canonical/test_observer/pull/810

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

TO-388

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

No API endpoints were drastically altered, but the bugged permission checking some of them did is now fixed.

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Tests are added