### PR TITLE
[TO-397] Show review progress per reviewer

### DIFF
--- a/backend/scripts/seed_data.py
+++ b/backend/scripts/seed_data.py
@@ -55,6 +55,7 @@ from test_observer.data_access.models import (
     User,
 )
 from test_observer.data_access.models_enums import (
+    ArtefactBuildEnvironmentReviewDecision,
     FamilyName,
     SnapStage,
     DebStage,
@@ -981,6 +982,9 @@ def _assign_environment_reviewers(session: Session) -> None:
 
         for review in environment_reviews:
             review.reviewers = [user]
+            # Mark jane.smith's rpi3bplus review as approved
+            if email == "jane.smith@canonical.com" and review.environment.name == "rpi3bplus":
+                review.review_decision = [ArtefactBuildEnvironmentReviewDecision.APPROVED_ALL_TESTS_PASS]
 
     session.commit()
 

--- a/frontend/lib/ui/artefact_page/artefact_page_header.dart
+++ b/frontend/lib/ui/artefact_page/artefact_page_header.dart
@@ -14,21 +14,26 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yaru/yaru.dart';
 
 import '../../models/artefact.dart';
+import '../../providers/artefact_environment_reviews.dart';
 import '../spacing.dart';
 import '../reviewers_avatars.dart';
 import 'artefact_signoff_button.dart';
 
-class ArtefactPageHeader extends StatelessWidget {
+class ArtefactPageHeader extends ConsumerWidget {
   const ArtefactPageHeader({super.key, required this.artefact});
 
   final Artefact artefact;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final dueDate = artefact.dueDateString;
+    final environmentReviewsAsync =
+        ref.watch(artefactEnvironmentReviewsProvider(artefact.id));
+    final environmentReviews = environmentReviewsAsync.valueOrNull ?? const [];
 
     return Row(
       children: [
@@ -41,6 +46,7 @@ class ArtefactPageHeader extends StatelessWidget {
           allEnvironmentReviewsCount: artefact.allEnvironmentReviewsCount,
           completedEnvironmentReviewsCount:
               artefact.completedEnvironmentReviewsCount,
+          environmentReviews: environmentReviews,
         ),
         const SizedBox(width: Spacing.level4),
         if (dueDate != null)

--- a/frontend/lib/ui/dashboard/artefact_card.dart
+++ b/frontend/lib/ui/dashboard/artefact_card.dart
@@ -19,11 +19,11 @@ import 'package:intersperse/intersperse.dart';
 import 'package:yaru/yaru.dart';
 
 import '../../models/artefact.dart';
-import '../../providers/artefact_environment_reviews.dart';
+import '../../models/user.dart';
 import '../../routing.dart';
 import '../spacing.dart';
 import '../navigable_link.dart';
-import '../reviewers_avatars.dart';
+import '../user_avatar.dart';
 import '../vanilla/vanilla_chip.dart';
 
 class ArtefactCard extends ConsumerWidget {
@@ -36,9 +36,6 @@ class ArtefactCard extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final dueDate = artefact.dueDateString;
-    final environmentReviewsAsync =
-        ref.watch(artefactEnvironmentReviewsProvider(artefact.id));
-    final environmentReviews = environmentReviewsAsync.valueOrNull ?? const [];
 
     return NavigableLink(
       path: getArtefactPagePath(context, artefact.id),
@@ -87,14 +84,30 @@ class ArtefactCard extends ConsumerWidget {
                       fontColor: YaruColors.red,
                     ),
                   const Spacer(),
-                  ReviewersAvatars(
-                    reviewers: artefact.reviewers,
-                    allEnvironmentReviewsCount:
-                        artefact.allEnvironmentReviewsCount,
-                    completedEnvironmentReviewsCount:
-                        artefact.completedEnvironmentReviewsCount,
-                    environmentReviews: environmentReviews,
-                  ),
+                  if (artefact.reviewers.isEmpty)
+                    UserAvatar(
+                      user: emptyUser,
+                      allEnvironmentReviewsCount:
+                          artefact.allEnvironmentReviewsCount,
+                      completedEnvironmentReviewsCount:
+                          artefact.completedEnvironmentReviewsCount,
+                    )
+                  else if (artefact.reviewers.length == 1)
+                    UserAvatar(
+                      user: artefact.reviewers.first,
+                      allEnvironmentReviewsCount:
+                          artefact.allEnvironmentReviewsCount,
+                      completedEnvironmentReviewsCount:
+                          artefact.completedEnvironmentReviewsCount,
+                    )
+                  else
+                    ReviewerCountAvatar(
+                      reviewers: artefact.reviewers,
+                      allEnvironmentReviewsCount:
+                          artefact.allEnvironmentReviewsCount,
+                      completedEnvironmentReviewsCount:
+                          artefact.completedEnvironmentReviewsCount,
+                    ),
                 ],
               ),
             ].intersperse(const SizedBox(height: Spacing.level2)).toList(),

--- a/frontend/lib/ui/dashboard/artefact_card.dart
+++ b/frontend/lib/ui/dashboard/artefact_card.dart
@@ -19,6 +19,7 @@ import 'package:intersperse/intersperse.dart';
 import 'package:yaru/yaru.dart';
 
 import '../../models/artefact.dart';
+import '../../providers/artefact_environment_reviews.dart';
 import '../../routing.dart';
 import '../spacing.dart';
 import '../navigable_link.dart';
@@ -35,6 +36,9 @@ class ArtefactCard extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final dueDate = artefact.dueDateString;
+    final environmentReviewsAsync =
+        ref.watch(artefactEnvironmentReviewsProvider(artefact.id));
+    final environmentReviews = environmentReviewsAsync.valueOrNull ?? const [];
 
     return NavigableLink(
       path: getArtefactPagePath(context, artefact.id),
@@ -89,6 +93,7 @@ class ArtefactCard extends ConsumerWidget {
                         artefact.allEnvironmentReviewsCount,
                     completedEnvironmentReviewsCount:
                         artefact.completedEnvironmentReviewsCount,
+                    environmentReviews: environmentReviews,
                   ),
                 ],
               ),

--- a/frontend/lib/ui/reviewers_avatars.dart
+++ b/frontend/lib/ui/reviewers_avatars.dart
@@ -36,9 +36,15 @@ class ReviewersAvatars extends StatelessWidget {
   /// Returns a map from user id to (all, completed) assignment counts
   /// derived from [environmentReviews]. When [environmentReviews] is empty
   /// the map is empty and callers fall back to the overall artefact counts.
+  /// Reviewers with zero assignments are included with (all: 0, completed: 0).
   Map<int, ({int all, int completed})> get _reviewerStats {
     if (environmentReviews.isEmpty) return {};
     final stats = <int, ({int all, int completed})>{};
+    // Initialize all reviewers with 0/0
+    for (final reviewer in reviewers) {
+      stats[reviewer.id] = (all: 0, completed: 0);
+    }
+    // Update with actual review counts
     for (final review in environmentReviews) {
       final isCompleted = review.reviewDecision.isNotEmpty;
       for (final reviewer in review.reviewers) {

--- a/frontend/lib/ui/reviewers_avatars.dart
+++ b/frontend/lib/ui/reviewers_avatars.dart
@@ -15,6 +15,7 @@
 
 import 'package:flutter/material.dart';
 
+import '../models/environment_review.dart';
 import '../models/user.dart';
 import 'user_avatar.dart';
 
@@ -24,14 +25,48 @@ class ReviewersAvatars extends StatelessWidget {
     required this.reviewers,
     required this.allEnvironmentReviewsCount,
     required this.completedEnvironmentReviewsCount,
+    this.environmentReviews = const [],
   });
 
   final List<User> reviewers;
   final int allEnvironmentReviewsCount;
   final int completedEnvironmentReviewsCount;
+  final List<EnvironmentReview> environmentReviews;
+
+  /// Returns a map from user id to (all, completed) assignment counts
+  /// derived from [environmentReviews]. When [environmentReviews] is empty
+  /// the map is empty and callers fall back to the overall artefact counts.
+  Map<int, ({int all, int completed})> get _reviewerStats {
+    if (environmentReviews.isEmpty) return {};
+    final stats = <int, ({int all, int completed})>{};
+    for (final review in environmentReviews) {
+      final isCompleted = review.reviewDecision.isNotEmpty;
+      for (final reviewer in review.reviewers) {
+        final current = stats[reviewer.id] ?? (all: 0, completed: 0);
+        stats[reviewer.id] = (
+          all: current.all + 1,
+          completed: current.completed + (isCompleted ? 1 : 0),
+        );
+      }
+    }
+    return stats;
+  }
 
   @override
   Widget build(BuildContext context) {
+    final stats = _reviewerStats;
+
+    UserAvatar buildUserAvatar(User user) {
+      final s = stats[user.id];
+      return UserAvatar(
+        user: user,
+        allEnvironmentReviewsCount: allEnvironmentReviewsCount,
+        completedEnvironmentReviewsCount: completedEnvironmentReviewsCount,
+        reviewerAllCount: s?.all,
+        reviewerCompletedCount: s?.completed,
+      );
+    }
+
     if (reviewers.isEmpty) {
       // Show single empty avatar if no reviewers
       return UserAvatar(
@@ -42,12 +77,7 @@ class ReviewersAvatars extends StatelessWidget {
     }
 
     if (reviewers.length == 1) {
-      // Show single avatar for one reviewer
-      return UserAvatar(
-        user: reviewers.first,
-        allEnvironmentReviewsCount: allEnvironmentReviewsCount,
-        completedEnvironmentReviewsCount: completedEnvironmentReviewsCount,
-      );
+      return buildUserAvatar(reviewers.first);
     }
 
     // Show stacked avatars for multiple reviewers
@@ -57,12 +87,7 @@ class ReviewersAvatars extends StatelessWidget {
         for (int i = 0; i < reviewers.length; i++)
           Transform.translate(
             offset: Offset(-8.0 * i, 0),
-            child: UserAvatar(
-              user: reviewers[i],
-              allEnvironmentReviewsCount: allEnvironmentReviewsCount,
-              completedEnvironmentReviewsCount:
-                  completedEnvironmentReviewsCount,
-            ),
+            child: buildUserAvatar(reviewers[i]),
           ),
       ],
     );

--- a/frontend/lib/ui/user_avatar.dart
+++ b/frontend/lib/ui/user_avatar.dart
@@ -32,13 +32,24 @@ class UserAvatar extends StatelessWidget {
     required this.user,
     required this.allEnvironmentReviewsCount,
     required this.completedEnvironmentReviewsCount,
+    this.reviewerAllCount,
+    this.reviewerCompletedCount,
   });
 
   final User user;
   final int allEnvironmentReviewsCount;
   final int completedEnvironmentReviewsCount;
+  final int? reviewerAllCount;
+  final int? reviewerCompletedCount;
+
+  bool get _hasReviewerStats =>
+      reviewerAllCount != null && reviewerCompletedCount != null;
 
   double get ratioCompleted {
+    if (_hasReviewerStats) {
+      if (reviewerAllCount == 0) return 0.0;
+      return reviewerCompletedCount! / reviewerAllCount!;
+    }
     if (allEnvironmentReviewsCount == 0) {
       return 0.0;
     }
@@ -79,8 +90,23 @@ class UserAvatar extends StatelessWidget {
   }
 
   String get _tooltipMessage {
-    String result = 'Completed: $completedEnvironmentReviewsCount / '
-        '$allEnvironmentReviewsCount (${(ratioCompleted * 100).round()}%)';
+    final overallRatio = allEnvironmentReviewsCount == 0
+        ? 0.0
+        : completedEnvironmentReviewsCount / allEnvironmentReviewsCount;
+    final overallLine =
+        'Overall: $completedEnvironmentReviewsCount / $allEnvironmentReviewsCount'
+        ' (${(overallRatio * 100).round()}%)';
+
+    String result;
+    if (_hasReviewerStats) {
+      final assignmentLine =
+          'Your assignments: $reviewerCompletedCount / $reviewerAllCount'
+          ' (${(ratioCompleted * 100).round()}%)';
+      result = '$assignmentLine\n$overallLine';
+    } else {
+      result = overallLine;
+    }
+
     if (user.isEmpty) {
       result = 'No reviewer assigned\n$result';
     } else {

--- a/frontend/lib/ui/user_avatar.dart
+++ b/frontend/lib/ui/user_avatar.dart
@@ -100,7 +100,7 @@ class UserAvatar extends StatelessWidget {
     String result;
     if (_hasReviewerStats) {
       final assignmentLine =
-          'Your assignments: $reviewerCompletedCount / $reviewerAllCount'
+          'Assignments: $reviewerCompletedCount / $reviewerAllCount'
           ' (${(ratioCompleted * 100).round()}%)';
       result = '$assignmentLine\n$overallLine';
     } else {
@@ -125,5 +125,79 @@ class UserAvatar extends StatelessWidget {
     final double lightness = (hsl.lightness - 0.2).clamp(0.0, 1.0);
 
     return hsl.withLightness(lightness).toColor();
+  }
+}
+
+class ReviewerCountAvatar extends StatelessWidget {
+  const ReviewerCountAvatar({
+    super.key,
+    required this.reviewers,
+    required this.allEnvironmentReviewsCount,
+    required this.completedEnvironmentReviewsCount,
+  });
+
+  final List<User> reviewers;
+  final int allEnvironmentReviewsCount;
+  final int completedEnvironmentReviewsCount;
+
+  double get ratioCompleted {
+    if (allEnvironmentReviewsCount == 0) {
+      return 0.0;
+    }
+    return completedEnvironmentReviewsCount / allEnvironmentReviewsCount;
+  }
+
+  String get _tooltipMessage {
+    final reviewerNames = reviewers.map((r) => r.name).join('\n');
+    final overallRatio = allEnvironmentReviewsCount == 0
+        ? 0.0
+        : completedEnvironmentReviewsCount / allEnvironmentReviewsCount;
+    final overallLine =
+        'Overall: $completedEnvironmentReviewsCount / $allEnvironmentReviewsCount'
+        ' (${(overallRatio * 100).round()}%)';
+
+    return '$reviewerNames\n$overallLine';
+  }
+
+  Color get _avatarColor =>
+      possibleColors[reviewers.hashCode % possibleColors.length];
+
+  Color get _progressColor {
+    final hsl = HSLColor.fromColor(_avatarColor);
+    final double lightness = (hsl.lightness - 0.2).clamp(0.0, 1.0);
+
+    return hsl.withLightness(lightness).toColor();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: _tooltipMessage,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          CircleAvatar(
+            backgroundColor: _avatarColor,
+            child: Text(
+              reviewers.length.toString(),
+              style: Theme.of(context)
+                  .textTheme
+                  .labelLarge
+                  ?.apply(fontWeightDelta: 4),
+            ),
+          ),
+          SizedBox(
+            width: 43.0,
+            height: 43.0,
+            child: CircularProgressIndicator(
+              color: _progressColor,
+              backgroundColor: _avatarColor,
+              value: ratioCompleted,
+              semanticsLabel: 'Circular progress indicator',
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/frontend/lib/ui/user_avatar.dart
+++ b/frontend/lib/ui/user_avatar.dart
@@ -26,6 +26,15 @@ const possibleColors = [
   Colors.purpleAccent,
 ];
 
+/// Displays a reviewer avatar with a circular progress indicator.
+///
+/// If both [reviewerAllCount] and [reviewerCompletedCount] are provided,
+/// the progress indicator shows per-reviewer completion and the tooltip
+/// displays both per-reviewer and overall statistics.
+///
+/// If only overall counts are provided (or if reviewer counts are partially
+/// provided), the progress indicator and tooltip show overall statistics
+/// across all environments.
 class UserAvatar extends StatelessWidget {
   const UserAvatar({
     super.key,
@@ -42,6 +51,8 @@ class UserAvatar extends StatelessWidget {
   final int? reviewerAllCount;
   final int? reviewerCompletedCount;
 
+  /// Whether both reviewer-specific stats are available.
+  /// If only one is provided, this returns false and stats fall back to overall.
   bool get _hasReviewerStats =>
       reviewerAllCount != null && reviewerCompletedCount != null;
 
@@ -159,8 +170,8 @@ class ReviewerCountAvatar extends StatelessWidget {
     return '$reviewerNames\n$overallLine';
   }
 
-  Color get _avatarColor =>
-      possibleColors[reviewers.hashCode % possibleColors.length];
+  Color get _avatarColor => possibleColors[
+      Object.hashAll(reviewers.map((r) => r.id)) % possibleColors.length];
 
   Color get _progressColor {
     final hsl = HSLColor.fromColor(_avatarColor);
@@ -193,7 +204,8 @@ class ReviewerCountAvatar extends StatelessWidget {
               color: _progressColor,
               backgroundColor: _avatarColor,
               value: ratioCompleted,
-              semanticsLabel: 'Circular progress indicator',
+              semanticsLabel:
+                  'Overall review progress: $completedEnvironmentReviewsCount of $allEnvironmentReviewsCount',
             ),
           ),
         ],


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR updates the progress reporting for individual environment reviewers and adds a new `ReviewerCountAvatar` class. On the dashboard page, the artefact card will show the reviewer count along when there are multiple reviewers. Mousing over the count will show the individual reviewers' names and the overall artefact progess.

Within the specific artefact page, the reviewer avatar has been updated to reflect each reviewer's individual progress. The overall progress is shown separately when viewing the individual progress.

### Dashboard Page - Default

<img width="685" height="392" alt="Screenshot from 2026-07-08 10-56-19" src="https://github.com/user-attachments/assets/016f606b-c7e5-4ba2-870f-44f94d4061fb" />

### Dashboard Page - Tooltip

<img width="731" height="777" alt="Screenshot from 2026-07-08 10-56-41" src="https://github.com/user-attachments/assets/9771c701-31ec-419b-bc5b-7f57123b34aa" />

### Artefact Page

<img width="1014" height="394" alt="Screenshot from 2026-07-07 18-16-54" src="https://github.com/user-attachments/assets/62f2dbc0-c843-4e4a-8f97-bdee92f7ebb4" />

<img width="1014" height="394" alt="Screenshot from 2026-07-07 18-16-43" src="https://github.com/user-attachments/assets/e6d01858-b31e-454d-8763-a461addf8b05" />

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

[TO-397]


[TO-397]: https://warthogs.atlassian.net/browse/TO-397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ