### PR TITLE
[SQT-728] Improve Artefact page load performance

### DIFF
--- a/backend/test_observer/controllers/artefacts/builds.py
+++ b/backend/test_observer/controllers/artefacts/builds.py
@@ -13,19 +13,20 @@
 # SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
 # SPDX-License-Identifier: AGPL-3.0-only
 
-from fastapi import APIRouter, Depends, Security
-from sqlalchemy.orm import selectinload
+from fastapi import APIRouter, Depends, HTTPException, Security
+from sqlalchemy.orm import Session, selectinload
 
 from test_observer.common.enums import Permission
 from test_observer.common.permissions import permission_checker
-from test_observer.controllers.artefacts.artefact_retriever import ArtefactRetriever
 from test_observer.controllers.test_executions.test_execution import (
-    TEST_EXECUTION_OPTIONS,
+    ARTEFACT_BUILD_TEST_EXECUTION_OPTIONS,
 )
 from test_observer.data_access.models import (
     Artefact,
     ArtefactBuild,
 )
+from test_observer.data_access.queries import latest_artefact_builds
+from test_observer.data_access.setup import get_db
 
 from .models import (
     ArtefactBuildResponse,
@@ -40,15 +41,22 @@ router = APIRouter(tags=["artefact-builds"])
     dependencies=[Security(permission_checker, scopes=[Permission.view_artefact])],
 )
 def get_artefact_builds(
-    artefact: Artefact = Depends(
-        ArtefactRetriever(
-            selectinload(Artefact.builds).selectinload(ArtefactBuild.test_executions).options(*TEST_EXECUTION_OPTIONS),
-            selectinload(Artefact.builds).selectinload(ArtefactBuild.bundled_in),
-        )
-    ),
+    artefact_id: int,
+    db: Session = Depends(get_db),
 ):
     """Get latest artefact builds of an artefact together with their test executions"""
-    for artefact_build in artefact.latest_builds:
+    artefact = db.get(Artefact, artefact_id)
+    if artefact is None:
+        raise HTTPException(status_code=404, detail=f"Artefact with id {artefact_id} not found")
+
+    latest_builds = db.scalars(
+        latest_artefact_builds.where(ArtefactBuild.artefact_id == artefact_id).options(
+            selectinload(ArtefactBuild.test_executions).options(*ARTEFACT_BUILD_TEST_EXECUTION_OPTIONS),
+            selectinload(ArtefactBuild.bundled_in),
+        )
+    ).all()
+
+    for artefact_build in latest_builds:
         artefact_build.test_executions.sort(key=lambda test_execution: test_execution.environment.name)
 
-    return artefact.latest_builds
+    return latest_builds

--- a/backend/test_observer/controllers/artefacts/builds.py
+++ b/backend/test_observer/controllers/artefacts/builds.py
@@ -45,16 +45,15 @@ def get_artefact_builds(
     db: Session = Depends(get_db),
 ):
     """Get latest artefact builds of an artefact together with their test executions"""
-    artefact = db.get(Artefact, artefact_id)
-    if artefact is None:
-        raise HTTPException(status_code=404, detail=f"Artefact with id {artefact_id} not found")
-
     latest_builds = db.scalars(
         latest_artefact_builds.where(ArtefactBuild.artefact_id == artefact_id).options(
             selectinload(ArtefactBuild.test_executions).options(*ARTEFACT_BUILD_TEST_EXECUTION_OPTIONS),
             selectinload(ArtefactBuild.bundled_in),
         )
     ).all()
+
+    if not latest_builds and db.get(Artefact, artefact_id) is None:
+        raise HTTPException(status_code=404, detail=f"Artefact with id {artefact_id} not found")
 
     for artefact_build in latest_builds:
         artefact_build.test_executions.sort(key=lambda test_execution: test_execution.environment.name)

--- a/backend/test_observer/controllers/artefacts/environment_reviews.py
+++ b/backend/test_observer/controllers/artefacts/environment_reviews.py
@@ -19,12 +19,12 @@ from sqlalchemy.orm import Session, selectinload
 
 from test_observer.common.enums import Permission
 from test_observer.common.permissions import permission_checker
-from test_observer.controllers.artefacts.artefact_retriever import ArtefactRetriever
 from test_observer.data_access.models import (
     Artefact,
     ArtefactBuild,
     ArtefactBuildEnvironmentReview,
 )
+from test_observer.data_access.queries import latest_artefact_builds
 from test_observer.data_access.setup import get_db
 
 from .models import (
@@ -41,15 +41,20 @@ router = APIRouter(tags=["environment-reviews"])
     dependencies=[Security(permission_checker, scopes=[Permission.view_environment_review])],
 )
 def get_environment_reviews(
-    artefact: Artefact = Depends(
-        ArtefactRetriever(
-            selectinload(Artefact.builds)
-            .selectinload(ArtefactBuild.environment_reviews)
-            .selectinload(ArtefactBuildEnvironmentReview.reviewers)
-        )
-    ),
+    artefact_id: int,
+    db: Session = Depends(get_db),
 ):
-    return [review for build in artefact.latest_builds for review in build.environment_reviews]
+    artefact = db.get(Artefact, artefact_id)
+    if artefact is None:
+        raise HTTPException(status_code=404, detail=f"Artefact with id {artefact_id} not found")
+
+    latest_builds = db.scalars(
+        latest_artefact_builds.where(ArtefactBuild.artefact_id == artefact_id).options(
+            selectinload(ArtefactBuild.environment_reviews).selectinload(ArtefactBuildEnvironmentReview.reviewers)
+        )
+    ).all()
+
+    return [review for build in latest_builds for review in build.environment_reviews]
 
 
 @router.patch(

--- a/backend/test_observer/controllers/artefacts/environment_reviews.py
+++ b/backend/test_observer/controllers/artefacts/environment_reviews.py
@@ -44,15 +44,14 @@ def get_environment_reviews(
     artefact_id: int,
     db: Session = Depends(get_db),
 ):
-    artefact = db.get(Artefact, artefact_id)
-    if artefact is None:
-        raise HTTPException(status_code=404, detail=f"Artefact with id {artefact_id} not found")
-
     latest_builds = db.scalars(
         latest_artefact_builds.where(ArtefactBuild.artefact_id == artefact_id).options(
             selectinload(ArtefactBuild.environment_reviews).selectinload(ArtefactBuildEnvironmentReview.reviewers)
         )
     ).all()
+
+    if not latest_builds and db.get(Artefact, artefact_id) is None:
+        raise HTTPException(status_code=404, detail=f"Artefact with id {artefact_id} not found")
 
     return [review for build in latest_builds for review in build.environment_reviews]
 

--- a/backend/test_observer/controllers/test_executions/test_execution.py
+++ b/backend/test_observer/controllers/test_executions/test_execution.py
@@ -34,7 +34,7 @@ from test_observer.data_access.setup import get_db
 from .models import TestExecutionsPatchRequest
 from .router import router
 
-TEST_EXECUTION_OPTIONS = [
+BASE_TEST_EXECUTION_OPTIONS = [
     # Single-query Joins (Many-to-One)
     joinedload(TestExecution.environment),
     joinedload(TestExecution.rerun_request),
@@ -42,6 +42,14 @@ TEST_EXECUTION_OPTIONS = [
     # Separate-query Collections (One-to-Many / Many-to-Many)
     selectinload(TestExecution.execution_metadata),
     selectinload(TestExecution.relevant_links),
+]
+
+ARTEFACT_BUILD_TEST_EXECUTION_OPTIONS = [
+    *BASE_TEST_EXECUTION_OPTIONS,
+]
+
+TEST_EXECUTION_OPTIONS = [
+    *BASE_TEST_EXECUTION_OPTIONS,
     # Needed by patch_test_execution to determine test execution status
     selectinload(TestExecution.test_results),
 ]

--- a/backend/test_observer/data_access/queries.py
+++ b/backend/test_observer/data_access/queries.py
@@ -25,7 +25,7 @@ latest_artefact_builds = (
     .order_by(
         ArtefactBuild.artefact_id,
         ArtefactBuild.architecture,
-        func.coalesce(ArtefactBuild.revision, 0).desc(),
+        ArtefactBuild.revision.desc().nullslast(),
     )
 )
 

--- a/backend/test_observer/data_access/queries.py
+++ b/backend/test_observer/data_access/queries.py
@@ -25,7 +25,7 @@ latest_artefact_builds = (
     .order_by(
         ArtefactBuild.artefact_id,
         ArtefactBuild.architecture,
-        ArtefactBuild.revision.desc(),
+        func.coalesce(ArtefactBuild.revision, 0).desc(),
     )
 )
 


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR tweaks the loading options for fetching the latest builds to do some context-dependent loading while also making use of a shared query in more locations. Testing locally with a dump of the Artefact that originally prompted the ticket, I see the the following:

Endpoint | branch | average wait time (seconds)
--- | --- |---
v1/artefacts/{id}/builds | main | 2.568 
v1/artefacts/{id}/builds | this | 0.2648
v1/artefacts/{id}/environment-reviews | main | 2.016
v1/artefacts/{id}/environment-reviews | this | 0.3528

So this should significantly improve the performance of these endpoints. There might be additional optimizations worth looking at in the future, but this should suffice for now.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

[SQT-728]

## Tests

No real behavior is changing, but local testing suggests there is indeed a performance improvement

[SQT-728]: https://warthogs.atlassian.net/browse/SQT-728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ