### PR TITLE
[SQT-200] Add priority column to reruns

### DIFF
--- a/backend/migrations/versions/2026_06_26_1835-ac1b18650275_add_priority_to_reruns.py
+++ b/backend/migrations/versions/2026_06_26_1835-ac1b18650275_add_priority_to_reruns.py
@@ -37,12 +37,12 @@ def upgrade() -> None:
         sa.Column("priority", sa.Integer(), nullable=False, server_default="0"),
     )
     op.create_index(
-        "ix_rerun_request_priority_created_at",
+        "idx_rerun_request_priority_created_at",
         "test_execution_rerun_request",
         [sa.text("priority DESC"), sa.text("created_at ASC")],
     )
 
 
 def downgrade() -> None:
-    op.drop_index("ix_rerun_request_priority_created_at", table_name="test_execution_rerun_request")
+    op.drop_index("idx_rerun_request_priority_created_at", table_name="test_execution_rerun_request")
     op.drop_column("test_execution_rerun_request", "priority")

--- a/backend/migrations/versions/2026_06_26_1835-ac1b18650275_add_priority_to_reruns.py
+++ b/backend/migrations/versions/2026_06_26_1835-ac1b18650275_add_priority_to_reruns.py
@@ -1,0 +1,48 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Add priority to reruns
+
+Revision ID: ac1b18650275
+Revises: 236cc88a9a64
+Create Date: 2026-06-26 18:35:32.947482+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "ac1b18650275"
+down_revision = "236cc88a9a64"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "test_execution_rerun_request",
+        sa.Column("priority", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.create_index(
+        "ix_rerun_request_priority_created_at",
+        "test_execution_rerun_request",
+        [sa.text("priority DESC"), sa.text("created_at ASC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_rerun_request_priority_created_at", table_name="test_execution_rerun_request")
+    op.drop_column("test_execution_rerun_request", "priority")

--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -7376,6 +7376,10 @@
           },
           "artefact_build": {
             "$ref": "#/components/schemas/ArtefactBuildMinimalResponse"
+          },
+          "priority": {
+            "type": "integer",
+            "title": "Priority"
           }
         },
         "type": "object",
@@ -7385,7 +7389,8 @@
           "family",
           "test_execution",
           "artefact",
-          "artefact_build"
+          "artefact_build",
+          "priority"
         ],
         "title": "PendingRerun"
       },
@@ -7477,6 +7482,17 @@
                 "type": "null"
               }
             ]
+          },
+          "priority": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Priority"
           }
         },
         "type": "object",

--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -302,6 +302,7 @@ class TestExecutionsPatchRequest(BaseModel):
 class RerunRequest(BaseModel):
     test_execution_ids: set[int] = Field(default_factory=set)
     test_results_filters: TestResultSearchFilters | None = None
+    priority: int | None = None
 
 
 class PendingRerun(BaseModel):
@@ -313,6 +314,7 @@ class PendingRerun(BaseModel):
     test_execution: TestExecutionResponse = Field(validation_alias=AliasPath("test_executions", 0))
     artefact: ArtefactResponse = Field(validation_alias=AliasPath("artefact_build", "artefact"))
     artefact_build: ArtefactBuildMinimalResponse = Field(validation_alias=AliasPath("artefact_build"))
+    priority: int
 
 
 class DeleteReruns(BaseModel):

--- a/backend/test_observer/controllers/test_executions/reruns.py
+++ b/backend/test_observer/controllers/test_executions/reruns.py
@@ -18,7 +18,7 @@ from typing import Annotated
 
 from fastapi import Depends, HTTPException, Query, Response, Security, status
 from fastapi.security import SecurityScopes
-from sqlalchemy import asc, delete, or_, select, tuple_
+from sqlalchemy import Select, asc, delete, desc, literal, or_, select, tuple_
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session, selectinload
 
@@ -54,28 +54,25 @@ from .models import DeleteReruns, PendingRerun, RerunRequest
 from .router import router
 
 
+class _TestExecutionNotFound(ValueError): ...
+
+
+# ==============================================================================
+# DB helpers
+# ==============================================================================
+
+
 def _build_rerun_conditions(request: RerunRequest | DeleteReruns) -> list:
-    """Build conditions for finding affected TestExecutions.
+    """Return SQLAlchemy WHERE conditions identifying the affected TestExecutions.
 
-    Constructs a list of SQLAlchemy conditions for either direct test execution IDs
-    or filtered test results.
-
-    Args:
-        request: RerunRequest or DeleteReruns with either test_execution_ids or test_results_filters
-
-    Returns:
-        List of SQLAlchemy conditions (may be empty if neither criterion is provided)
-
-    Raises:
-        HTTPException(422): If test_results_filters is provided but has no filters
+    Raises HTTPException(422) if test_results_filters is provided but empty.
+    Returns an empty list if neither criterion is provided (caller should no-op).
     """
     conditions = []
 
-    # Add condition for direct test execution IDs
-    if request.test_execution_ids is not None and len(request.test_execution_ids) > 0:
+    if request.test_execution_ids:
         conditions.append(TestExecution.id.in_(request.test_execution_ids))
 
-    # Add condition for filtered test results
     if request.test_results_filters is not None:
         filters = request.test_results_filters
         if not filters.has_filters():
@@ -89,18 +86,9 @@ def _build_rerun_conditions(request: RerunRequest | DeleteReruns) -> list:
     return conditions
 
 
-def modify_reruns(
-    db: Session,
-    request: RerunRequest | DeleteReruns,
-):
-    conditions = _build_rerun_conditions(request)
-
-    # Do nothing if no conditions were added
-    if not conditions:
-        return
-
-    # Build subquery selecting the composite key from TestExecution
-    subquery = (
+def _rerun_group_subquery(conditions: list) -> Select[tuple[int, int, int]]:
+    """Select the composite key (test_plan_id, artefact_build_id, environment_id) for matching executions."""
+    return (
         select(
             TestExecution.test_plan_id,
             TestExecution.artefact_build_id,
@@ -110,31 +98,69 @@ def modify_reruns(
         .distinct()
     )
 
-    if isinstance(request, RerunRequest):
+
+def _create_reruns(db: Session, conditions: list, priority: int | None) -> None:
+    subquery = _rerun_group_subquery(conditions)
+    if priority is not None:
+        subquery = subquery.add_columns(literal(priority).label("priority"))
+        insert_stmt = pg_insert(TestExecutionRerunRequest).from_select(
+            ["test_plan_id", "artefact_build_id", "environment_id", "priority"],
+            subquery,
+        )
         db.execute(
-            pg_insert(TestExecutionRerunRequest)
-            .from_select(
-                [
-                    "test_plan_id",
-                    "artefact_build_id",
-                    "environment_id",
-                ],
-                subquery,
+            insert_stmt.on_conflict_do_update(
+                constraint="uq_rerun_request_group",
+                set_={"priority": insert_stmt.excluded.priority},
             )
-            .on_conflict_do_nothing()
         )
     else:
-        db.execute(
-            delete(TestExecutionRerunRequest).where(
-                tuple_(
-                    TestExecutionRerunRequest.test_plan_id,
-                    TestExecutionRerunRequest.artefact_build_id,
-                    TestExecutionRerunRequest.environment_id,
-                ).in_(subquery)
-            )
+        insert_stmt = pg_insert(TestExecutionRerunRequest).from_select(
+            ["test_plan_id", "artefact_build_id", "environment_id"],
+            subquery,
         )
+        db.execute(insert_stmt.on_conflict_do_nothing())
 
-    db.commit()
+
+def _delete_reruns(db: Session, conditions: list) -> None:
+    subquery = _rerun_group_subquery(conditions)
+    db.execute(
+        delete(TestExecutionRerunRequest).where(
+            tuple_(
+                TestExecutionRerunRequest.test_plan_id,
+                TestExecutionRerunRequest.artefact_build_id,
+                TestExecutionRerunRequest.environment_id,
+            ).in_(subquery)
+        )
+    )
+
+
+def _create_rerun_request(
+    test_execution_id: int, db: Session, priority: int | None = None
+) -> TestExecutionRerunRequest:
+    te = db.get(TestExecution, test_execution_id)
+    if not te:
+        raise _TestExecutionNotFound
+
+    rerun = get_or_create(
+        db,
+        TestExecutionRerunRequest,
+        {
+            "test_plan_id": te.test_plan_id,
+            "artefact_build_id": te.artefact_build_id,
+            "environment_id": te.environment_id,
+        },
+        creation_kwargs={"priority": priority} if priority is not None else None,
+    )
+    # If the record already existed, get_or_create ignores creation_kwargs,
+    # so explicitly update priority here.
+    if priority is not None:
+        rerun.priority = priority
+    return rerun
+
+
+# ==============================================================================
+# Permission helpers (FastAPI dependencies)
+# ==============================================================================
 
 
 def require_bulk_permission(
@@ -143,55 +169,28 @@ def require_bulk_permission(
     user: User | None = Depends(get_current_user),
     app: Application | None = Depends(get_current_application),
 ):
-    if (request.test_execution_ids is not None and len(request.test_execution_ids) > 1) or (
-        request.test_results_filters is not None
-    ):
+    if len(request.test_execution_ids) > 1 or request.test_results_filters is not None:
         permission_checker(security_scopes, user, app)
 
 
-def _validate_amr_permissions_for_request(
+def _validate_amr_permissions(
     db: Session,
     user: User | None,
     app: Application | None,
     request: RerunRequest | DeleteReruns,
     permission: Permission,
 ) -> None:
-    """
-    Validate AMR permissions for rerun requests with optimized batch querying.
-
-    Handles two cases:
-    1. Direct IDs: When request.test_execution_ids is provided
-    2. Filters: When request.test_results_filters is provided
-
-    Uses all-or-nothing semantics: raise HTTPException(403) if ANY artefact is unauthorized.
-    Honors IGNORE_PERMISSIONS, app.permissions, and admin bypass through early exits.
-    Uses batch querying to reduce database load from O(n) to O(1) for AMR matching.
-
-    Args:
-        db: Database session
-        user: Current user (can be None)
-        app: Current application (can be None)
-        request: RerunRequest or DeleteReruns with either test_execution_ids or test_results_filters
-        permission: Permission to check (e.g., Permission.change_rerun)
-
-    Raises:
-        HTTPException(403): If any affected artefact is unauthorized
-    """
+    """Raise HTTPException(403) if the user/app lacks AMR permission on any affected artefact."""
     if has_general_permission(user, app, permission):
         return
 
-    # If user is None, we cannot check AMR permissions, so raise 403
     if user is None:
         raise HTTPException(status_code=403, detail="Insufficient permissions")
 
-    # Collect conditions to find affected TestExecutions
     conditions = _build_rerun_conditions(request)
-
-    # If no conditions, nothing to check
     if not conditions:
         return
 
-    # Query for all unique artefacts affected by the request
     affected_artefacts_query = (
         select(Artefact)
         .distinct()
@@ -199,10 +198,14 @@ def _validate_amr_permissions_for_request(
         .join(TestExecution, TestExecution.artefact_build_id == ArtefactBuild.id)
         .where(or_(*conditions))
     )
-
     affected_artefacts = db.scalars(affected_artefacts_query).all()
     if not has_amr_permissions(db, user, affected_artefacts, permission):
         raise HTTPException(status_code=403, detail="Insufficient permissions")
+
+
+# ==============================================================================
+# Route handlers
+# ==============================================================================
 
 
 @router.post(
@@ -231,11 +234,13 @@ def create_rerun_requests(
     user: User | None = Depends(get_current_user),
     app: Application | None = Depends(get_current_application),
 ):
-    # Validate AMR permissions in addition to basic app/user permissions
-    _validate_amr_permissions_for_request(db, user, app, request, Permission.change_rerun)
+    _validate_amr_permissions(db, user, app, request, Permission.change_rerun)
 
     if silent:
-        modify_reruns(db, request)
+        conditions = _build_rerun_conditions(request)
+        if conditions:
+            _create_reruns(db, conditions, request.priority)
+            db.commit()
         return
 
     if request.test_results_filters is not None:
@@ -247,7 +252,7 @@ def create_rerun_requests(
     rerun_requests = []
     for test_execution_id in request.test_execution_ids:
         with contextlib.suppress(_TestExecutionNotFound):
-            rerun_requests.append(_create_rerun_request(test_execution_id, db))
+            rerun_requests.append(_create_rerun_request(test_execution_id, db, request.priority))
 
     if not rerun_requests:
         raise HTTPException(
@@ -261,22 +266,6 @@ def create_rerun_requests(
     db.commit()
 
     return rerun_requests
-
-
-def _create_rerun_request(test_execution_id: int, db: Session) -> TestExecutionRerunRequest:
-    te = db.get(TestExecution, test_execution_id)
-    if not te:
-        raise _TestExecutionNotFound
-
-    return get_or_create(
-        db,
-        TestExecutionRerunRequest,
-        {
-            "test_plan_id": te.test_plan_id,
-            "artefact_build_id": te.artefact_build_id,
-            "environment_id": te.environment_id,
-        },
-    )
 
 
 @router.get(
@@ -305,7 +294,11 @@ def get_rerun_requests(
             selectinload(TestExecutionRerunRequest.test_plan),
             selectinload(TestExecutionRerunRequest.test_executions),
         )
-        .order_by(asc(TestExecutionRerunRequest.created_at))
+        .order_by(
+            desc(TestExecutionRerunRequest.priority),
+            asc(TestExecutionRerunRequest.created_at),
+            asc(TestExecutionRerunRequest.id),
+        )
     )
 
     if family is not None:
@@ -339,10 +332,9 @@ def delete_rerun_requests(
     user: User | None = Depends(get_current_user),
     app: Application | None = Depends(get_current_application),
 ):
-    # Validate AMR permissions in addition to basic app/user permissions
-    _validate_amr_permissions_for_request(db, user, app, request, Permission.change_rerun)
+    _validate_amr_permissions(db, user, app, request, Permission.change_rerun)
 
-    modify_reruns(db, request)
-
-
-class _TestExecutionNotFound(ValueError): ...
+    conditions = _build_rerun_conditions(request)
+    if conditions:
+        _delete_reruns(db, conditions)
+        db.commit()

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -578,6 +578,11 @@ class TestExecutionRerunRequest(Base):
             "environment_id",
             name="uq_rerun_request_group",
         ),
+        Index(
+            "idx_rerun_request_priority_created_at",
+            desc(column("priority")),
+            column("created_at"),
+        ),
     )
 
     priority: Mapped[int] = mapped_column(default=0)

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -580,6 +580,8 @@ class TestExecutionRerunRequest(Base):
         ),
     )
 
+    priority: Mapped[int] = mapped_column(default=0)
+
     test_plan_id: Mapped[int] = mapped_column(ForeignKey("test_plan.id", ondelete="CASCADE"), index=True)
     test_plan: Mapped["TestPlan"] = relationship(back_populates="rerun_requests")
 

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -1695,13 +1695,13 @@ def test_post_without_priority_does_not_change_existing_priority(post: Post, get
     assert reruns[0]["priority"] == 7
 
 
-def test_bulk_post_without_priority_does_not_change_existing_priority(
+def test_silent_post_without_priority_does_not_change_existing_priority(
     test_client: TestClient, get: Get, generator: DataGenerator
 ):
-    """Bulk silent post without priority should not overwrite an existing rerun's priority."""
+    """Silent post without priority should not overwrite an existing rerun's priority."""
     a = generator.gen_artefact(StageName.beta)
     ab = generator.gen_artefact_build(a)
-    e = generator.gen_environment("bulk-no-priority-env")
+    e = generator.gen_environment("silent-no-priority-env")
     te = generator.gen_test_execution(ab, e)
 
     make_authenticated_request(
@@ -1732,13 +1732,13 @@ def test_post_updates_priority_if_rerun_already_exists(post: Post, get: Get, tes
     assert reruns[0]["priority"] == 5
 
 
-def test_bulk_post_updates_priority_if_rerun_already_exists(
+def test_silent_post_updates_priority_if_rerun_already_exists(
     test_client: TestClient, get: Get, generator: DataGenerator
 ):
-    """Bulk silent post with a different priority should update existing reruns."""
+    """Silent post with a different priority should update an existing rerun's priority."""
     a = generator.gen_artefact(StageName.beta)
     ab = generator.gen_artefact_build(a)
-    e = generator.gen_environment("bulk-update-env")
+    e = generator.gen_environment("silent-update-env")
     te = generator.gen_test_execution(ab, e)
 
     make_authenticated_request(

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -113,11 +113,12 @@ type Get = Callable[..., Response]
 type Delete = Callable[[Any], Response]
 
 
-def test_execution_to_pending_rerun(test_execution: TestExecution) -> dict:
+def test_execution_to_pending_rerun(test_execution: TestExecution, priority: int = 0) -> dict:
     return_data = {
         "test_execution_id": test_execution.id,
         "ci_link": test_execution.ci_link,
         "family": test_execution.artefact_build.artefact.family,
+        "priority": priority,
         "test_execution": {
             "id": test_execution.id,
             "ci_link": test_execution.ci_link,
@@ -1618,3 +1619,145 @@ class TestRerunAMRPermissions:
         finally:
             del app.dependency_overrides[get_current_user]
             del app.dependency_overrides[get_current_application]
+
+
+# ==============================================================================
+# Priority Tests
+# ==============================================================================
+
+
+def test_post_default_priority_is_zero(post: Post, get: Get, test_execution: TestExecution):
+    post({"test_execution_ids": [test_execution.id]})
+    reruns = get().json()
+    assert len(reruns) == 1
+    assert reruns[0]["priority"] == 0
+
+
+def test_post_custom_priority_is_returned(post: Post, get: Get, test_execution: TestExecution):
+    post({"test_execution_ids": [test_execution.id], "priority": 5})
+    reruns = get().json()
+    assert len(reruns) == 1
+    assert reruns[0]["priority"] == 5
+
+
+def test_post_negative_priority_is_returned(post: Post, get: Get, test_execution: TestExecution):
+    post({"test_execution_ids": [test_execution.id], "priority": -3})
+    reruns = get().json()
+    assert len(reruns) == 1
+    assert reruns[0]["priority"] == -3
+
+
+def test_get_sorted_by_priority_descending(post: Post, get: Get, generator: DataGenerator):
+    a = generator.gen_artefact(StageName.beta)
+    ab = generator.gen_artefact_build(a)
+    e1 = generator.gen_environment("e1")
+    e2 = generator.gen_environment("e2")
+    e3 = generator.gen_environment("e3")
+    te1 = generator.gen_test_execution(ab, e1)
+    te2 = generator.gen_test_execution(ab, e2)
+    te3 = generator.gen_test_execution(ab, e3)
+
+    post({"test_execution_ids": [te1.id], "priority": 0})
+    post({"test_execution_ids": [te2.id], "priority": 10})
+    post({"test_execution_ids": [te3.id], "priority": -1})
+
+    reruns = get().json()
+    priorities = [r["priority"] for r in reruns]
+    assert priorities == [10, 0, -1]
+
+
+def test_get_fifo_within_same_priority(get: Get, generator: DataGenerator):
+    """Within same priority, older reruns should come first."""
+    a = generator.gen_artefact(StageName.beta)
+    ab = generator.gen_artefact_build(a)
+    e1 = generator.gen_environment("env-fifo-1")
+    e2 = generator.gen_environment("env-fifo-2")
+    te1 = generator.gen_test_execution(ab, e1)
+    te2 = generator.gen_test_execution(ab, e2)
+
+    rr1 = generator.gen_rerun_request(te1, priority=1)
+    rr2 = generator.gen_rerun_request(te2, priority=1)
+
+    reruns = get().json()
+    te_ids = [r["test_execution_id"] for r in reruns]
+    # te1's rerun was created first, so it should appear first
+    assert te_ids.index(te1.id) < te_ids.index(te2.id)
+    assert rr1.priority == rr2.priority == 1
+
+
+def test_post_without_priority_does_not_change_existing_priority(post: Post, get: Get, test_execution: TestExecution):
+    """Posting without a priority should not overwrite an existing rerun's priority."""
+    post({"test_execution_ids": [test_execution.id], "priority": 7})
+    post({"test_execution_ids": [test_execution.id]})  # no priority supplied
+
+    reruns = get().json()
+    assert len(reruns) == 1
+    assert reruns[0]["priority"] == 7
+
+
+def test_bulk_post_without_priority_does_not_change_existing_priority(
+    test_client: TestClient, get: Get, generator: DataGenerator
+):
+    """Bulk silent post without priority should not overwrite an existing rerun's priority."""
+    a = generator.gen_artefact(StageName.beta)
+    ab = generator.gen_artefact_build(a)
+    e = generator.gen_environment("bulk-no-priority-env")
+    te = generator.gen_test_execution(ab, e)
+
+    make_authenticated_request(
+        lambda: test_client.post(
+            reruns_url,
+            params={"silent": True},
+            json={"test_execution_ids": [te.id], "priority": 3},
+        ),
+        Permission.change_rerun,
+    )
+    make_authenticated_request(
+        lambda: test_client.post(reruns_url, params={"silent": True}, json={"test_execution_ids": [te.id]}),
+        Permission.change_rerun,
+    )
+
+    reruns = get().json()
+    assert len(reruns) == 1
+    assert reruns[0]["priority"] == 3
+
+
+def test_post_updates_priority_if_rerun_already_exists(post: Post, get: Get, test_execution: TestExecution):
+    """Re-posting a rerun with a different priority should update the priority."""
+    post({"test_execution_ids": [test_execution.id], "priority": 1})
+    post({"test_execution_ids": [test_execution.id], "priority": 5})
+
+    reruns = get().json()
+    assert len(reruns) == 1
+    assert reruns[0]["priority"] == 5
+
+
+def test_bulk_post_updates_priority_if_rerun_already_exists(
+    test_client: TestClient, get: Get, generator: DataGenerator
+):
+    """Bulk silent post with a different priority should update existing reruns."""
+    a = generator.gen_artefact(StageName.beta)
+    ab = generator.gen_artefact_build(a)
+    e = generator.gen_environment("bulk-update-env")
+    te = generator.gen_test_execution(ab, e)
+
+    make_authenticated_request(
+        lambda: test_client.post(
+            reruns_url,
+            params={"silent": True},
+            json={"test_execution_ids": [te.id], "priority": 2},
+        ),
+        Permission.change_rerun,
+    )
+    make_authenticated_request(
+        lambda: test_client.post(
+            reruns_url,
+            params={"silent": True},
+            json={"test_execution_ids": [te.id], "priority": 9},
+        ),
+        Permission.change_rerun,
+    )
+
+    reruns = get().json()
+    assert len(reruns) == 1
+    assert reruns[0]["priority"] == 9

--- a/backend/tests/data_generator.py
+++ b/backend/tests/data_generator.py
@@ -342,11 +342,12 @@ class DataGenerator:
         self._add_object(test_result)
         return test_result
 
-    def gen_rerun_request(self, test_execution: TestExecution) -> TestExecutionRerunRequest:
+    def gen_rerun_request(self, test_execution: TestExecution, priority: int = 0) -> TestExecutionRerunRequest:
         rerun = TestExecutionRerunRequest(
             test_plan_id=test_execution.test_plan_id,
             artefact_build_id=test_execution.artefact_build_id,
             environment_id=test_execution.environment_id,
+            priority=priority,
         )
         self._add_object(rerun)
         return rerun


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

Adds a priority column to reruns. This is used in the ordering of how reruns are returns.

Also adds the ability to set this to the idempotent rerun creation api, for setting the priority.

Default priority is `0`, with higher priorities being, well, higher priority (returned first).

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

No way to prioritize reruns.

https://warthogs.atlassian.net/browse/TO-200

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

OpenAPI schema reflects the changes.

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

OpenAPI schema reflects the changes (backwards compatible).

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Unit tests added for priority cases. Existing Rerun API unit tests pass as well.