### PR TITLE
[Add] Delete user and application endpoints

### DIFF
--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -3944,6 +3944,42 @@
           "view_user"
         ]
       },
+      "delete": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Delete User",
+        "operationId": "delete_user_v1_users__user_id__delete",
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-permissions": [
+          "change_user"
+        ]
+      },
       "patch": {
         "tags": [
           "users"
@@ -4438,6 +4474,42 @@
         },
         "x-permissions": [
           "view_application"
+        ]
+      },
+      "delete": {
+        "tags": [
+          "applications"
+        ],
+        "summary": "Delete Application",
+        "operationId": "delete_application_v1_applications__application_id__delete",
+        "parameters": [
+          {
+            "name": "application_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Application Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-permissions": [
+          "change_application"
         ]
       },
       "patch": {

--- a/backend/test_observer/controllers/applications/applications.py
+++ b/backend/test_observer/controllers/applications/applications.py
@@ -84,6 +84,22 @@ def get_application(
     return application
 
 
+@router.delete(
+    "/{application_id}",
+    status_code=204,
+    dependencies=[Security(permission_checker, scopes=[Permission.change_application])],
+)
+def delete_application(
+    application_id: int,
+    db: Session = Depends(get_db),
+):
+    application = db.get(Application, application_id)
+    if application is None:
+        return
+    db.delete(application)
+    db.commit()
+
+
 @router.patch(
     "/{application_id}",
     response_model=ApplicationResponse,

--- a/backend/test_observer/controllers/users/users.py
+++ b/backend/test_observer/controllers/users/users.py
@@ -126,6 +126,22 @@ def get_user(
     return user
 
 
+@router.delete(
+    "/{user_id}",
+    status_code=204,
+    dependencies=[Security(permission_checker, scopes=[Permission.change_user])],
+)
+def delete_user(
+    user_id: int,
+    db: Session = Depends(get_db),
+):
+    user = db.get(User, user_id)
+    if user is None:
+        return
+    db.delete(user)
+    db.commit()
+
+
 @router.patch(
     "/{user_id}",
     response_model=UserResponse,

--- a/backend/tests/controllers/applications/test_applications.py
+++ b/backend/tests/controllers/applications/test_applications.py
@@ -255,3 +255,25 @@ def test_update_invalid_permissions_api(test_client: TestClient, generator: Data
 def test_create_invalid_permissions_orm(generator: DataGenerator):
     with pytest.raises(DBAPIError):
         generator.gen_application(permissions=["invalid_permission"])
+
+
+def test_delete_application(test_client: TestClient, generator: DataGenerator, db_session: Session):
+    application = generator.gen_application()
+    application_id = application.id
+
+    response = make_authenticated_request(
+        lambda: test_client.delete(f"/v1/applications/{application_id}"),
+        Permission.change_application,
+    )
+
+    assert response.status_code == 204
+    assert db_session.get(Application, application_id) is None
+
+
+def test_delete_application_idempotent(test_client: TestClient):
+    response = make_authenticated_request(
+        lambda: test_client.delete("/v1/applications/999999"),
+        Permission.change_application,
+    )
+
+    assert response.status_code == 204

--- a/backend/tests/controllers/users/test_users.py
+++ b/backend/tests/controllers/users/test_users.py
@@ -531,3 +531,25 @@ def test_get_issues_pagination_metadata(test_client: TestClient, generator: Data
     assert data["limit"] == 2
     assert data["offset"] == 1
     assert len(data["issues"]) == 2
+
+
+def test_delete_user(test_client: TestClient, generator: DataGenerator, db_session: Session):
+    user = generator.gen_user()
+    user_id = user.id
+
+    response = make_authenticated_request(
+        lambda: test_client.delete(f"/v1/users/{user_id}"),
+        Permission.change_user,
+    )
+
+    assert response.status_code == 204
+    assert db_session.get(type(user), user_id) is None
+
+
+def test_delete_user_idempotent(test_client: TestClient):
+    response = make_authenticated_request(
+        lambda: test_client.delete("/v1/users/999999"),
+        Permission.change_user,
+    )
+
+    assert response.status_code == 204


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

Adds API to delete users and application.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

Gives us the ability to actually revoke application tokens.

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

N/A

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

2 new endpoints in the openapi.

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Unit tests added for the endpoints.