### PR TITLE
[TO-386] Allow starting image test executions with sha256 only

### DIFF
--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -7774,17 +7774,38 @@
       "StartImageTestExecutionRequest": {
         "properties": {
           "name": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Name",
             "description": "User-defined name identifying the artefact under test. Not unique - multiple versions/stages of the same artefact share this name. Examples: 'core22', 'ubuntu-desktop', 'snapd'"
           },
           "version": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Version",
             "description": "Version identifier of the artefact being tested. Format depends on artefact family - e.g., revisions for charms/snaps, version numbers for debs."
           },
           "arch": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Arch",
             "description": "CPU architecture where tests will execute. Common values: 'amd64', 'arm64', 'armhf', 's390x', 'ppc64el'"
           },
@@ -7840,16 +7861,37 @@
             "default": "image"
           },
           "execution_stage": {
-            "$ref": "#/components/schemas/ImageStage",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ImageStage"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "Promotion stage of the image being tested. Options: 'pending' (awaiting approval), 'current' (approved and published). Use 'pending' for images undergoing testing before promotion."
           },
           "os": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Os",
             "description": "Operating system of the image. Examples: 'ubuntu', 'ubuntu-core', 'ubuntu-server'"
           },
           "release": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Release",
             "description": "OS release codename or version. Examples: 'focal', 'jammy', 'noble', '20.04', '22.04', '24.04'"
           },
@@ -7859,32 +7901,38 @@
             "description": "SHA256 checksum hash uniquely identifying this image build. Used to verify image integrity and uniqueness."
           },
           "owner": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Owner",
             "description": "Team or organization responsible for the image. Examples: 'canonical', 'ubuntu-images', team names"
           },
           "image_url": {
-            "type": "string",
-            "maxLength": 2083,
-            "minLength": 1,
-            "format": "uri",
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2083,
+                "minLength": 1,
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Image Url",
             "description": "Direct URL where the image file can be downloaded or accessed. Should be a valid HTTP/HTTPS URL."
           }
         },
         "type": "object",
         "required": [
-          "name",
-          "version",
-          "arch",
           "environment",
           "test_plan",
-          "execution_stage",
-          "os",
-          "release",
-          "sha256",
-          "owner",
-          "image_url"
+          "sha256"
         ],
         "title": "StartImageTestExecutionRequest"
       },

--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -15,7 +15,7 @@
 
 from datetime import datetime
 from enum import StrEnum
-from typing import Annotated, Literal, Self
+from typing import Annotated, ClassVar, Literal, Self
 
 from pydantic import (
     AliasPath,
@@ -216,24 +216,67 @@ class StartCharmTestExecutionRequest(_StartTestExecutionRequest):
 
 class StartImageTestExecutionRequest(_StartTestExecutionRequest):
     family: Literal[FamilyName.image] = FamilyName.image
-    execution_stage: ImageStage = Field(
+
+    # Fields that must be present to register a brand new image. An existing image is
+    # identified by sha256 alone, so these may be omitted when it already exists. Kept
+    # next to the field declarations below so the two stay in sync.
+    REQUIRED_CREATION_FIELDS: ClassVar[tuple[str, ...]] = (
+        "name",
+        "version",
+        "os",
+        "release",
+        "owner",
+        "image_url",
+        "execution_stage",
+        "arch",
+    )
+
+    # sha256 alone identifies an existing image, so all other fields are optional and
+    # only required to create a new one (enforced by the controller via
+    # REQUIRED_CREATION_FIELDS). The type: ignore lines relax base-class required fields;
+    # the narrowing is intentional for this discriminated-union member.
+    name: str | None = Field(  # type: ignore[assignment]
+        default=None,
+        description="User-defined name identifying the artefact under test. "
+        "Not unique - multiple versions/stages of the same artefact share this name. "
+        "Examples: 'core22', 'ubuntu-desktop', 'snapd'",
+    )
+    version: str | None = Field(  # type: ignore[assignment]
+        default=None,
+        description="Version identifier of the artefact being tested. "
+        "Format depends on artefact family - e.g., revisions for "
+        "charms/snaps, version numbers for debs.",
+    )
+    arch: str | None = Field(  # type: ignore[assignment]
+        default=None,
+        description="CPU architecture where tests will execute. "
+        "Common values: 'amd64', 'arm64', 'armhf', 's390x', 'ppc64el'",
+    )
+    execution_stage: ImageStage | None = Field(
+        default=None,
         description="Promotion stage of the image being tested. "
         "Options: 'pending' (awaiting approval), 'current' (approved and published). "
-        "Use 'pending' for images undergoing testing before promotion."
+        "Use 'pending' for images undergoing testing before promotion.",
     )
-    os: str = Field(description="Operating system of the image. Examples: 'ubuntu', 'ubuntu-core', 'ubuntu-server'")
-    release: str = Field(
-        description="OS release codename or version. Examples: 'focal', 'jammy', 'noble', '20.04', '22.04', '24.04'"
+    os: str | None = Field(
+        default=None, description="Operating system of the image. Examples: 'ubuntu', 'ubuntu-core', 'ubuntu-server'"
+    )
+    release: str | None = Field(
+        default=None,
+        description="OS release codename or version. Examples: 'focal', 'jammy', 'noble', '20.04', '22.04', '24.04'",
     )
     sha256: str = Field(
         description="SHA256 checksum hash uniquely identifying this image build. "
         "Used to verify image integrity and uniqueness."
     )
-    owner: str = Field(
-        description="Team or organization responsible for the image. Examples: 'canonical', 'ubuntu-images', team names"
+    owner: str | None = Field(
+        default=None,
+        description="Team or organization responsible for the image. "
+        "Examples: 'canonical', 'ubuntu-images', team names",
     )
-    image_url: HttpUrl = Field(
-        description="Direct URL where the image file can be downloaded or accessed. Should be a valid HTTP/HTTPS URL."
+    image_url: HttpUrl | None = Field(
+        default=None,
+        description="Direct URL where the image file can be downloaded or accessed. Should be a valid HTTP/HTTPS URL.",
     )
 
 

--- a/backend/test_observer/controllers/test_executions/start_test.py
+++ b/backend/test_observer/controllers/test_executions/start_test.py
@@ -97,6 +97,9 @@ class StartTestExecutionController:
 
     def execute(self):
         self.create_artefact()
+        # arch must be resolved after the artefact exists: for an existing image the
+        # request may omit arch, in which case it is derived from the image's build.
+        self.resolved_arch = self._resolve_arch()
         self.create_environment()
         self.create_artefact_build()
         self.create_artefact_build_environment()
@@ -281,7 +284,7 @@ class StartTestExecutionController:
             self.db,
             ArtefactBuild,
             filter_kwargs={
-                "architecture": self.request.arch,
+                "architecture": self.resolved_arch,
                 "revision": getattr(self.request, "revision", None),
                 "artefact_id": self.artefact.id,
             },
@@ -293,16 +296,20 @@ class StartTestExecutionController:
             Environment,
             filter_kwargs={
                 "name": self.request.environment,
-                "architecture": self.request.arch,
+                "architecture": self.resolved_arch,
             },
         )
 
     def create_artefact(self) -> None:
+        # The lookup filter must hold exactly the artefact's family-specific unique key;
+        # any other fields go in creation_kwargs so a differing value can't miss the
+        # existing row and then trip the unique constraint on insert.
         filter_kwargs = {
             "name": self.request.name,
             "version": self.request.version,
             "family": self.request.family,
         }
+        creation_kwargs: dict = {"stage": self.request.execution_stage}
 
         match self.request:
             case StartSnapTestExecutionRequest():
@@ -316,12 +323,26 @@ class StartTestExecutionController:
                 filter_kwargs["series"] = self.request.series
                 filter_kwargs["repo"] = self.request.repo
                 filter_kwargs["source"] = self.request.source
+
+            # An image is identified by its sha256 alone, so an existing image can be
+            # tested by submitting only its sha256; the rest is needed only to create it.
             case StartImageTestExecutionRequest():
-                filter_kwargs["os"] = self.request.os
-                filter_kwargs["release"] = self.request.release
-                filter_kwargs["sha256"] = self.request.sha256
-                filter_kwargs["owner"] = self.request.owner
-                filter_kwargs["image_url"] = str(self.request.image_url)
+                filter_kwargs = {"family": self.request.family, "sha256": self.request.sha256}
+                if self.db.query(Artefact).filter_by(**filter_kwargs).one_or_none() is None and any(
+                    getattr(self.request, field) is None for field in self.request.REQUIRED_CREATION_FIELDS
+                ):
+                    raise HTTPException(
+                        status_code=422,
+                        detail="No image with this sha256 exists yet; provide the full image details to create it.",
+                    )
+                creation_kwargs |= {
+                    "name": self.request.name,
+                    "version": self.request.version,
+                    "os": self.request.os,
+                    "release": self.request.release,
+                    "owner": self.request.owner,
+                    "image_url": str(self.request.image_url),
+                }
 
             # In other families, a single artefact will progress through stages,
             # i.e. move from edge to stable. Solutions are different. Different stages are treated
@@ -331,14 +352,22 @@ class StartTestExecutionController:
                 filter_kwargs["source"] = self.request.source
                 filter_kwargs["stage"] = self.request.execution_stage
                 filter_kwargs["bundled_builds_hash"] = calculate_bundled_builds_hash([])
+                creation_kwargs = {}
 
-        self.artefact = get_or_create(
-            self.db,
-            Artefact,
-            filter_kwargs=filter_kwargs,
-            creation_kwargs={"stage": self.request.execution_stage}
-            if not isinstance(self.request, StartSolutionTestExecutionRequest)
-            else {},
+        self.artefact = get_or_create(self.db, Artefact, filter_kwargs=filter_kwargs, creation_kwargs=creation_kwargs)
+
+    def _resolve_arch(self) -> str:
+        if self.request.arch is not None:
+            return self.request.arch
+
+        # arch was omitted: only valid for an existing image, derive it from its build.
+        architectures = self.artefact.architectures
+        if len(architectures) == 1:
+            return next(iter(architectures))
+
+        raise HTTPException(
+            status_code=422,
+            detail="'arch' is required and could not be derived from the image's builds.",
         )
 
     def delete_rerun_request(self):

--- a/backend/test_observer/controllers/test_executions/start_test.py
+++ b/backend/test_observer/controllers/test_executions/start_test.py
@@ -328,12 +328,24 @@ class StartTestExecutionController:
             # tested by submitting only its sha256; the rest is needed only to create it.
             case StartImageTestExecutionRequest():
                 filter_kwargs = {"family": self.request.family, "sha256": self.request.sha256}
-                if self.db.query(Artefact).filter_by(**filter_kwargs).one_or_none() is None and any(
+                existing_image = self.db.query(Artefact).filter_by(**filter_kwargs).one_or_none()
+
+                if existing_image is None and any(
                     getattr(self.request, field) is None for field in self.request.REQUIRED_CREATION_FIELDS
                 ):
                     raise HTTPException(
                         status_code=422,
                         detail="No image with this sha256 exists yet; provide the full image details to create it.",
+                    )
+                # An image is single-architecture: a provided arch must match the existing build.
+                if (
+                    existing_image is not None
+                    and self.request.arch is not None
+                    and self.request.arch not in existing_image.architectures
+                ):
+                    raise HTTPException(
+                        status_code=422,
+                        detail="'arch' must match the existing image build architecture.",
                     )
                 creation_kwargs |= {
                     "name": self.request.name,

--- a/backend/tests/controllers/test_executions/test_start_test.py
+++ b/backend/tests/controllers/test_executions/test_start_test.py
@@ -731,24 +731,103 @@ def test_charm_required_fields(execute: Execute, field: str):
 @pytest.mark.parametrize(
     "field",
     [
-        "name",
-        "version",
-        "os",
-        "release",
-        "arch",
         "sha256",
-        "owner",
-        "image_url",
-        "execution_stage",
         "environment",
+        "test_plan",
     ],
 )
-def test_image_required_fields(execute: Execute, field: str):
+def test_image_schema_required_fields(execute: Execute, field: str):
+    """Fields that are always required by the request schema for images."""
     request = image_test_request.copy()
     request.pop(field)
     response = execute(request)
 
     assert_fails_validation(response, field, "missing")
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "name",
+        "version",
+        "os",
+        "release",
+        "arch",
+        "owner",
+        "image_url",
+        "execution_stage",
+    ],
+)
+def test_image_missing_create_fields_returns_422(execute: Execute, field: str):
+    """When no image with the sha256 exists yet, creating one requires all these
+    fields. Omitting any returns a clean 422 (not a 500)."""
+    request = image_test_request.copy()
+    request.pop(field)
+    response = execute(request)
+
+    assert response.status_code == 422
+
+
+# A second, distinct sha256 used for tests that pre-seed an existing image so that the
+# request under test resolves to "existing" rather than "create".
+_EXISTING_IMAGE_SHA256 = "a" * 64
+
+
+def _existing_image_request(**overrides: object) -> dict[str, Any]:
+    """A minimal image start-test payload for an image that already exists: just the
+    sha256 plus the test-execution context, no descriptive fields and no arch."""
+    request: dict[str, Any] = {
+        "family": "image",
+        "sha256": _EXISTING_IMAGE_SHA256,
+        "environment": "xps",
+        "test_plan": "image test plan",
+        "ci_link": "http://localhost",
+    }
+    request.update(overrides)
+    return request
+
+
+def test_image_minimal_payload_reuses_existing_artefact(
+    execute: Execute, generator: DataGenerator, db_session: Session
+):
+    """An existing image can be tested with only its sha256 + test context; arch is
+    derived from the image's single build."""
+    image = generator.gen_image(sha256=_EXISTING_IMAGE_SHA256, name="noble-desktop-amd64")
+    generator.gen_artefact_build(image, architecture="arm64")
+
+    response = execute(_existing_image_request())
+
+    assert response.status_code == 200
+    test_execution = db_session.get(TestExecution, response.json()["id"])
+    assert test_execution is not None
+    assert test_execution.artefact_build.artefact_id == image.id
+    # arch was omitted and derived from the existing build
+    assert test_execution.artefact_build.architecture == "arm64"
+    assert test_execution.environment.architecture == "arm64"
+
+
+def test_image_same_sha_reuses_existing_artefact(execute: Execute, db_session: Session):
+    """Regression: two image payloads sharing a sha256 used to 500 via an uncaught
+    NoResultFound. The sha256 identifies the image, so the second request now reuses
+    the existing artefact."""
+    first = {**image_test_request, "sha256": _EXISTING_IMAGE_SHA256}
+    first_response = execute(first)
+    assert first_response.status_code == 200
+    first_te = db_session.get(TestExecution, first_response.json()["id"])
+    assert first_te is not None
+
+    second = {
+        **image_test_request,
+        "sha256": _EXISTING_IMAGE_SHA256,
+        "name": "different-image",
+        "ci_link": "http://localhost/other",
+    }
+    second_response = execute(second)
+    assert second_response.status_code == 200
+    second_te = db_session.get(TestExecution, second_response.json()["id"])
+    assert second_te is not None
+
+    assert first_te.artefact_build.artefact_id == second_te.artefact_build.artefact_id
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/controllers/test_executions/test_start_test.py
+++ b/backend/tests/controllers/test_executions/test_start_test.py
@@ -377,6 +377,9 @@ class TestFamilyIndependentTests:
         When an artefact has multiple builds and multiple reviewers,
         each build's environment reviews should get reviewer assignments
         """
+        if start_request["family"] == "image":
+            pytest.skip("an image is single-architecture, so it cannot have multiple builds")
+
         # Create a team that can review all families
         snap_rule = generator.gen_artefact_matching_rule(family=FamilyName.snap)
         deb_rule = generator.gen_artefact_matching_rule(family=FamilyName.deb)
@@ -792,7 +795,7 @@ def test_image_minimal_payload_reuses_existing_artefact(
 ):
     """An existing image can be tested with only its sha256 + test context; arch is
     derived from the image's single build."""
-    image = generator.gen_image(sha256=_EXISTING_IMAGE_SHA256, name="noble-desktop-amd64")
+    image = generator.gen_image(sha256=_EXISTING_IMAGE_SHA256, name="noble-desktop-arm64")
     generator.gen_artefact_build(image, architecture="arm64")
 
     response = execute(_existing_image_request())
@@ -804,6 +807,16 @@ def test_image_minimal_payload_reuses_existing_artefact(
     # arch was omitted and derived from the existing build
     assert test_execution.artefact_build.architecture == "arm64"
     assert test_execution.environment.architecture == "arm64"
+
+
+def test_image_conflicting_arch_is_rejected(execute: Execute, generator: DataGenerator):
+    """A provided arch that differs from the existing image's build is rejected (422)."""
+    image = generator.gen_image(sha256=_EXISTING_IMAGE_SHA256)
+    generator.gen_artefact_build(image, architecture="amd64")
+
+    response = execute(_existing_image_request(arch="arm64"))
+
+    assert response.status_code == 422
 
 
 def test_image_same_sha_reuses_existing_artefact(execute: Execute, db_session: Session):


### PR DESCRIPTION
Look up image artifacts by sha256 alone so an existing image can be tested by submitting just its sha256 plus the test context; other fields are ignored when it already exists. Eliminates the 500 that occurred when a request reused a sha256 with differing metadata, and returns 422 when creating a new image with incomplete details.

Closes #799

## Tests
Tested locally by starting test executions on already existing images using only sha256