### PR TITLE
[TO-390] Fix long artefact version overlap

### DIFF
--- a/frontend/lib/ui/artefact_page/artefact_page.dart
+++ b/frontend/lib/ui/artefact_page/artefact_page.dart
@@ -80,6 +80,7 @@ class ArtefactPage extends ConsumerWidget {
                           child: ArtefactPageSide(artefact: artefact),
                         ),
                       ),
+                      if (showSide) const SizedBox(width: Spacing.level4),
                       Expanded(
                         child: SelectionArea(
                           child: ArtefactPageBody(artefact: artefact),

--- a/frontend/lib/ui/artefact_page/artefact_page.dart
+++ b/frontend/lib/ui/artefact_page/artefact_page.dart
@@ -80,7 +80,7 @@ class ArtefactPage extends ConsumerWidget {
                           child: ArtefactPageSide(artefact: artefact),
                         ),
                       ),
-                      if (showSide) const SizedBox(width: Spacing.level4),
+                      const SizedBox(width: Spacing.level4),
                       Expanded(
                         child: SelectionArea(
                           child: ArtefactPageBody(artefact: artefact),

--- a/frontend/lib/ui/artefact_page/artefact_page_info_section.dart
+++ b/frontend/lib/ui/artefact_page/artefact_page_info_section.dart
@@ -106,21 +106,26 @@ class _ArtefactVersionSelector extends ConsumerWidget {
     return Row(
       children: [
         Text('version: ', style: labelFontStyle),
-        DropdownMenu<ArtefactVersion>(
-          initialSelection: currentVersion,
-          dropdownMenuEntries: versions
-              .map(
-                (version) => DropdownMenuEntry<ArtefactVersion>(
-                  value: version,
-                  label: version.version,
-                ),
-              )
-              .toList(),
-          onSelected: (version) {
-            if (version != null) {
-              navigateToArtefactPage(context, version.artefactId);
-            }
-          },
+        Expanded(
+          child: DropdownMenu<ArtefactVersion>(
+            // Fill the remaining width of the sidebar so a long version name
+            // truncates with an ellipsis instead of overflowing into the body.
+            expandedInsets: EdgeInsets.zero,
+            initialSelection: currentVersion,
+            dropdownMenuEntries: versions
+                .map(
+                  (version) => DropdownMenuEntry<ArtefactVersion>(
+                    value: version,
+                    label: version.version,
+                  ),
+                )
+                .toList(),
+            onSelected: (version) {
+              if (version != null) {
+                navigateToArtefactPage(context, version.artefactId);
+              }
+            },
+          ),
         ),
       ],
     );


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR fixes a frontend bug where long version names for an artefact would cause the dropdown menu for version selection to overlap with the word "Environments". It also adds a bit of spacing between the sidebar and the main page body.

Version Dropdown Before
<img width="1062" height="118" alt="Screenshot from 2026-06-26 18-19-58" src="https://github.com/user-attachments/assets/f775c050-1c32-43ee-bfdf-eb3b7f6a7cbd" />

Version Dropdown After (Unselected)
<img width="1102" height="116" alt="Screenshot from 2026-06-26 18-20-16" src="https://github.com/user-attachments/assets/6698cdbf-b703-44f1-a05e-9615c278cb84" />

Version Dropdown After (Selected - the full version text is visible)
<img width="1188" height="230" alt="Screenshot from 2026-06-26 18-20-33" src="https://github.com/user-attachments/assets/90964bd5-0a2f-4559-9d66-3c47b7b365e5" />

Spacing Before (Sidebar collapsed)
<img width="1170" height="122" alt="Screenshot from 2026-06-26 18-25-53" src="https://github.com/user-attachments/assets/363bb3c4-31a8-47c2-acbd-87ec221a68a5" />

Spacing After (Sidebar collapsed)
<img width="1170" height="122" alt="Screenshot from 2026-06-26 18-28-00" src="https://github.com/user-attachments/assets/854025fb-561a-4082-adbd-72584234f15a" />

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

[TO-390]



[TO-390]: https://warthogs.atlassian.net/browse/TO-390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ