### PR TITLE
Change charm resources to 'latest' tag

### DIFF
--- a/backend/charm/charmcraft.yaml
+++ b/backend/charm/charmcraft.yaml
@@ -119,7 +119,7 @@ resources:
   api-image:
     type: oci-image
     description: OCI image from GitHub Container Repository
-    upstream-source: ghcr.io/canonical/test_observer/api:main
+    upstream-source: ghcr.io/canonical/test_observer/api:latest
 
 containers:
   api:

--- a/frontend/charm/charmcraft.yaml
+++ b/frontend/charm/charmcraft.yaml
@@ -91,7 +91,7 @@ resources:
   frontend-image:
     type: oci-image
     description: OCI image for test-observer-frontend
-    upstream-source: ghcr.io/canonical/test_observer/frontend:main
+    upstream-source: ghcr.io/canonical/test_observer/frontend:latest
 
 containers:
   frontend:


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

It seems like Juju on Kubernetes tends to set an `ImagePullPolicy` of `IfNotPresent` rather than `Always` (at least with Juju 3.6 and K8s 1.32), unless the image tag is `latest`. I think changing the charms to use the `latest` tag will enable easy deployment updates with `juju refresh` alone.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

In a previous deployment, `juju refresh` was sufficient to pull image updates. A newer deployment doesn't currently have that behavior, but this PR may resolve it.
