### PR TITLE
[TO-393] Change default expansion settings

### DIFF
--- a/frontend/lib/ui/artefact_page/test_result_expandable.dart
+++ b/frontend/lib/ui/artefact_page/test_result_expandable.dart
@@ -89,8 +89,8 @@ class TestResultExpandable extends ConsumerWidget {
         ),
         _TestResultOutputExpandable(
           testResult: testResult,
-          initiallyExpanded: initiallyExpanded ||
-              testResult.status == TestResultStatus.failed,
+          initiallyExpanded:
+              initiallyExpanded || testResult.status == TestResultStatus.failed,
         ),
       ],
     );

--- a/frontend/lib/ui/artefact_page/test_result_expandable.dart
+++ b/frontend/lib/ui/artefact_page/test_result_expandable.dart
@@ -89,7 +89,7 @@ class TestResultExpandable extends ConsumerWidget {
         ),
         _TestResultOutputExpandable(
           testResult: testResult,
-          initiallyExpanded: initiallyExpanded,
+          initiallyExpanded: true,
         ),
       ],
     );

--- a/frontend/lib/ui/artefact_page/test_result_expandable.dart
+++ b/frontend/lib/ui/artefact_page/test_result_expandable.dart
@@ -89,7 +89,8 @@ class TestResultExpandable extends ConsumerWidget {
         ),
         _TestResultOutputExpandable(
           testResult: testResult,
-          initiallyExpanded: true,
+          initiallyExpanded: initiallyExpanded ||
+              testResult.status == TestResultStatus.failed,
         ),
       ],
     );

--- a/frontend/lib/ui/artefact_page/test_result_filter_expandable.dart
+++ b/frontend/lib/ui/artefact_page/test_result_filter_expandable.dart
@@ -55,7 +55,9 @@ class TestResultsFilterExpandable extends ConsumerWidget {
             filteredResults.any((result) => result.id == testResultIdToExpand);
 
         return SliverExpandable(
-          initiallyExpanded: shouldExpandStatus,
+          initiallyExpanded: shouldExpandStatus ||
+              (statusToFilterBy == TestResultStatus.failed &&
+                  filteredResults.isNotEmpty),
           title: Row(
             children: [
               TestResultHelpers.getStatusIcon(statusToFilterBy),


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR changes some of the default expansion settings such that failed results are automatically expanded under test executions, and the details of failed test cases are automatically expanded within test results.

Since failures are generally what users are most interested in, automatically expanding these reduces the amount of effort required from users to view information of interest.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

[TO-393]

## Tests

Tested manually. Things look correct

[TO-393]: https://warthogs.atlassian.net/browse/TO-393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ