### PR TITLE
TO-395: change old concept of assignee to reviewers

### DIFF
--- a/frontend/lib/filtering/artefact_filters.dart
+++ b/frontend/lib/filtering/artefact_filters.dart
@@ -20,20 +20,20 @@ import 'filter.dart';
 List<Filter<Artefact>> getArtefactFiltersFor(FamilyName family) =>
     switch (family) {
       FamilyName.snap => [
-          _artefactAssigneeFilter,
+          _artefactReviewerFilter,
           _artefactStatusFilter,
           _artefactDueDateFilter,
           _artefactRiskFilter,
         ],
       FamilyName.deb => [
-          _artefactAssigneeFilter,
+          _artefactReviewerFilter,
           _artefactStatusFilter,
           _artefactDueDateFilter,
           _artefactSeriesFilter,
           _artefactPocketFilter,
         ],
       FamilyName.charm => [
-          _artefactAssigneeFilter,
+          _artefactReviewerFilter,
           _artefactStatusFilter,
           _artefactDueDateFilter,
           _artefactRiskFilter,
@@ -42,15 +42,15 @@ List<Filter<Artefact>> getArtefactFiltersFor(FamilyName family) =>
           _artefactOSFilter,
           _artefactReleaseFilter,
           _artefactOwnerFilter,
-          _artefactAssigneeFilter,
+          _artefactReviewerFilter,
           _artefactStatusFilter,
           _artefactDueDateFilter,
         ],
     };
 
-final _artefactAssigneeFilter = createFilterFromExtractor<Artefact>(
-  'Assignee',
-  (artefact) => artefact.assignee.name,
+final _artefactReviewerFilter = createFilterFromListExtractor<Artefact>(
+  'Reviewer',
+  (artefact) => artefact.reviewers.map((r) => r.name).toList(),
 );
 
 final _artefactStatusFilter = createFilterFromExtractor<Artefact>(

--- a/frontend/lib/filtering/filter.dart
+++ b/frontend/lib/filtering/filter.dart
@@ -38,3 +38,15 @@ Filter<T> createFilterFromExtractor<T>(
           .filter((item) => options.contains(extractOption(item)))
           .toList(),
     );
+
+Filter<T> createFilterFromListExtractor<T>(
+  String name,
+  List<String> Function(T) extractOptions,
+) =>
+    Filter(
+      name: name,
+      extractOptions: (items) => items.expand(extractOptions).toSet(),
+      filter: (items, options) => items
+          .filter((item) => extractOptions(item).any(options.contains))
+          .toList(),
+    );

--- a/frontend/lib/models/artefact.dart
+++ b/frontend/lib/models/artefact.dart
@@ -58,8 +58,6 @@ abstract class Artefact with _$Artefact {
   factory Artefact.fromJson(Map<String, Object?> json) =>
       _$ArtefactFromJson(json);
 
-  User get assignee => reviewers.isNotEmpty ? reviewers.first : emptyUser;
-
   String? get dueDateString {
     final month = dueDate?.month;
     final day = dueDate?.day;

--- a/frontend/lib/models/test_results_filters.dart
+++ b/frontend/lib/models/test_results_filters.dart
@@ -193,7 +193,7 @@ abstract class TestResultsFilters with _$TestResultsFilters {
       parseParam(parameters['issues']),
     );
     final reviewers = IntListFilter.fromQueryParam(
-      parseParam(parameters['reviewer_ids']),
+      parseParam(parameters['reviewer_ids'] ?? parameters['assignee_ids']),
     );
     final fromDate = parseParam(parameters['from_date'])
         .map((s) => DateTime.tryParse(s))

--- a/frontend/lib/models/test_results_filters.dart
+++ b/frontend/lib/models/test_results_filters.dart
@@ -141,8 +141,9 @@ abstract class TestResultsFilters with _$TestResultsFilters {
     @Default(IntListFilter.list([]))
     IntListFilter issues,
     @IntListFilterConverter()
+    @JsonKey(name: 'reviewer_ids')
     @Default(IntListFilter.list([]))
-    IntListFilter assignees,
+    IntListFilter reviewers,
     @JsonKey(name: 'from_date') DateTime? fromDate,
     @JsonKey(name: 'until_date') DateTime? untilDate,
     int? offset,
@@ -191,8 +192,8 @@ abstract class TestResultsFilters with _$TestResultsFilters {
     final issues = IntListFilter.fromQueryParam(
       parseParam(parameters['issues']),
     );
-    final assignees = IntListFilter.fromQueryParam(
-      parseParam(parameters['assignee_ids']),
+    final reviewers = IntListFilter.fromQueryParam(
+      parseParam(parameters['reviewer_ids']),
     );
     final fromDate = parseParam(parameters['from_date'])
         .map((s) => DateTime.tryParse(s))
@@ -219,7 +220,7 @@ abstract class TestResultsFilters with _$TestResultsFilters {
       templateIds: templateIds,
       executionMetadata: executionMetadata,
       issues: issues,
-      assignees: assignees,
+      reviewers: reviewers,
       fromDate: fromDate,
       untilDate: untilDate,
       offset: offset,
@@ -264,9 +265,9 @@ abstract class TestResultsFilters with _$TestResultsFilters {
     if (issuesParam.isNotEmpty) {
       params['issues'] = issuesParam;
     }
-    final assigneesParam = assignees.toQueryParam();
-    if (assigneesParam.isNotEmpty) {
-      params['assignee_ids'] = assigneesParam;
+    final reviewersParam = reviewers.toQueryParam();
+    if (reviewersParam.isNotEmpty) {
+      params['reviewer_ids'] = reviewersParam;
     }
     if (fromDate != null) {
       params['from_date'] = [fromDate!.toIso8601String()];
@@ -295,7 +296,7 @@ abstract class TestResultsFilters with _$TestResultsFilters {
       templateIds.isNotEmpty ||
       executionMetadata.isNotEmpty ||
       issues.isNotEmpty ||
-      assignees.isNotEmpty ||
+      reviewers.isNotEmpty ||
       fromDate != null ||
       untilDate != null;
 

--- a/frontend/lib/providers/filtered_family_artefacts.dart
+++ b/frontend/lib/providers/filtered_family_artefacts.dart
@@ -38,7 +38,8 @@ LinkedHashMap<int, Artefact> filteredFamilyArtefacts(Ref ref, Uri pageUri) {
       ref.watch(familyArtefactsProvider(family)).value?.values.toList() ?? [];
 
   for (var filter in getArtefactFiltersFor(family)) {
-    final filterOptions = parameters[filter.name];
+    final filterOptions = parameters[filter.name] ??
+        (filter.name == 'Reviewer' ? parameters['Assignee'] : null);
     if (filterOptions != null) {
       artefacts = filter.filter(artefacts, filterOptions.toSet());
     }

--- a/frontend/lib/ui/dashboard/dashboard_body/artefacts_list_view/column_metadata.dart
+++ b/frontend/lib/ui/dashboard/dashboard_body/artefacts_list_view/column_metadata.dart
@@ -73,7 +73,7 @@ const _snapColumnsMetadata = <ColumnMetadata>[
   ),
   (
     name: 'Reviewers',
-    queryParam: ArtefactSortingQuery.assignee,
+    queryParam: ArtefactSortingQuery.reviewer,
     flex: 1,
     cellBuilder: _buildReviewersCell,
   ),
@@ -136,7 +136,7 @@ const _debColumnsMetadata = <ColumnMetadata>[
   ),
   (
     name: 'Reviewers',
-    queryParam: ArtefactSortingQuery.assignee,
+    queryParam: ArtefactSortingQuery.reviewer,
     flex: 1,
     cellBuilder: _buildReviewersCell,
   ),
@@ -193,7 +193,7 @@ const _charmColumnsMetadata = <ColumnMetadata>[
   ),
   (
     name: 'Reviewers',
-    queryParam: ArtefactSortingQuery.assignee,
+    queryParam: ArtefactSortingQuery.reviewer,
     flex: 1,
     cellBuilder: _buildReviewersCell,
   ),
@@ -250,7 +250,7 @@ const _imageColumnsMetadata = <ColumnMetadata>[
   ),
   (
     name: 'Reviewers',
-    queryParam: ArtefactSortingQuery.assignee,
+    queryParam: ArtefactSortingQuery.reviewer,
     flex: 1,
     cellBuilder: _buildReviewersCell,
   ),

--- a/frontend/lib/ui/dashboard/dashboard_body/artefacts_list_view/column_metadata.dart
+++ b/frontend/lib/ui/dashboard/dashboard_body/artefacts_list_view/column_metadata.dart
@@ -75,7 +75,7 @@ const _snapColumnsMetadata = <ColumnMetadata>[
     name: 'Reviewers',
     queryParam: ArtefactSortingQuery.assignee,
     flex: 1,
-    cellBuilder: _buildAssigneeCell,
+    cellBuilder: _buildReviewersCell,
   ),
 ];
 
@@ -138,7 +138,7 @@ const _debColumnsMetadata = <ColumnMetadata>[
     name: 'Reviewers',
     queryParam: ArtefactSortingQuery.assignee,
     flex: 1,
-    cellBuilder: _buildAssigneeCell,
+    cellBuilder: _buildReviewersCell,
   ),
 ];
 
@@ -195,7 +195,7 @@ const _charmColumnsMetadata = <ColumnMetadata>[
     name: 'Reviewers',
     queryParam: ArtefactSortingQuery.assignee,
     flex: 1,
-    cellBuilder: _buildAssigneeCell,
+    cellBuilder: _buildReviewersCell,
   ),
 ];
 
@@ -252,7 +252,7 @@ const _imageColumnsMetadata = <ColumnMetadata>[
     name: 'Reviewers',
     queryParam: ArtefactSortingQuery.assignee,
     flex: 1,
-    cellBuilder: _buildAssigneeCell,
+    cellBuilder: _buildReviewersCell,
   ),
 ];
 
@@ -294,7 +294,7 @@ Widget _buildStatusCell(BuildContext context, Artefact artefact) {
   );
 }
 
-Widget _buildAssigneeCell(BuildContext context, Artefact artefact) {
+Widget _buildReviewersCell(BuildContext context, Artefact artefact) {
   if (artefact.reviewers.isEmpty) {
     return const Text('N/A');
   }

--- a/frontend/lib/ui/test_results_page/test_results_filters_view.dart
+++ b/frontend/lib/ui/test_results_page/test_results_filters_view.dart
@@ -39,7 +39,7 @@ enum FilterType {
   families,
   testResultStatuses,
   issues,
-  assignees,
+  reviewers,
   artefacts,
   artefactIsArchived,
   rerunIsRequested,
@@ -330,17 +330,17 @@ class _TestResultsFiltersViewState
               },
             ),
           ),
-        if (_isFilterEnabled(FilterType.assignees))
+        if (_isFilterEnabled(FilterType.reviewers))
           _box(
             _buildIntListFilterCombobox(
-              title: 'Assignees',
-              currentFilter: _selectedFilters.assignees,
+              title: 'Reviewers',
+              currentFilter: _selectedFilters.reviewers,
               metaOptions: const [
-                MetaOption(value: 'any', label: 'Has any assignee'),
-                MetaOption(value: 'none', label: 'Has no assignee'),
+                MetaOption(value: 'any', label: 'Has any reviewer'),
+                MetaOption(value: 'none', label: 'Has no reviewer'),
               ],
               onFilterChanged: (filter) {
-                _selectedFilters = _selectedFilters.copyWith(assignees: filter);
+                _selectedFilters = _selectedFilters.copyWith(reviewers: filter);
                 _notifyChanged(_selectedFilters);
               },
               asyncSuggestionsCallback: (pattern) async {

--- a/frontend/lib/utils/artefact_sorting.dart
+++ b/frontend/lib/utils/artefact_sorting.dart
@@ -26,7 +26,6 @@ enum ArtefactSortingQuery {
   reviewsRemaining,
   status,
   reviewer,
-  // ignore: constant_identifier_names
   assignee, // deprecated alias for reviewer, kept for URL backwards-compatibility
   series,
   source,
@@ -91,8 +90,12 @@ int Function(Artefact, Artefact) _getArtefactCompareFunction(
     case ArtefactSortingQuery.reviewer:
     case ArtefactSortingQuery.assignee: // deprecated alias for reviewer
       return (a1, a2) {
+        if (a1.reviewers.isEmpty && a2.reviewers.isEmpty) return 0;
         if (a1.reviewers.isEmpty) return 1;
         if (a2.reviewers.isEmpty) return -1;
+        final countComparison =
+            a1.reviewers.length.compareTo(a2.reviewers.length);
+        if (countComparison != 0) return countComparison;
         return a1.reviewers.first.name.compareTo(a2.reviewers.first.name);
       };
     case ArtefactSortingQuery.series:

--- a/frontend/lib/utils/artefact_sorting.dart
+++ b/frontend/lib/utils/artefact_sorting.dart
@@ -88,11 +88,9 @@ int Function(Artefact, Artefact) _getArtefactCompareFunction(
       return (a1, a2) => a1.status.name.compareTo(a2.status.name);
     case ArtefactSortingQuery.assignee:
       return (a1, a2) {
-        // no assignee is always larger
-        if (a1.assignee.isEmpty) return 1;
-        if (a2.assignee.isEmpty) return -1;
-
-        return a1.assignee.name.compareTo(a2.assignee.name);
+        if (a1.reviewers.isEmpty) return 1;
+        if (a2.reviewers.isEmpty) return -1;
+        return a1.reviewers.first.name.compareTo(a2.reviewers.first.name);
       };
     case ArtefactSortingQuery.series:
       return (a1, a2) => a1.series.compareTo(a2.series);

--- a/frontend/lib/utils/artefact_sorting.dart
+++ b/frontend/lib/utils/artefact_sorting.dart
@@ -26,6 +26,8 @@ enum ArtefactSortingQuery {
   reviewsRemaining,
   status,
   reviewer,
+  // ignore: constant_identifier_names
+  assignee, // deprecated alias for reviewer, kept for URL backwards-compatibility
   series,
   source,
   repo,
@@ -87,6 +89,7 @@ int Function(Artefact, Artefact) _getArtefactCompareFunction(
     case ArtefactSortingQuery.status:
       return (a1, a2) => a1.status.name.compareTo(a2.status.name);
     case ArtefactSortingQuery.reviewer:
+    case ArtefactSortingQuery.assignee: // deprecated alias for reviewer
       return (a1, a2) {
         if (a1.reviewers.isEmpty) return 1;
         if (a2.reviewers.isEmpty) return -1;

--- a/frontend/lib/utils/artefact_sorting.dart
+++ b/frontend/lib/utils/artefact_sorting.dart
@@ -25,7 +25,7 @@ enum ArtefactSortingQuery {
   dueDate,
   reviewsRemaining,
   status,
-  assignee,
+  reviewer,
   series,
   source,
   repo,
@@ -86,7 +86,7 @@ int Function(Artefact, Artefact) _getArtefactCompareFunction(
           .compareTo(a2.remainingTestExecutionCount);
     case ArtefactSortingQuery.status:
       return (a1, a2) => a1.status.name.compareTo(a2.status.name);
-    case ArtefactSortingQuery.assignee:
+    case ArtefactSortingQuery.reviewer:
       return (a1, a2) {
         if (a1.reviewers.isEmpty) return 1;
         if (a2.reviewers.isEmpty) return -1;

--- a/frontend/test/artefact_sorting_test.dart
+++ b/frontend/test/artefact_sorting_test.dart
@@ -19,7 +19,7 @@ import 'package:test/test.dart';
 import 'package:testcase_dashboard/routing.dart';
 import 'package:testcase_dashboard/utils/artefact_sorting.dart';
 
-import '../dummy_data.dart';
+import 'dummy_data.dart';
 
 void main() {
   test('sortArtefacts sorts by reviewer query parameter', () {

--- a/frontend/test/artefact_sorting_test.dart
+++ b/frontend/test/artefact_sorting_test.dart
@@ -1,0 +1,41 @@
+// Copyright 2026 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+import 'package:test/test.dart';
+import 'package:testcase_dashboard/routing.dart';
+import 'package:testcase_dashboard/utils/artefact_sorting.dart';
+
+import '../dummy_data.dart';
+
+void main() {
+  test('sortArtefacts sorts by reviewer query parameter', () {
+    final artefacts = [
+      dummyArtefact.copyWith(id: 1, name: 'zulu', reviewers: [dummyUser2]),
+      dummyArtefact.copyWith(id: 2, name: 'alpha', reviewers: [dummyUser3]),
+      dummyArtefact.copyWith(id: 3, name: 'middle', reviewers: []),
+    ];
+
+    sortArtefacts(
+      {
+        CommonQueryParameters.sortBy: ArtefactSortingQuery.reviewer.name,
+      },
+      artefacts,
+    );
+
+    expect(artefacts.map((artefact) => artefact.id).toList(), [2, 1, 3]);
+  });
+}

--- a/frontend/test/filtering/filter_test.dart
+++ b/frontend/test/filtering/filter_test.dart
@@ -1,0 +1,71 @@
+// Copyright 2026 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+import 'package:test/test.dart';
+import 'package:testcase_dashboard/filtering/filter.dart';
+
+void main() {
+  const items = [
+    _FilterItem('first', ['alice', 'bob']),
+    _FilterItem('second', ['bob', 'carol']),
+    _FilterItem('third', ['dave']),
+  ];
+
+  final filter = createFilterFromListExtractor<_FilterItem>(
+    'Reviewer',
+    (item) => item.options,
+  );
+
+  test('extractOptions returns the union of options across all items', () {
+    expect(
+      filter.extractOptions(items),
+      equals({'alice', 'bob', 'carol', 'dave'}),
+    );
+  });
+
+  test('filter returns items when any extracted option is selected', () {
+    expect(
+      filter.filter(items, {'bob', 'dave'}),
+      equals([items[0], items[1], items[2]]),
+    );
+  });
+
+  test('filter excludes items that have no matching option', () {
+    expect(
+      filter.filter(items, {'alice'}),
+      equals([items[0]]),
+    );
+  });
+
+  test('filter returns an empty list when no items match', () {
+    expect(filter.filter(items, {'eve'}), isEmpty);
+  });
+
+  test('filter returns all items when all items have a matching option', () {
+    expect(
+      filter.filter(items, {'alice', 'carol', 'dave'}),
+      equals(items),
+    );
+  });
+}
+
+class _FilterItem {
+  const _FilterItem(this.name, this.options);
+
+  final String name;
+  final List<String> options;
+}

--- a/frontend/test/models/test_results_filters_test.dart
+++ b/frontend/test/models/test_results_filters_test.dart
@@ -233,7 +233,7 @@ void main() {
             },
           ),
           issues: const IntListFilter.list([1, 2]),
-          assignees: const IntListFilter.any(),
+          reviewers: const IntListFilter.any(),
           fromDate: DateTime.utc(2024, 1, 1),
           untilDate: DateTime.utc(2024, 12, 31),
           offset: 10,
@@ -250,7 +250,7 @@ void main() {
         expect(json['template_ids'], equals(['template1']));
         expect(json['execution_metadata'], isA<Map>());
         expect(json['issues'], equals([1, 2]));
-        expect(json['assignees'], equals('any'));
+        expect(json['reviewer_ids'], equals('any'));
         expect(json['from_date'], equals('2024-01-01T00:00:00.000Z'));
         expect(json['until_date'], equals('2024-12-31T00:00:00.000Z'));
         expect(json['offset'], equals(10));
@@ -260,19 +260,19 @@ void main() {
       test('serializes IntListFilter variants correctly in JSON', () {
         final filtersWithList = TestResultsFilters(
           issues: const IntListFilter.list([1, 2, 3]),
-          assignees: const IntListFilter.list([4, 5]),
+          reviewers: const IntListFilter.list([4, 5]),
         );
         final jsonList = filtersWithList.toJson();
         expect(jsonList['issues'], equals([1, 2, 3]));
-        expect(jsonList['assignees'], equals([4, 5]));
+        expect(jsonList['reviewer_ids'], equals([4, 5]));
 
         final filtersWithAny = TestResultsFilters(
           issues: const IntListFilter.any(),
-          assignees: const IntListFilter.none(),
+          reviewers: const IntListFilter.none(),
         );
         final jsonAny = filtersWithAny.toJson();
         expect(jsonAny['issues'], equals('any'));
-        expect(jsonAny['assignees'], equals('none'));
+        expect(jsonAny['reviewer_ids'], equals('none'));
       });
 
       test('omits default values', () {
@@ -304,7 +304,7 @@ void main() {
             'key': ['value1', 'value2'],
           },
           'issues': [1, 2, 3],
-          'assignees': 'any',
+          'reviewer_ids': 'any',
           'from_date': '2024-01-01T00:00:00.000Z',
           'until_date': '2024-12-31T00:00:00.000Z',
           'offset': 10,
@@ -321,7 +321,7 @@ void main() {
         expect(filters.templateIds, equals(['template1']));
         expect(filters.executionMetadata.data, isA<Map<String, Set<String>>>());
         expect(filters.issues.values, equals([1, 2, 3]));
-        expect(filters.assignees.isAny, isTrue);
+        expect(filters.reviewers.isAny, isTrue);
         expect(filters.fromDate, equals(DateTime.utc(2024, 1, 1)));
         expect(filters.untilDate, equals(DateTime.utc(2024, 12, 31)));
         expect(filters.offset, equals(10));
@@ -331,17 +331,17 @@ void main() {
       test('deserializes IntListFilter variants correctly', () {
         final jsonWithList = {
           'issues': [1, 2],
-          'assignees': [],
+          'reviewer_ids': [],
         };
         final filtersWithList = TestResultsFilters.fromJson(jsonWithList);
         expect(filtersWithList.issues.values, equals([1, 2]));
-        expect(filtersWithList.assignees.values, equals([]));
+        expect(filtersWithList.reviewers.values, equals([]));
 
-        final jsonWithKeywords = {'issues': 'any', 'assignees': 'none'};
+        final jsonWithKeywords = {'issues': 'any', 'reviewer_ids': 'none'};
         final filtersWithKeywords =
             TestResultsFilters.fromJson(jsonWithKeywords);
         expect(filtersWithKeywords.issues.isAny, isTrue);
-        expect(filtersWithKeywords.assignees.isNone, isTrue);
+        expect(filtersWithKeywords.reviewers.isNone, isTrue);
       });
 
       test('handles missing optional fields', () {
@@ -370,7 +370,7 @@ void main() {
             },
           ),
           issues: const IntListFilter.list([1, 2, 3]),
-          assignees: const IntListFilter.none(),
+          reviewers: const IntListFilter.none(),
           fromDate: DateTime.utc(2024, 1, 1),
           untilDate: DateTime.utc(2024, 12, 31),
           offset: 10,
@@ -397,7 +397,7 @@ void main() {
             '${base64Encode(utf8.encode('key'))}:${base64Encode(utf8.encode('value'))}',
           ],
           'issues': ['1,2,3'],
-          'assignee_ids': ['any'],
+          'reviewer_ids': ['any'],
           'from_date': ['2024-01-01T00:00:00.000Z'],
           'until_date': ['2024-12-31T00:00:00.000Z'],
           'offset': ['10'],
@@ -416,7 +416,7 @@ void main() {
         expect(filters.testCases, equals(['test1']));
         expect(filters.templateIds, equals(['template1', 'template2']));
         expect(filters.issues.values, equals([1, 2, 3]));
-        expect(filters.assignees.isAny, isTrue);
+        expect(filters.reviewers.isAny, isTrue);
         expect(filters.fromDate, equals(DateTime.utc(2024, 1, 1)));
         expect(filters.untilDate, equals(DateTime.utc(2024, 12, 31)));
         expect(filters.offset, equals(10));
@@ -426,21 +426,21 @@ void main() {
       test('fromQueryParams handles IntListFilter variants', () {
         final paramsWithList = {
           'issues': ['1,2,3'],
-          'assignee_ids': ['4,5'],
+          'reviewer_ids': ['4,5'],
         };
         final filtersWithList =
             TestResultsFilters.fromQueryParams(paramsWithList);
         expect(filtersWithList.issues.values, equals([1, 2, 3]));
-        expect(filtersWithList.assignees.values, equals([4, 5]));
+        expect(filtersWithList.reviewers.values, equals([4, 5]));
 
         final paramsWithKeywords = {
           'issues': ['any'],
-          'assignee_ids': ['none'],
+          'reviewer_ids': ['none'],
         };
         final filtersWithKeywords =
             TestResultsFilters.fromQueryParams(paramsWithKeywords);
         expect(filtersWithKeywords.issues.isAny, isTrue);
-        expect(filtersWithKeywords.assignees.isNone, isTrue);
+        expect(filtersWithKeywords.reviewers.isNone, isTrue);
       });
 
       test('fromQueryParams handles empty params', () {
@@ -472,7 +472,7 @@ void main() {
             },
           ),
           issues: const IntListFilter.list([1, 2]),
-          assignees: const IntListFilter.any(),
+          reviewers: const IntListFilter.any(),
           fromDate: DateTime.utc(2024, 1, 1),
           untilDate: DateTime.utc(2024, 12, 31),
           offset: 10,
@@ -494,7 +494,7 @@ void main() {
           ]),
         );
         expect(params['issues'], equals(['1', '2']));
-        expect(params['assignee_ids'], equals(['any']));
+        expect(params['reviewer_ids'], equals(['any']));
         expect(params['from_date'], equals(['2024-01-01T00:00:00.000Z']));
         expect(params['until_date'], equals(['2024-12-31T00:00:00.000Z']));
         expect(params['offset'], equals(['10']));
@@ -514,22 +514,22 @@ void main() {
       test('toQueryParams handles IntListFilter variants', () {
         final filtersWithList = TestResultsFilters(
           issues: const IntListFilter.list([1, 2]),
-          assignees: const IntListFilter.list([]),
+          reviewers: const IntListFilter.list([]),
         );
         final paramsWithList = filtersWithList.toQueryParams();
         expect(paramsWithList['issues'], equals(['1', '2']));
         expect(
-          paramsWithList.containsKey('assignee_ids'),
+          paramsWithList.containsKey('reviewer_ids'),
           isFalse,
         ); // empty list
 
         final filtersWithKeywords = TestResultsFilters(
           issues: const IntListFilter.any(),
-          assignees: const IntListFilter.none(),
+          reviewers: const IntListFilter.none(),
         );
         final paramsWithKeywords = filtersWithKeywords.toQueryParams();
         expect(paramsWithKeywords['issues'], equals(['any']));
-        expect(paramsWithKeywords['assignee_ids'], equals(['none']));
+        expect(paramsWithKeywords['reviewer_ids'], equals(['none']));
       });
     });
 
@@ -551,7 +551,7 @@ void main() {
             },
           ),
           issues: const IntListFilter.list([1, 2, 3]),
-          assignees: const IntListFilter.none(),
+          reviewers: const IntListFilter.none(),
           fromDate: DateTime.utc(2024, 1, 1),
           untilDate: DateTime.utc(2024, 12, 31),
           offset: 10,
@@ -575,7 +575,7 @@ void main() {
           equals(original.executionMetadata.data),
         );
         expect(restored.issues.values, equals(original.issues.values));
-        expect(restored.assignees.isNone, equals(original.assignees.isNone));
+        expect(restored.reviewers.isNone, equals(original.reviewers.isNone));
         expect(restored.fromDate, equals(original.fromDate));
         expect(restored.untilDate, equals(original.untilDate));
         expect(restored.offset, equals(original.offset));
@@ -652,13 +652,13 @@ void main() {
         expect(filters.hasFilters, isTrue);
       });
 
-      test('returns true when assignees is any', () {
-        const filters = TestResultsFilters(assignees: IntListFilter.any());
+      test('returns true when reviewers is any', () {
+        const filters = TestResultsFilters(reviewers: IntListFilter.any());
         expect(filters.hasFilters, isTrue);
       });
 
-      test('returns true when assignees is none', () {
-        const filters = TestResultsFilters(assignees: IntListFilter.none());
+      test('returns true when reviewers is none', () {
+        const filters = TestResultsFilters(reviewers: IntListFilter.none());
         expect(filters.hasFilters, isTrue);
       });
 
@@ -704,11 +704,11 @@ void main() {
       test('creates URI with IntListFilter variants', () {
         const filters = TestResultsFilters(
           issues: IntListFilter.any(),
-          assignees: IntListFilter.none(),
+          reviewers: IntListFilter.none(),
         );
         final uri = filters.toTestResultsUri();
         expect(uri.queryParameters['issues'], equals('any'));
-        expect(uri.queryParameters['assignee_ids'], equals('none'));
+        expect(uri.queryParameters['reviewer_ids'], equals('none'));
       });
     });
   });

--- a/frontend/test/providers/filtered_family_artefacts_test.dart
+++ b/frontend/test/providers/filtered_family_artefacts_test.dart
@@ -44,7 +44,7 @@ void main() {
     expect(filteredArtefacts, allArtefacts);
   });
 
-  test('it filters artefacts by assignees', () async {
+  test('it filters artefacts by reviewers', () async {
     final apiMock = ApiRepositoryMock();
     final container = createContainer(
       overrides: [apiProvider.overrideWith((ref) => apiMock)],
@@ -61,12 +61,40 @@ void main() {
       filteredFamilyArtefactsProvider(
         Uri(
           path: AppRoutes.snaps,
-          queryParameters: {'Assignee': firstArtefact.assignee.name},
+          queryParameters: {'Reviewer': firstArtefact.reviewers.first.name},
         ),
       ),
     );
 
     expect(filteredArtefacts, {firstArtefact.id: firstArtefact});
+  });
+
+  test('it filters artefacts by non-first reviewer', () async {
+    final apiMock = ApiRepositoryMock();
+    final container = createContainer(
+      overrides: [apiProvider.overrideWith((ref) => apiMock)],
+    );
+    const family = FamilyName.snap;
+
+    await container.read(familyArtefactsProvider(family).future);
+
+    final allArtefacts = await apiMock.getFamilyArtefacts(family);
+    final artefactWithMultipleReviewers =
+        allArtefacts.values.firstWhere((a) => a.reviewers.length > 1);
+    final secondReviewer = artefactWithMultipleReviewers.reviewers[1];
+
+    final filteredArtefacts = container.read(
+      filteredFamilyArtefactsProvider(
+        Uri(
+          path: AppRoutes.snaps,
+          queryParameters: {'Reviewer': secondReviewer.name},
+        ),
+      ),
+    );
+
+    expect(filteredArtefacts, {
+      artefactWithMultipleReviewers.id: artefactWithMultipleReviewers,
+    });
   });
 
   test('it filters artefacts by status', () async {

--- a/frontend/test/providers/page_filters_test.dart
+++ b/frontend/test/providers/page_filters_test.dart
@@ -42,10 +42,14 @@ void main() {
     final filters =
         container.read(pageFiltersProvider(Uri(path: AppRoutes.snaps)));
 
-    expect(filters[0].name, 'Assignee');
+    expect(filters[0].name, 'Reviewer');
     expect(
       filters[0].options,
-      [(name: dummyArtefact.assignee.name, isSelected: false)],
+      unorderedEquals(
+        dummyArtefact.reviewers
+            .map((r) => (name: r.name, isSelected: false))
+            .toList(),
+      ),
     );
     expect(filters[1].name, 'Status');
     expect(


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

Some time ago we changed the concept of assignee to reviewers in the backend. This was not followed at the time in the frontend, but now that we have multiple reviewers for some artefacts, this causes a bug where you can't filter by reviewers that are not the first assigned. This PR fixes that and moves away from the concept of assignee completely.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

TO-395

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->

Added unit tests and tested locally by creating an artefact with some reviewers and filtering by the last of them:

<img width="1839" height="1152" alt="image" src="https://github.com/user-attachments/assets/d7fb000c-b805-425d-828c-b4ac556a592e" />
<img width="780" height="160" alt="image" src="https://github.com/user-attachments/assets/7e697ddc-b6d0-40f2-b2f4-bbc4d213ce67" />

