### PR TITLE
TO-394: fix too many reviewers assigned to artefact

### DIFF
--- a/backend/test_observer/controllers/test_executions/start_test.py
+++ b/backend/test_observer/controllers/test_executions/start_test.py
@@ -183,7 +183,7 @@ class StartTestExecutionController:
             )
 
             if users:
-                environment_count = sum(len(b.test_executions) for b in self.artefact.builds)
+                environment_count = sum(len(b.test_executions) for b in self.artefact.latest_builds)
                 expected_number_of_reviewers = _ceil_division(environment_count, ENVIRONMENTS_PER_REVIEWER)
                 number_of_reviewers_to_assign = max(0, expected_number_of_reviewers - len(self.artefact.reviewers))
                 newly_assigned_reviewers = random.sample(users, min(len(users), number_of_reviewers_to_assign))

--- a/backend/tests/controllers/test_executions/test_reviewer_assignment.py
+++ b/backend/tests/controllers/test_executions/test_reviewer_assignment.py
@@ -221,7 +221,6 @@ def test_reviewer_count_uses_latest_builds_not_all_builds(
         version="v1",
         track="22",
         store="ubuntu",
-        stage=SnapStage.beta,  # type: ignore[arg-type]
     )
     envs_per_old_build = ENVIRONMENTS_PER_REVIEWER // 2 + 1
     for rev in range(1, 3):

--- a/backend/tests/controllers/test_executions/test_reviewer_assignment.py
+++ b/backend/tests/controllers/test_executions/test_reviewer_assignment.py
@@ -25,6 +25,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from test_observer.common.enums import Permission
+from test_observer.controllers.test_executions.start_test import ENVIRONMENTS_PER_REVIEWER
 from test_observer.data_access.models import TestExecution
 from test_observer.data_access.models_enums import (
     CharmStage,
@@ -193,3 +194,62 @@ class TestReviewerAssignmentWithMatchingRules:
         else:
             assert assignee is not None
             assert assignee.name in expected_user_names
+
+
+def test_reviewer_count_uses_latest_builds_not_all_builds(
+    start_test: Callable[[dict], dict],
+    db_session: Session,
+    generator: DataGenerator,
+):
+    """Regression test: reviewer count should be based on latest_builds, not all builds.
+
+    If an artefact has many historical builds with many test executions, the total
+    across all builds can exceed ENVIRONMENTS_PER_REVIEWER even when the current
+    (latest) builds have far fewer environments. Only the latest build per architecture
+    should be counted when deciding how many reviewers to assign.
+    """
+    # GIVEN a team with multiple users and a matching rule
+    team = generator.gen_team(name="snap-team")
+    for i in range(3):
+        generator.gen_user(name=f"User{i}", email=f"user{i}@test.com", teams=[team])
+    generator.gen_artefact_matching_rule(family=FamilyName.snap, teams=[team])
+
+    # AND an artefact with old builds whose total test executions exceed ENVIRONMENTS_PER_REVIEWER
+    artefact = generator.gen_artefact(
+        family=FamilyName.snap,
+        name="core22",
+        version="v1",
+        track="22",
+        store="ubuntu",
+        stage=SnapStage.beta,  # type: ignore[arg-type]
+    )
+    envs_per_old_build = ENVIRONMENTS_PER_REVIEWER // 2 + 1
+    for rev in range(1, 3):
+        old_build = generator.gen_artefact_build(artefact, architecture="amd64", revision=rev)
+        for i in range(envs_per_old_build):
+            env = generator.gen_environment(name=f"env-rev{rev}-{i}", architecture="amd64")
+            generator.gen_test_execution(old_build, env, ci_link=f"http://ci/{rev}/{i}")
+
+    # WHEN a new test starts with a higher revision (latest build has only 1 environment)
+    result = start_test(
+        {
+            "family": "snap",
+            "name": "core22",
+            "version": "v1",
+            "arch": "amd64",
+            "store": "ubuntu",
+            "track": "22",
+            "revision": 3,
+            "execution_stage": SnapStage.beta,
+            "environment": "env-new",
+            "ci_link": "http://ci/new",
+            "test_plan": "test",
+            "needs_assignment": True,
+        }
+    )
+
+    # THEN exactly 1 reviewer is assigned (not ceil(total_old_executions / ENVIRONMENTS_PER_REVIEWER))
+    test_execution = db_session.get(TestExecution, result["id"])
+    assert test_execution is not None
+    artefact_db = test_execution.artefact_build.artefact
+    assert len(artefact_db.reviewers) == 1


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

A bug was found which caused environments to have too many reviewers assigned. This was because we were using `artefact.builds` instead of `artefact.latest_builds` to compute how many reviewers to assign. `artefact.builds` contains every build associated with the artefact, while `latest_builds` contains only the latest revision for each build.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

Resolves TO-394.

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

No changes to documentation

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

No changes to the API

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Added a regression test for this case