### PR TITLE
feat: add artefact.attributes JSONB column (expand) [1/3]

### DIFF
--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -57,6 +57,10 @@ jobs:
       - name: Check if alembic migrations are up to date
         run: docker compose exec test-observer-api alembic check
       - name: Compare schema with repository
-        run: diff <(curl -s http://localhost:30000/openapi.json | jq) schemata/openapi.json
+        # Normalise integer-valued floats so the comparison is stable across jq
+        # versions (jq 1.6 on jammy canonicalises 1000000.0 -> 1000000 while jq
+        # 1.7 preserves the literal). Keep this filter in sync with
+        # scripts/fetch_openapi_schema.sh.
+        run: diff <(curl -s http://localhost:30000/openapi.json | jq 'walk(if type == "number" and floor == . then floor else . end)') schemata/openapi.json
       - name: Ensure all endpoints are secured
         run: ./scripts/check_endpoint_permissions.sh schemata/openapi.json

--- a/backend/migrations/versions/2026_08_17_1723-6e262c3c6c8f_add_artefact_attributes.py
+++ b/backend/migrations/versions/2026_08_17_1723-6e262c3c6c8f_add_artefact_attributes.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Add artefact.attributes
+
+This is the first (expand) step of adding a generic ``attributes`` field to
+artefacts. It only adds the new column with an empty-object default so that
+code running against the old schema keeps working during a rolling upgrade.
+
+Backfilling existing data into ``attributes`` and switching the code to read
+from it happen in later, separately deployed migrations.
+
+Revision ID: 6e262c3c6c8f
+Revises: eba1d1c92dba
+Create Date: 2026-08-17 17:23:00.000000+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "6e262c3c6c8f"
+down_revision = "eba1d1c92dba"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("artefact", sa.Column("attributes", postgresql.JSONB(), server_default="{}", nullable=False))
+
+
+def downgrade() -> None:
+    op.drop_column("artefact", "attributes")

--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -6530,6 +6530,11 @@
             "type": "string",
             "title": "Comment"
           },
+          "attributes": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Attributes"
+          },
           "archived": {
             "type": "boolean",
             "title": "Archived"
@@ -6621,6 +6626,7 @@
           "family",
           "status",
           "comment",
+          "attributes",
           "archived",
           "reviewers",
           "due_date",

--- a/backend/scripts/fetch_openapi_schema.sh
+++ b/backend/scripts/fetch_openapi_schema.sh
@@ -23,8 +23,13 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR/.."
 
 tmpfile=$(mktemp)
+# Normalise integer-valued floats (e.g. 1000000.0 -> 1000000) so the committed
+# schema is stable across jq versions. jq 1.7 preserves number literals while
+# jq 1.6 (used on the jammy CI runner) canonicalises them, which otherwise
+# causes spurious diffs in the "Compare schema with repository" CI step.
+normalise='walk(if type == "number" and floor == . then floor else . end)'
 if curl --silent --fail "http://localhost:30000/openapi.json" -o "$tmpfile"; then
-    jq < "$tmpfile" > schemata/openapi.json
+    jq "$normalise" < "$tmpfile" > schemata/openapi.json
     echo "OpenAPI schema fetched and written to schemata/openapi.json"
 else
     echo "Failed to fetch openapi.json"

--- a/backend/test_observer/controllers/artefacts/models.py
+++ b/backend/test_observer/controllers/artefacts/models.py
@@ -71,6 +71,7 @@ class ArtefactResponse(BaseModel):
     family: str
     status: ArtefactStatus
     comment: str
+    attributes: dict[str, Any]
     archived: bool
     reviewers: list[ReviewerResponse]
     due_date: date | None

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -38,8 +38,9 @@ from sqlalchemy import (
     exists,
     select,
 )
-from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import (
     DeclarativeBase,
     Mapped,
@@ -353,6 +354,7 @@ class Artefact(Base):
         secondary=artefact_reviewers_association, back_populates="artefact_reviews"
     )
 
+    attributes: Mapped[dict[str, Any]] = mapped_column(MutableDict.as_mutable(JSONB), default=dict, server_default="{}")
     jira_issue: Mapped[str | None] = mapped_column(default=None)
 
     @property

--- a/backend/tests/controllers/artefacts/test_artefacts.py
+++ b/backend/tests/controllers/artefacts/test_artefacts.py
@@ -1187,6 +1187,7 @@ def _assert_get_artefact_response(response: dict[str, Any], artefact: Artefact) 
         "image_url": artefact.image_url,
         "status": artefact.status,
         "comment": artefact.comment,
+        "attributes": artefact.attributes,
         "archived": artefact.archived,
         "family": artefact.family,
         "assignee": assignee,

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -183,6 +183,7 @@ def test_execution_to_pending_rerun(test_execution: TestExecution, priority: int
             ),
             "family": test_execution.artefact_build.artefact.family,
             "created_at": (test_execution.artefact_build.artefact.created_at.isoformat()),
+            "attributes": test_execution.artefact_build.artefact.attributes,
         },
         "artefact_build": {
             "id": test_execution.artefact_build.id,

--- a/backend/tests/data_access/test_models.py
+++ b/backend/tests/data_access/test_models.py
@@ -14,9 +14,11 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 import pytest
+from sqlalchemy.orm import Session
 
 from test_observer.data_access.models import Issue
-from test_observer.data_access.models_enums import IssueSource
+from test_observer.data_access.models_enums import FamilyName, IssueSource
+from tests.data_generator import DataGenerator
 
 
 @pytest.mark.parametrize(
@@ -52,3 +54,21 @@ def test_issue_url(
         assert expected is None
     else:
         assert result == expected
+
+
+def test_artefact_attributes_defaults_to_empty_dict(generator: DataGenerator, db_session: Session) -> None:
+    artefact = generator.gen_artefact(family=FamilyName.snap)
+    db_session.refresh(artefact)
+
+    assert artefact.attributes == {}
+
+
+def test_artefact_attributes_persists_arbitrary_data(generator: DataGenerator, db_session: Session) -> None:
+    artefact = generator.gen_artefact(family=FamilyName.snap)
+
+    artefact.attributes["track"] = "latest"
+    artefact.attributes["bundled_builds"] = [1, 2, 3]
+    db_session.commit()
+    db_session.refresh(artefact)
+
+    assert artefact.attributes == {"track": "latest", "bundled_builds": [1, 2, 3]}


### PR DESCRIPTION
Part 1 of 3 (stacked) — splitting `TO-404/remove-solution-specific-fields` into rolling-upgrade-safe expand/contract steps.

## What
**Expand step**: introduce a generic `attributes` JSONB field on artefacts, without changing any behaviour.

- Add the `attributes` column via a non-destructive migration (add column only, empty-object default).
- Map `attributes` on the `Artefact` ORM model and expose it read-only on `ArtefactResponse`.
- All existing solution-specific fields/mappings are left untouched, so old code keeps working during a rolling upgrade.
- Normalise integer-valued floats when fetching the OpenAPI schema so the committed schema is stable across `jq` versions in CI.

## Safety
No-op for clients: nothing writes to or reads from `attributes` yet.

## Stacked PR order
1. **This PR** → `main`
2. `TO-404/2-write-both` → `TO-404/1-add-attributes`
3. `TO-404/3-migrate-read-new` → `TO-404/2-write-both`

Each must be merged **and deployed** before the next (expand/contract rolling-upgrade requirement).
