### PR TITLE
[TO-391] Enable filtering environments by reviewer

### DIFF
--- a/backend/scripts/seed_data.py
+++ b/backend/scripts/seed_data.py
@@ -885,7 +885,6 @@ def seed_data(client: TestClient | requests.Session, session: Session | None = N
 
     _add_issue_attachments(client, session, issues, auth_headers)
 
-    # Assign some environment reviewers
     _assign_environment_reviewers(session)
 
     print("Database seeding completed successfully!")

--- a/backend/scripts/seed_data.py
+++ b/backend/scripts/seed_data.py
@@ -45,7 +45,15 @@ from test_observer.controllers.issues.models import (
 )
 from test_observer.controllers.artefacts.models import TestExecutionRelevantLinkCreate
 
-from test_observer.data_access.models import Artefact, User, TestResult, Application
+from test_observer.data_access.models import (
+    Application,
+    Artefact,
+    ArtefactBuild,
+    ArtefactBuildEnvironmentReview,
+    Environment,
+    TestResult,
+    User,
+)
 from test_observer.data_access.models_enums import (
     FamilyName,
     SnapStage,
@@ -197,7 +205,7 @@ START_TEST_EXECUTION_REQUESTS = [
         store="ubuntu",
         arch="armhf",
         execution_stage=SnapStage.beta,
-        environment="rp3bplus",
+        environment="rpi3bplus",
         ci_link="http://example12",
         test_plan="com.canonical.certification::client-cert-iot-ubuntucore-22-automated",
     ),
@@ -791,6 +799,7 @@ def seed_data(client: TestClient | requests.Session, session: Session | None = N
     print("Seeding database with test data...")
 
     add_user("john.doe@canonical.com", session, launchpad_api=FakeLaunchpadAPI())
+    add_user("jane.smith@canonical.com", session, launchpad_api=FakeLaunchpadAPI())
 
     certbot = add_user("certbot@canonical.com", session, launchpad_api=FakeLaunchpadAPI())
     certbot.is_admin = True
@@ -876,6 +885,9 @@ def seed_data(client: TestClient | requests.Session, session: Session | None = N
 
     _add_issue_attachments(client, session, issues, auth_headers)
 
+    # Assign some environment reviewers
+    _assign_environment_reviewers(session)
+
     print("Database seeding completed successfully!")
 
 
@@ -931,6 +943,46 @@ def _add_issue_attachments(
                 json={"test_results": [test_result.id]},
                 headers=auth_headers,
             ).raise_for_status()
+    session.commit()
+
+
+def _assign_environment_reviewers(session: Session) -> None:
+    artefact = session.scalar(
+        select(Artefact).where(
+            Artefact.family == FamilyName.snap,
+            Artefact.name == "core22",
+            Artefact.version == "20230531",
+            Artefact.track == "22",
+            Artefact.store == "ubuntu",
+            Artefact.branch == "",
+        )
+    )
+    if artefact is None:
+        raise ValueError("Could not find artefact for environment review assignment")
+
+    reviewer_assignments = {
+        "john.doe@canonical.com": ["rpi2", "rpi4"],
+        "jane.smith@canonical.com": ["rpi3aplus", "rpi3bplus"],
+    }
+
+    for email, assignments in reviewer_assignments.items():
+        user = session.scalar(select(User).where(User.email == email))
+        if user is None:
+            raise ValueError(f"Could not find user with email {email} for environment review assignment")
+
+        environment_reviews = session.scalars(
+            select(ArtefactBuildEnvironmentReview)
+            .join(ArtefactBuildEnvironmentReview.artefact_build)
+            .join(ArtefactBuildEnvironmentReview.environment)
+            .where(ArtefactBuild.artefact_id == artefact.id, Environment.name.in_(assignments))
+        ).all()
+
+        if user not in artefact.reviewers:
+            artefact.reviewers.append(user)
+
+        for review in environment_reviews:
+            review.reviewers = [user]
+
     session.commit()
 
 

--- a/backend/tests/fake_launchpad_api.py
+++ b/backend/tests/fake_launchpad_api.py
@@ -30,6 +30,13 @@ class FakeLaunchpadAPI(LaunchpadAPI):
                 name="John Doe",
                 teams=["canonical", "hw-cert"],
             )
+        if email == "jane.smith@canonical.com":
+            return LaunchpadUser(
+                handle="jane-smith",
+                email=email,
+                name="Jane Smith",
+                teams=["canonical"],
+            )
         if email == "certbot@canonical.com":
             return LaunchpadUser(
                 handle="certbot",

--- a/frontend/lib/filtering/enriched_test_execution_filters.dart
+++ b/frontend/lib/filtering/enriched_test_execution_filters.dart
@@ -72,6 +72,40 @@ final environmentNameFilter = createFilterFromExtractor<EnrichedTestExecution>(
   (ee) => ee.environmentReview.environment.name,
 );
 
+const noEnvironmentReviewerAssignedOption = 'Unassigned';
+
+String _reviewerFilterOptionLabel(String name, String email) =>
+    '$name ($email)';
+
+Set<String> _reviewerFilterOptionsFor(EnrichedTestExecution ee) {
+  if (ee.environmentReview.reviewers.isEmpty) {
+    return {noEnvironmentReviewerAssignedOption};
+  }
+
+  return ee.environmentReview.reviewers
+      .map(
+        (reviewer) => _reviewerFilterOptionLabel(reviewer.name, reviewer.email),
+      )
+      .toSet();
+}
+
+final environmentReviewerFilter = Filter<EnrichedTestExecution>(
+  name: 'Environment reviewer',
+  extractOptions: (items) {
+    final options = <String>{};
+    for (final item in items) {
+      options.addAll(_reviewerFilterOptionsFor(item));
+    }
+    return options;
+  },
+  filter: (items, options) => items
+      .where(
+        (item) => _reviewerFilterOptionsFor(item)
+            .any((reviewerOption) => options.contains(reviewerOption)),
+      )
+      .toList(),
+);
+
 final testExecutionStatusFilter =
     createFilterFromExtractor<EnrichedTestExecution>(
   'Test Execution Status',
@@ -89,6 +123,7 @@ final enrichedTestExecutionFilters = [
   testPlanLastStatusFilter,
   testPlanNameFilter,
   environmentNameFilter,
+  environmentReviewerFilter,
   testExecutionStatusFilter,
   testExecutionTriagedFilter,
 ];

--- a/frontend/lib/ui/page_filters/artefact_filters_view.dart
+++ b/frontend/lib/ui/page_filters/artefact_filters_view.dart
@@ -33,6 +33,11 @@ class ArtefactFiltersView extends ConsumerWidget {
       GlobalKey<MultiSelectComboboxState>();
 
   static const spacingBetweenFilters = Spacing.level4;
+  static const comboboxFilterNames = {
+    'Environment',
+    'Test plan',
+    'Environment reviewer',
+  };
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -47,13 +52,11 @@ class ArtefactFiltersView extends ConsumerWidget {
     }
 
     final widgets = <Widget>[];
-
-    // Process filters: Environment and Test plan as comboboxes, others as checkboxes
     final comboboxFilters = <FilterState>[];
     final regularFilters = <FilterState>[];
 
     for (final filter in filters) {
-      if (filter.name == 'Environment' || filter.name == 'Test plan') {
+      if (comboboxFilterNames.contains(filter.name)) {
         comboboxFilters.add(filter);
       } else {
         regularFilters.add(filter);

--- a/frontend/lib/ui/page_filters/artefact_filters_view.dart
+++ b/frontend/lib/ui/page_filters/artefact_filters_view.dart
@@ -81,10 +81,18 @@ class ArtefactFiltersView extends ConsumerWidget {
           .map((option) => option.name)
           .toSet();
 
+      // 'Environment reviewer' is long enough that the combobox text, which adds '(N selected)' after the title,
+      // where N is the number of selected elements,splits onto a new line after the number
+      // given the fixed max width of the sidebar.
+      // Add a newline for aesthetics in the case of 'Environment reviewer' to avoid the split.
+      final comboboxTitle = filter.name == 'Environment reviewer'
+          ? 'Environment reviewer\n'
+          : filter.name;
+
       widgets.add(
         MultiSelectCombobox<String>(
           key: key,
-          title: filter.name,
+          title: comboboxTitle,
           allOptions: options,
           itemToString: (option) => option,
           initialSelected: initialSelected,

--- a/frontend/lib/ui/page_filters/artefact_filters_view.dart
+++ b/frontend/lib/ui/page_filters/artefact_filters_view.dart
@@ -81,23 +81,20 @@ class ArtefactFiltersView extends ConsumerWidget {
           .map((option) => option.name)
           .toSet();
 
-      // The combobox implementation in lib/ui/page_filters/multi_select_combobox.dart
-      // automatically appends '(N selected)' to the title of the combobox, where N is the number of selected elements.
-      //'Environment reviewer' is long enough that the text splits onto a new line
-      // after the number N, given the fixed max width of the sidebar.
-      // Add a newline for aesthetics in the case of 'Environment reviewer' to avoid the split.
-      final comboboxTitle = filter.name == 'Environment reviewer'
-          ? 'Environment reviewer\n'
-          : filter.name;
+      // Use newline separator for 'Environment reviewer' to improve layout
+      // when the title is long and would otherwise wrap awkwardly
+      final titleSuffixSeparator =
+          filter.name == 'Environment reviewer' ? '\n' : ' ';
 
       widgets.add(
         MultiSelectCombobox<String>(
           key: key,
-          title: comboboxTitle,
+          title: filter.name,
           allOptions: options,
           itemToString: (option) => option,
           initialSelected: initialSelected,
           maxSuggestions: 10,
+          titleSuffixSeparator: titleSuffixSeparator,
           onChanged: (option, isSelected) {
             // Update the filter state
             ref

--- a/frontend/lib/ui/page_filters/artefact_filters_view.dart
+++ b/frontend/lib/ui/page_filters/artefact_filters_view.dart
@@ -81,9 +81,10 @@ class ArtefactFiltersView extends ConsumerWidget {
           .map((option) => option.name)
           .toSet();
 
-      // 'Environment reviewer' is long enough that the combobox text, which adds '(N selected)' after the title,
-      // where N is the number of selected elements,splits onto a new line after the number
-      // given the fixed max width of the sidebar.
+      // The combobox implementation in lib/ui/page_filters/multi_select_combobox.dart
+      // automatically appends '(N selected)' to the title of the combobox, where N is the number of selected elements.
+      //'Environment reviewer' is long enough that the text splits onto a new line
+      // after the number N, given the fixed max width of the sidebar.
       // Add a newline for aesthetics in the case of 'Environment reviewer' to avoid the split.
       final comboboxTitle = filter.name == 'Environment reviewer'
           ? 'Environment reviewer\n'

--- a/frontend/lib/ui/page_filters/date_time_selector.dart
+++ b/frontend/lib/ui/page_filters/date_time_selector.dart
@@ -263,6 +263,7 @@ class _ExpandableHeader extends StatelessWidget {
             Expanded(
               child: Text(
                 display,
+                textAlign: TextAlign.center,
                 style: const TextStyle(fontSize: 16),
               ),
             ),

--- a/frontend/lib/ui/page_filters/multi_select_combobox.dart
+++ b/frontend/lib/ui/page_filters/multi_select_combobox.dart
@@ -423,6 +423,7 @@ class _ComboboxHeader extends StatelessWidget {
             Expanded(
               child: Text(
                 title,
+                textAlign: TextAlign.center,
                 style: const TextStyle(fontSize: 16),
               ),
             ),

--- a/frontend/lib/ui/page_filters/multi_select_combobox.dart
+++ b/frontend/lib/ui/page_filters/multi_select_combobox.dart
@@ -63,6 +63,10 @@ class MultiSelectCombobox<T> extends StatefulWidget {
   // Make selections mutually exclusive (only one item can be selected at a time)
   final bool isMutuallyExclusive;
 
+  // Separator between title and the selection count/meta option label
+  // Defaults to a space, but can be customized (e.g., to a newline)
+  final String titleSuffixSeparator;
+
   const MultiSelectCombobox({
     super.key,
     required this.title,
@@ -80,6 +84,7 @@ class MultiSelectCombobox<T> extends StatefulWidget {
     this.onMetaOptionChanged,
     this.showAllOptionsWithoutSearch = false,
     this.isMutuallyExclusive = false,
+    this.titleSuffixSeparator = ' ',
   })  : assert(
           asyncSuggestionsCallback != null ||
               (allOptions != null && itemToString != null),
@@ -229,9 +234,11 @@ class MultiSelectComboboxState<T> extends State<MultiSelectCombobox<T>> {
       // Find the label for the selected meta option
       final selectedMeta = widget.metaOptions!
           .firstWhere((opt) => opt.value == widget.selectedMetaOption);
-      displayText = '${widget.title} (${selectedMeta.label})';
+      displayText =
+          '${widget.title}${widget.titleSuffixSeparator}(${selectedMeta.label})';
     } else {
-      displayText = '${widget.title} (${_selected.length} selected)';
+      displayText =
+          '${widget.title}${widget.titleSuffixSeparator}(${_selected.length} selected)';
     }
 
     return Column(

--- a/frontend/test/dummy_data.dart
+++ b/frontend/test/dummy_data.dart
@@ -23,9 +23,9 @@ import 'package:testcase_dashboard/models/user.dart';
 
 const dummyUser = User(
   id: 1,
-  name: 'Omar Abou Selo',
-  email: 'omar.selo@canonical.com',
-  launchpadHandle: 'omar-selo',
+  name: 'Dummy User',
+  email: 'dummy.user@canonical.com',
+  launchpadHandle: 'dummy-user',
 );
 
 const dummyUser2 = User(
@@ -66,6 +66,12 @@ const dummyEnvironment = Environment(
   architecture: 'amd64',
 );
 
+const dummyEnvironment2 = Environment(
+  id: 2,
+  name: 'desktop',
+  architecture: 'amd64',
+);
+
 const dummyArtefactBuild = ArtefactBuild(
   id: 1,
   architecture: 'amd64',
@@ -85,6 +91,18 @@ final dummyTestExecution = TestExecution(
   isTriaged: false,
 );
 
+final dummyTestExecution2 = TestExecution(
+  id: 2,
+  ciLink: 'ci-link-2',
+  c3Link: 'c3-link-2',
+  status: TestExecutionStatus.failed,
+  environment: dummyEnvironment2,
+  artefactBuildId: dummyArtefactBuild.id,
+  testPlan: 'test plan 2',
+  createdAt: DateTime.now(),
+  isTriaged: false,
+);
+
 final dummyEnvironmentReview = EnvironmentReview(
   id: 1,
   artefactBuild: EnvironmentReviewArtefactBuild(
@@ -95,4 +113,17 @@ final dummyEnvironmentReview = EnvironmentReview(
   environment: dummyEnvironment,
   reviewComment: '',
   reviewDecision: [],
+);
+
+final dummyEnvironmentReviewWithReviewer = EnvironmentReview(
+  id: 2,
+  artefactBuild: EnvironmentReviewArtefactBuild(
+    id: dummyArtefactBuild.id,
+    architecture: dummyArtefactBuild.architecture,
+    revision: dummyArtefactBuild.revision,
+  ),
+  environment: dummyEnvironment2,
+  reviewComment: '',
+  reviewDecision: [],
+  reviewers: [dummyUser],
 );

--- a/frontend/test/filtering/enriched_test_execution_filters_test.dart
+++ b/frontend/test/filtering/enriched_test_execution_filters_test.dart
@@ -1,0 +1,83 @@
+// Copyright 2026 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+import 'package:test/test.dart';
+import 'package:testcase_dashboard/filtering/enriched_test_execution_filters.dart';
+import 'package:testcase_dashboard/models/enriched_test_execution.dart';
+
+import '../dummy_data.dart';
+
+void main() {
+  final executionWithNoReviewer = EnrichedTestExecution(
+    testExecution: dummyTestExecution,
+    environmentReview: dummyEnvironmentReview,
+  );
+
+  final executionWithSingleReviewer = EnrichedTestExecution(
+    testExecution: dummyTestExecution2,
+    environmentReview: dummyEnvironmentReviewWithReviewer,
+  );
+
+  final executionWithMultipleReviewers = EnrichedTestExecution(
+    testExecution: dummyTestExecution2.copyWith(id: 3),
+    environmentReview: dummyEnvironmentReviewWithReviewer.copyWith(
+      id: 3,
+      reviewers: [dummyUser, dummyUser2],
+    ),
+  );
+
+  test('extractOptions includes reviewer labels and unassigned option', () {
+    final options = environmentReviewerFilter.extractOptions([
+      executionWithNoReviewer,
+      executionWithSingleReviewer,
+    ]);
+
+    expect(options, contains(noEnvironmentReviewerAssignedOption));
+    expect(options, contains('Dummy User (dummy.user@canonical.com)'));
+  });
+
+  test('filter returns executions with selected reviewer', () {
+    final filtered = environmentReviewerFilter.filter([
+      executionWithNoReviewer,
+      executionWithSingleReviewer,
+    ], {
+      'Dummy User (dummy.user@canonical.com)',
+    });
+
+    expect(filtered, [executionWithSingleReviewer]);
+  });
+
+  test('filter returns unassigned executions for unassigned option', () {
+    final filtered = environmentReviewerFilter.filter([
+      executionWithNoReviewer,
+      executionWithSingleReviewer,
+    ], {
+      noEnvironmentReviewerAssignedOption,
+    });
+
+    expect(filtered, [executionWithNoReviewer]);
+  });
+
+  test('filter matches any reviewer assigned to an environment review', () {
+    final filtered = environmentReviewerFilter.filter([
+      executionWithSingleReviewer,
+      executionWithMultipleReviewers,
+    ], {
+      'John Doe (john.doe@canonical.com)',
+    });
+
+    expect(filtered, [executionWithMultipleReviewers]);
+  });
+}

--- a/frontend/test/providers/page_filters_test.dart
+++ b/frontend/test/providers/page_filters_test.dart
@@ -71,8 +71,8 @@ void main() {
     expect(filters[0].options, [(name: 'Undecided', isSelected: false)]);
     expect(filters[4].name, 'Environment reviewer');
     expect(filters[4].options, [
-      (name: 'Unassigned', isSelected: false),
       (name: 'Dummy User (dummy.user@canonical.com)', isSelected: false),
+      (name: 'Unassigned', isSelected: false),
     ]);
   });
 }

--- a/frontend/test/providers/page_filters_test.dart
+++ b/frontend/test/providers/page_filters_test.dart
@@ -67,10 +67,11 @@ void main() {
       pageFiltersProvider(Uri(path: '${AppRoutes.snaps}/$artefactId')),
     );
 
-    expect(filters[0].name, 'Review status');
-    expect(filters[0].options, [(name: 'Undecided', isSelected: false)]);
-    expect(filters[4].name, 'Environment reviewer');
-    expect(filters[4].options, [
+    final statusFilter = filters.firstWhere((f) => f.name == 'Review status');
+    expect(statusFilter.options, [(name: 'Undecided', isSelected: false)]);
+    final reviewerFilter =
+        filters.firstWhere((f) => f.name == 'Environment reviewer');
+    expect(reviewerFilter.options, [
       (name: 'Dummy User (dummy.user@canonical.com)', isSelected: false),
       (name: 'Unassigned', isSelected: false),
     ]);

--- a/frontend/test/providers/page_filters_test.dart
+++ b/frontend/test/providers/page_filters_test.dart
@@ -69,6 +69,11 @@ void main() {
 
     expect(filters[0].name, 'Review status');
     expect(filters[0].options, [(name: 'Undecided', isSelected: false)]);
+    expect(filters[4].name, 'Environment reviewer');
+    expect(filters[4].options, [
+      (name: 'Unassigned', isSelected: false),
+      (name: 'Dummy User (dummy.user@canonical.com)', isSelected: false),
+    ]);
   });
 }
 
@@ -82,7 +87,7 @@ class ApiRepositoryMock extends Mock implements ApiRepository {
   Future<List<ArtefactBuild>> getArtefactBuilds(int artefactId) async {
     return [
       dummyArtefactBuild.copyWith(
-        testExecutions: [dummyTestExecution],
+        testExecutions: [dummyTestExecution, dummyTestExecution2],
       ),
     ];
   }
@@ -91,6 +96,6 @@ class ApiRepositoryMock extends Mock implements ApiRepository {
   Future<List<EnvironmentReview>> getArtefactEnvironmentReviews(
     int artefactId,
   ) async {
-    return [dummyEnvironmentReview];
+    return [dummyEnvironmentReview, dummyEnvironmentReviewWithReviewer];
   }
 }


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR enables users to filter environments by reviewer. This makes it much easier for a reviewer to rerun only their environments. This PR updates the `seed_data.py` script (and `FakeLaunchpadAPI()`) to add reviewers to an artefact for easy local testing. 

This PR tweaks the dropdown behavior to allow specifying the separator between the primary text and the number of selected items, which allows a newline to be provided for longer text entries instead of a space. Without that, the line gets split awkwardly (see screenshots). This PR also centers text in dropdown menus, which I find looks a bit better, especially for the Environment Review filter, which is split onto two lines.

### Initial Implementation - No Reviewers Selected

<img width="3304" height="1236" alt="Screenshot from 2026-07-07 11-04-14" src="https://github.com/user-attachments/assets/7bfe08de-86fa-44ac-870a-fd1c2b0fd5e4" />

### Initial Implementation - Reviewer Selected

<img width="3304" height="1276" alt="Screenshot from 2026-07-07 11-04-41" src="https://github.com/user-attachments/assets/be628967-0635-4612-8c13-c32a232b62b5" />

### Newline Split in Dropdown Text

<img width="3304" height="1276" alt="Screenshot from 2026-07-07 11-13-11" src="https://github.com/user-attachments/assets/f7843d80-e8d4-46c0-a316-e6d2c4fbf37f" />

### Text Centering - Artefact Environment Filters

<img width="3304" height="1276" alt="Screenshot from 2026-07-07 11-15-51" src="https://github.com/user-attachments/assets/b334b80e-9146-4b58-b36d-f7ef159335ce" />

### Text Centering - Test Result Search Page

<img width="3304" height="1276" alt="Screenshot from 2026-07-07 11-16-01" src="https://github.com/user-attachments/assets/1483ae13-d7e3-490d-8e8d-2a2d1c2c811c" />

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

[TO-391]

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Tests are added for the environment filtering

[TO-391]: https://warthogs.atlassian.net/browse/TO-391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ