### PR TITLE
Add created timestamp to rerun response

### DIFF
--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -7380,6 +7380,11 @@
           "priority": {
             "type": "integer",
             "title": "Priority"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
           }
         },
         "type": "object",
@@ -7390,7 +7395,8 @@
           "test_execution",
           "artefact",
           "artefact_build",
-          "priority"
+          "priority",
+          "created_at"
         ],
         "title": "PendingRerun"
       },

--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -358,6 +358,7 @@ class PendingRerun(BaseModel):
     artefact: ArtefactResponse = Field(validation_alias=AliasPath("artefact_build", "artefact"))
     artefact_build: ArtefactBuildMinimalResponse = Field(validation_alias=AliasPath("artefact_build"))
     priority: int
+    created_at: datetime
 
 
 class DeleteReruns(BaseModel):

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -187,7 +187,7 @@ def test_execution_to_pending_rerun(test_execution: TestExecution, priority: int
 def without_server_fields(reruns: list[dict] | dict) -> list[dict] | dict:
     """Strip server-generated fields (e.g. created_at) before comparing to an expected dict."""
     if isinstance(reruns, list):
-        return [without_server_fields(r) for r in reruns]
+        return [{k: v for k, v in r.items() if k != "created_at"} for r in reruns]
     return {k: v for k, v in reruns.items() if k != "created_at"}
 
 

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -14,6 +14,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 from collections.abc import Callable
+from datetime import datetime
 from operator import itemgetter
 from typing import Any
 
@@ -183,6 +184,13 @@ def test_execution_to_pending_rerun(test_execution: TestExecution, priority: int
     return jsonable_encoder(return_data)
 
 
+def without_server_fields(reruns: list[dict] | dict) -> list[dict] | dict:
+    """Strip server-generated fields (e.g. created_at) before comparing to an expected dict."""
+    if isinstance(reruns, list):
+        return [without_server_fields(r) for r in reruns]
+    return {k: v for k, v in reruns.items() if k != "created_at"}
+
+
 # ==============================================================================
 # Basic POST Operations - Single ID
 # ==============================================================================
@@ -203,7 +211,7 @@ def test_valid_post(post: Post, test_execution: TestExecution):
     response = post({"test_execution_ids": [test_execution.id]})
 
     assert response.status_code == 200
-    assert response.json() == [test_execution_to_pending_rerun(test_execution)]
+    assert without_server_fields(response.json()) == [test_execution_to_pending_rerun(test_execution)]
 
 
 def test_post_with_valid_and_invalid_ids(post: Post, test_execution: TestExecution):
@@ -228,7 +236,15 @@ def test_get_after_one_post(get: Get, post: Post, test_execution: TestExecution)
 
     post({"test_execution_ids": [test_execution.id]})
 
-    assert get().json() == [test_execution_to_pending_rerun(test_execution)]
+    assert without_server_fields(get().json()) == [test_execution_to_pending_rerun(test_execution)]
+
+
+def test_get_returns_created_at(get: Get, post: Post, test_execution: TestExecution):
+    post({"test_execution_ids": [test_execution.id]})
+
+    rerun = get().json()[0]
+    assert "created_at" in rerun
+    datetime.fromisoformat(rerun["created_at"])
 
 
 def test_get_after_two_identical_posts(get: Get, post: Post, test_execution: TestExecution):
@@ -237,7 +253,7 @@ def test_get_after_two_identical_posts(get: Get, post: Post, test_execution: Tes
     post({"test_execution_ids": [test_execution.id]})
     post({"test_execution_ids": [test_execution.id]})
 
-    assert get().json() == [test_execution_to_pending_rerun(test_execution)]
+    assert without_server_fields(get().json()) == [test_execution_to_pending_rerun(test_execution)]
 
 
 def test_get_after_two_different_posts(get: Get, post: Post, test_execution: TestExecution, generator: DataGenerator):
@@ -250,7 +266,7 @@ def test_get_after_two_different_posts(get: Get, post: Post, test_execution: Tes
     post({"test_execution_ids": [te1.id]})
     post({"test_execution_ids": [te2.id]})
 
-    assert get().json() == [
+    assert without_server_fields(get().json()) == [
         test_execution_to_pending_rerun(te1),
         test_execution_to_pending_rerun(te2),
     ]
@@ -266,7 +282,7 @@ def test_get_after_post_with_two_test_execution_ids(get: Get, post: Post, genera
 
     post({"test_execution_ids": [te1.id, te2.id]})
 
-    assert sorted(get().json(), key=itemgetter("test_execution_id")) == [
+    assert sorted(without_server_fields(get().json()), key=itemgetter("test_execution_id")) == [
         test_execution_to_pending_rerun(te1),
         test_execution_to_pending_rerun(te2),
     ]
@@ -279,7 +295,7 @@ def test_get_with_limit(get: Get, post: Post, test_execution: TestExecution, gen
     post({"test_execution_ids": [te1.id]})
     post({"test_execution_ids": [te2.id]})
 
-    assert get(limit=1).json() == [test_execution_to_pending_rerun(te1)]
+    assert without_server_fields(get(limit=1).json()) == [test_execution_to_pending_rerun(te1)]
 
 
 # ==============================================================================
@@ -407,8 +423,8 @@ def test_get_with_family(get: Get, post: Post, test_execution: TestExecution, ge
     post({"test_execution_ids": [te1.id]})
     post({"test_execution_ids": [te2.id]})
 
-    assert get(family=FamilyName.snap).json() == [test_execution_to_pending_rerun(te1)]
-    assert get(family=FamilyName.charm).json() == [test_execution_to_pending_rerun(te2)]
+    assert without_server_fields(get(family=FamilyName.snap).json()) == [test_execution_to_pending_rerun(te1)]
+    assert without_server_fields(get(family=FamilyName.charm).json()) == [test_execution_to_pending_rerun(te2)]
     assert get(family=FamilyName.image).json() == []
 
 
@@ -457,8 +473,8 @@ def test_get_with_environment_filter(get: Get, post: Post, test_execution: TestE
     post({"test_execution_ids": [te1.id]})
     post({"test_execution_ids": [te2.id]})
 
-    assert get(environment="rpi2").json() == [test_execution_to_pending_rerun(te1)]
-    assert get(environment="dawson-i").json() == [test_execution_to_pending_rerun(te2)]
+    assert without_server_fields(get(environment="rpi2").json()) == [test_execution_to_pending_rerun(te1)]
+    assert without_server_fields(get(environment="dawson-i").json()) == [test_execution_to_pending_rerun(te2)]
     assert get(environment="nonexistent").json() == []
 
 
@@ -475,9 +491,9 @@ def test_get_with_build_architecture_filter(get: Get, post: Post, generator: Dat
 
     post({"test_execution_ids": [te1.id, te2.id, te3.id]})
 
-    assert get(build_architecture="arm64").json() == [test_execution_to_pending_rerun(te1)]
-    assert get(build_architecture="amd64").json() == [test_execution_to_pending_rerun(te2)]
-    assert get(build_architecture="armhf").json() == [test_execution_to_pending_rerun(te3)]
+    assert without_server_fields(get(build_architecture="arm64").json()) == [test_execution_to_pending_rerun(te1)]
+    assert without_server_fields(get(build_architecture="amd64").json()) == [test_execution_to_pending_rerun(te2)]
+    assert without_server_fields(get(build_architecture="armhf").json()) == [test_execution_to_pending_rerun(te3)]
     assert get(build_architecture="riscv64").json() == []
 
 
@@ -495,9 +511,9 @@ def test_get_with_environment_architecture_filter(get: Get, post: Post, generato
 
     post({"test_execution_ids": [te1.id, te2.id, te3.id]})
 
-    assert get(environment_architecture="arm64").json() == [test_execution_to_pending_rerun(te1)]
-    assert get(environment_architecture="amd64").json() == [test_execution_to_pending_rerun(te2)]
-    assert get(environment_architecture="armhf").json() == [test_execution_to_pending_rerun(te3)]
+    assert without_server_fields(get(environment_architecture="arm64").json()) == [test_execution_to_pending_rerun(te1)]
+    assert without_server_fields(get(environment_architecture="amd64").json()) == [test_execution_to_pending_rerun(te2)]
+    assert without_server_fields(get(environment_architecture="armhf").json()) == [test_execution_to_pending_rerun(te3)]
 
 
 def test_get_with_combined_filters(get: Get, post: Post, generator: DataGenerator):
@@ -527,15 +543,19 @@ def test_get_with_combined_filters(get: Get, post: Post, generator: DataGenerato
     assert result[1]["test_execution_id"] in [te1.id, te3.id]
 
     # Test combining family + environment
-    assert get(family=FamilyName.snap, environment="rpi4").json() == [test_execution_to_pending_rerun(te1)]
+    assert without_server_fields(get(family=FamilyName.snap, environment="rpi4").json()) == [
+        test_execution_to_pending_rerun(te1)
+    ]
 
     # Test combining all filters
-    assert get(
-        family=FamilyName.snap,
-        build_architecture="arm64",
-        environment="rpi4",
-        environment_architecture="arm64",
-    ).json() == [test_execution_to_pending_rerun(te1)]
+    assert without_server_fields(
+        get(
+            family=FamilyName.snap,
+            build_architecture="arm64",
+            environment="rpi4",
+            environment_architecture="arm64",
+        ).json()
+    ) == [test_execution_to_pending_rerun(te1)]
 
     # Test filter combination with no matches
     assert (
@@ -567,7 +587,7 @@ def test_get_multiple_reruns_same_build_different_environments(get: Get, post: P
     assert len(result) == 3
 
     # Only specific environment
-    assert get(environment="rpi4").json() == [test_execution_to_pending_rerun(te1)]
+    assert without_server_fields(get(environment="rpi4").json()) == [test_execution_to_pending_rerun(te1)]
 
     # All should be returned with environment_architecture filter
     result = get(environment_architecture="arm64").json()


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

Currently for the test scheduler we use the test execution created timestamp, which may be different from the rerun creation timestamp. This may be wrong.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

Test execution created timestamp != rerun created timestamp.

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

N/A

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

Schema up to date.

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->
Unit test added.