### PR TITLE
[Add] test_plans matching and complete artefact filter parity

### DIFF
--- a/backend/migrations/versions/2026_08_25_1653-a2cce585712b_add_test_plans_to_attachment_rules.py
+++ b/backend/migrations/versions/2026_08_25_1653-a2cce585712b_add_test_plans_to_attachment_rules.py
@@ -1,0 +1,43 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Add test_plans to attachment rules
+
+Revision ID: a2cce585712b
+Revises: eba1d1c92dba
+Create Date: 2026-08-25 16:53:14.299864+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "a2cce585712b"
+down_revision = "eba1d1c92dba"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "issue_test_result_attachment_rule",
+        sa.Column("test_plans", postgresql.ARRAY(sa.String()), nullable=False, server_default="{}"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("issue_test_result_attachment_rule", "test_plans")

--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -755,6 +755,27 @@
             "description": "Filter by environment names"
           },
           {
+            "name": "test_plans",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by test plan names",
+              "title": "Test Plans"
+            },
+            "description": "Filter by test plan names"
+          },
+          {
             "name": "test_execution_statuses",
             "in": "query",
             "required": false,
@@ -2663,6 +2684,109 @@
         ]
       }
     },
+    "/v1/test-plans": {
+      "get": {
+        "tags": [
+          "test-plans"
+        ],
+        "summary": "Get Test Plans",
+        "description": "Returns list of distinct test plan names that have been used in test executions.\n\nSupports pagination and search filtering.",
+        "operationId": "get_test_plans_v1_test_plans_get",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Search term for test plan names",
+              "title": "Q"
+            },
+            "description": "Search term for test plan names"
+          },
+          {
+            "name": "families",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FamilyName"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by artefact families",
+              "title": "Families"
+            },
+            "description": "Filter by artefact families"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "description": "Maximum number of results (defaults to 50 if not specified)",
+              "default": 50,
+              "title": "Limit"
+            },
+            "description": "Maximum number of results (defaults to 50 if not specified)"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Number of results to skip for pagination",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Number of results to skip for pagination"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestPlansResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-permissions": [
+          "view_test"
+        ]
+      }
+    },
     "/v1/issues/{issue_id}/attach": {
       "post": {
         "tags": [
@@ -3439,6 +3563,27 @@
               "title": "Environments"
             },
             "description": "Filter by environment names"
+          },
+          {
+            "name": "test_plans",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by test plan names",
+              "title": "Test Plans"
+            },
+            "description": "Filter by test plan names"
           },
           {
             "name": "test_cases",
@@ -7395,6 +7540,13 @@
             "type": "array",
             "title": "Environment Names"
           },
+          "test_plans": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Test Plans"
+          },
           "test_case_names": {
             "items": {
               "type": "string"
@@ -7592,6 +7744,13 @@
             "type": "array",
             "title": "Environment Names"
           },
+          "test_plans": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Test Plans"
+          },
           "test_case_names": {
             "items": {
               "type": "string"
@@ -7627,6 +7786,7 @@
           "artefact_stages",
           "artefact_tracks",
           "environment_names",
+          "test_plans",
           "test_case_names",
           "template_ids",
           "test_result_statuses",
@@ -8886,6 +9046,13 @@
             "type": "array",
             "title": "Environments"
           },
+          "test_plans": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Test Plans"
+          },
           "test_execution_statuses": {
             "items": {
               "$ref": "#/components/schemas/TestExecutionStatus"
@@ -9286,6 +9453,38 @@
         "type": "object",
         "title": "TestExecutionsPatchRequest"
       },
+      "TestPlansResponse": {
+        "properties": {
+          "test_plans": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Test Plans"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          }
+        },
+        "type": "object",
+        "required": [
+          "test_plans",
+          "count",
+          "limit",
+          "offset"
+        ],
+        "title": "TestPlansResponse",
+        "description": "Response model for test plans endpoint"
+      },
       "TestReportedIssueRequest": {
         "properties": {
           "template_id": {
@@ -9560,6 +9759,13 @@
             },
             "type": "array",
             "title": "Template Ids"
+          },
+          "test_plans": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Test Plans"
           },
           "execution_metadata": {
             "$ref": "#/components/schemas/ExecutionMetadata"

--- a/backend/test_observer/controllers/issues/attachment_rules.py
+++ b/backend/test_observer/controllers/issues/attachment_rules.py
@@ -59,6 +59,7 @@ def post_attachment_rule(
         artefact_stages=request.artefact_stages,
         artefact_tracks=request.artefact_tracks,
         environment_names=request.environment_names,
+        test_plans=request.test_plans,
         test_case_names=request.test_case_names,
         template_ids=request.template_ids,
         test_result_statuses=request.test_result_statuses,

--- a/backend/test_observer/controllers/issues/attachment_rules_logic.py
+++ b/backend/test_observer/controllers/issues/attachment_rules_logic.py
@@ -153,6 +153,14 @@ def query_matching_test_result_attachment_rules(
         )
     )
 
+    # Filter test_plans
+    stmt = stmt.where(
+        _array_empty_or_contains(
+            IssueTestResultAttachmentRule.test_plans,
+            literal(test_result.test_execution.test_plan.name),
+        )
+    )
+
     # Filter test_case_names
     stmt = stmt.where(
         _array_empty_or_contains(

--- a/backend/test_observer/controllers/issues/models.py
+++ b/backend/test_observer/controllers/issues/models.py
@@ -63,6 +63,7 @@ class IssueTestResultAttachmentRulePostRequest(BaseModel):
     artefact_stages: list[str] = Field(default_factory=list)
     artefact_tracks: list[str] = Field(default_factory=list)
     environment_names: list[str] = Field(default_factory=list)
+    test_plans: list[str] = Field(default_factory=list)
     test_case_names: list[str] = Field(default_factory=list)
     template_ids: list[str] = Field(default_factory=list)
     test_result_statuses: list[TestResultStatus] = Field(default_factory=list)

--- a/backend/test_observer/controllers/issues/shared_models.py
+++ b/backend/test_observer/controllers/issues/shared_models.py
@@ -63,6 +63,7 @@ class MinimalIssueTestResultAttachmentRuleResponse(BaseModel):
     artefact_stages: list[str]
     artefact_tracks: list[str]
     environment_names: list[str]
+    test_plans: list[str]
     test_case_names: list[str]
     template_ids: list[str]
     test_result_statuses: list[TestResultStatus]

--- a/backend/test_observer/controllers/router.py
+++ b/backend/test_observer/controllers/router.py
@@ -33,6 +33,7 @@ from . import (
     reports,
     test_cases,
     test_executions,
+    test_plans,
     test_results,
 )
 from .application import version
@@ -49,6 +50,7 @@ router.include_router(artefacts.router, prefix="/v1/artefacts")
 router.include_router(reports.router, prefix="/v1/reports")
 router.include_router(test_cases.router, prefix="/v1/test-cases")
 router.include_router(environments.router, prefix="/v1/environments")
+router.include_router(test_plans.router, prefix="/v1/test-plans")
 router.include_router(issues.router, prefix="/v1/issues")
 router.include_router(test_results.router, prefix="/v1/test-results")
 router.include_router(execution_metadata.router, prefix="/v1/execution-metadata")

--- a/backend/test_observer/controllers/test_executions/execution_filters.py
+++ b/backend/test_observer/controllers/test_executions/execution_filters.py
@@ -36,11 +36,12 @@ from test_observer.data_access.models import (
     TestExecution,
     TestExecutionMetadata,
     TestExecutionRerunRequest,
+    TestPlan,
     User,
     test_execution_metadata_association_table,
 )
 
-JoinName = Literal["artefact_build", "artefact", "environment"]
+JoinName = Literal["artefact_build", "artefact", "environment", "test_plan"]
 
 
 def filter_execution_metadata(
@@ -97,6 +98,10 @@ def build_execution_filters(
     if filters.environments:
         query_filters.append(Environment.name.in_(filters.environments))
         joins_needed.add("environment")
+
+    if filters.test_plans:
+        query_filters.append(TestPlan.name.in_(filters.test_plans))
+        joins_needed.add("test_plan")
 
     if filters.execution_metadata and len(filters.execution_metadata) > 0:
         query_filters.append(filter_execution_metadata(filters.execution_metadata))
@@ -174,4 +179,6 @@ def apply_te_joins(query: Select, joins_needed: set[JoinName]) -> Select:
         query = query.join(ArtefactBuild.artefact)
     if "environment" in joins_needed:
         query = query.join(TestExecution.environment)
+    if "test_plan" in joins_needed:
+        query = query.join(TestExecution.test_plan)
     return query

--- a/backend/test_observer/controllers/test_executions/search.py
+++ b/backend/test_observer/controllers/test_executions/search.py
@@ -246,6 +246,10 @@ def search_test_executions(
         list[str] | None,
         Query(description="Filter by environment names"),
     ] = None,
+    test_plans: Annotated[
+        list[str] | None,
+        Query(description="Filter by test plan names"),
+    ] = None,
     execution_metadata: Annotated[ExecutionMetadata | None, Depends(parse_execution_metadata)] = None,
     test_execution_statuses: Annotated[
         list[TestExecutionStatus] | None,
@@ -320,6 +324,7 @@ def search_test_executions(
         artefact_tracks=artefact_tracks or [],
         artefact_is_archived=artefact_is_archived,
         environments=environments or [],
+        test_plans=test_plans or [],
         execution_metadata=execution_metadata or ExecutionMetadata(),
         test_execution_statuses=test_execution_statuses or [],
         reviewer_ids=parse_list_or_query_value(reviewer_ids),  # type: ignore[arg-type]

--- a/backend/test_observer/controllers/test_executions/shared_models.py
+++ b/backend/test_observer/controllers/test_executions/shared_models.py
@@ -71,6 +71,7 @@ class TestExecutionFilterBase(BaseModel):
     artefact_tracks: list[str] = Field(default_factory=list)
     artefact_is_archived: bool | None = None
     environments: list[str] = Field(default_factory=list)
+    test_plans: list[str] = Field(default_factory=list)
     test_execution_statuses: list[TestExecutionStatus] = Field(default_factory=list)
     execution_metadata: ExecutionMetadata = Field(default_factory=ExecutionMetadata)
     reviewer_ids: list[int] | Literal[QueryValue.ANY, QueryValue.NONE] = Field(default_factory=list)

--- a/backend/test_observer/controllers/test_plans/__init__.py
+++ b/backend/test_observer/controllers/test_plans/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from .test_plans import router
+
+__all__ = ["router"]

--- a/backend/test_observer/controllers/test_plans/models.py
+++ b/backend/test_observer/controllers/test_plans/models.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from pydantic import BaseModel
+
+
+class TestPlansResponse(BaseModel):
+    """Response model for test plans endpoint"""
+
+    test_plans: list[str]
+    count: int
+    limit: int
+    offset: int

--- a/backend/test_observer/controllers/test_plans/test_plans.py
+++ b/backend/test_observer/controllers/test_plans/test_plans.py
@@ -1,0 +1,100 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query, Security
+from sqlalchemy import distinct, func, select
+from sqlalchemy.orm import Session
+
+from test_observer.common.enums import Permission
+from test_observer.common.permissions import permission_checker
+from test_observer.data_access.models import (
+    Artefact,
+    ArtefactBuild,
+    TestExecution,
+    TestPlan,
+)
+from test_observer.data_access.models_enums import FamilyName
+from test_observer.data_access.setup import get_db
+
+from .models import TestPlansResponse
+
+router = APIRouter(tags=["test-plans"])
+
+
+@router.get(
+    "",
+    response_model=TestPlansResponse,
+    dependencies=[Security(permission_checker, scopes=[Permission.view_test])],
+)
+def get_test_plans(
+    q: Annotated[
+        str | None,
+        Query(description="Search term for test plan names"),
+    ] = None,
+    families: Annotated[
+        list[FamilyName] | None,
+        Query(description="Filter by artefact families"),
+    ] = None,
+    limit: Annotated[
+        int,
+        Query(
+            ge=1,
+            le=1000,
+            description="Maximum number of results (defaults to 50 if not specified)",
+        ),
+    ] = 50,
+    offset: Annotated[
+        int,
+        Query(ge=0, description="Number of results to skip for pagination"),
+    ] = 0,
+    db: Session = Depends(get_db),
+) -> TestPlansResponse:
+    """
+    Returns list of distinct test plan names that have been used in test executions.
+
+    Supports pagination and search filtering.
+    """
+    query = select(distinct(TestPlan.name)).order_by(TestPlan.name)
+
+    # Filter by families if provided
+    if families and len(families) > 0:
+        query = (
+            query.join(TestExecution, TestExecution.test_plan_id == TestPlan.id)
+            .join(ArtefactBuild, ArtefactBuild.id == TestExecution.artefact_build_id)
+            .join(Artefact, Artefact.id == ArtefactBuild.artefact_id)
+            .where(Artefact.family.in_(families))
+        )
+
+    # Apply search filter if provided
+    if q and q.strip():
+        search_term = f"%{q.strip()}%"
+        query = query.where(TestPlan.name.ilike(search_term))
+
+    # Count total before pagination
+    count_query = select(func.count()).select_from(query.subquery())
+    total_count = db.execute(count_query).scalar() or 0
+
+    # Apply pagination
+    query = query.offset(offset).limit(limit)
+
+    test_plans = db.execute(query).scalars().all()
+    return TestPlansResponse(
+        test_plans=list(test_plans),
+        count=total_count,
+        limit=limit,
+        offset=offset,
+    )

--- a/backend/test_observer/controllers/test_results/filter_test_results.py
+++ b/backend/test_observer/controllers/test_results/filter_test_results.py
@@ -29,6 +29,7 @@ from test_observer.data_access.models import (
     TestExecution,
     TestExecutionMetadata,
     TestExecutionRerunRequest,
+    TestPlan,
     TestResult,
     User,
     test_execution_metadata_association_table,
@@ -91,6 +92,10 @@ def build_query_filters_and_joins(
     if len(filters.environments) > 0:
         query_filters.append(Environment.name.in_(filters.environments))
         joins_needed.update(["test_execution", "environment"])
+
+    if len(filters.test_plans) > 0:
+        query_filters.append(TestPlan.name.in_(filters.test_plans))
+        joins_needed.update(["test_execution", "test_plan"])
 
     if len(filters.test_cases) > 0:
         query_filters.append(TestCase.name.in_(filters.test_cases))
@@ -200,6 +205,9 @@ def apply_joins(query: Select, joins_needed: set[str]) -> Select:
 
     if "test_case" in joins_needed:
         query = query.join(TestResult.test_case)
+
+    if "test_plan" in joins_needed:
+        query = query.join(TestExecution.test_plan)
 
     return query
 

--- a/backend/test_observer/controllers/test_results/shared_models.py
+++ b/backend/test_observer/controllers/test_results/shared_models.py
@@ -37,6 +37,7 @@ class TestResultSearchFilters(BaseModel):
     environments: list[str] = Field(default_factory=list)
     test_cases: list[str] = Field(default_factory=list)
     template_ids: list[str] = Field(default_factory=list)
+    test_plans: list[str] = Field(default_factory=list)
     execution_metadata: ExecutionMetadata = Field(default_factory=ExecutionMetadata)
     issues: list[int] | Literal[QueryValue.ANY, QueryValue.NONE] = Field(default_factory=list)
     test_result_statuses: list[TestResultStatus] = Field(default_factory=list)

--- a/backend/test_observer/controllers/test_results/test_results.py
+++ b/backend/test_observer/controllers/test_results/test_results.py
@@ -195,6 +195,10 @@ def search_test_results(
         list[str] | None,
         Query(description="Filter by environment names"),
     ] = None,
+    test_plans: Annotated[
+        list[str] | None,
+        Query(description="Filter by test plan names"),
+    ] = None,
     test_cases: Annotated[
         list[str] | None,
         Query(description="Filter by test case names"),
@@ -254,6 +258,7 @@ def search_test_results(
         environments=environments or [],
         test_cases=test_cases or [],
         template_ids=template_ids or [],
+        test_plans=test_plans or [],
         execution_metadata=execution_metadata or ExecutionMetadata(),
         issues=parse_list_or_query_value(issues),  # type: ignore[arg-type]
         test_result_statuses=test_result_statuses or [],

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -962,6 +962,7 @@ class IssueTestResultAttachmentRule(Base):
     artefact_stages: Mapped[list[str]] = mapped_column(ARRAY(String), nullable=False, default=list)
     artefact_tracks: Mapped[list[str]] = mapped_column(ARRAY(String), nullable=False, default=list)
     environment_names: Mapped[list[str]] = mapped_column(ARRAY(String), nullable=False, default=list)
+    test_plans: Mapped[list[str]] = mapped_column(ARRAY(String), nullable=False, default=list)
     test_case_names: Mapped[list[str]] = mapped_column(ARRAY(String), nullable=False, default=list)
     template_ids: Mapped[list[str]] = mapped_column(ARRAY(String), nullable=False, default=list)
     execution_metadata: Mapped[list["IssueTestResultAttachmentRuleExecutionMetadata"]] = relationship(

--- a/backend/tests/controllers/issues/test_attachment_rules.py
+++ b/backend/tests/controllers/issues/test_attachment_rules.py
@@ -49,6 +49,7 @@ def post_attachment_rule():
         "enabled": True,
         "families": ["charm"],
         "environment_names": ["environment-1"],
+        "test_plans": ["test-plan-1"],
         "test_case_names": ["test-case-1"],
         "template_ids": ["template-id-1"],
         "execution_metadata": {"category-1": ["value-1", "value-2"]},
@@ -69,6 +70,7 @@ def _assert_attachment_rule_response(
         "artefact_stages",
         "artefact_tracks",
         "environment_names",
+        "test_plans",
         "test_case_names",
         "template_ids",
         "test_result_statuses",
@@ -78,6 +80,7 @@ def _assert_attachment_rule_response(
     assert json["enabled"] == model.enabled
     assert sorted(json["families"]) == sorted(model.families)
     assert sorted(json["environment_names"]) == sorted(model.environment_names)
+    assert sorted(json["test_plans"]) == sorted(model.test_plans)
     assert sorted(json["test_case_names"]) == sorted(model.test_case_names)
     assert sorted(json["template_ids"]) == sorted(model.template_ids)
     assert [s.name for s in sorted(json["test_result_statuses"])] == [

--- a/backend/tests/controllers/issues/test_attachment_rules_logic.py
+++ b/backend/tests/controllers/issues/test_attachment_rules_logic.py
@@ -61,6 +61,14 @@ params_query_matching_test_result_attachment_rules: list[dict] = [
         ],
     },
     {
+        "label": "match_test_plan",
+        "attachment_rules": [
+            (True, {"test_plans": ["Test plan"]}),
+            (True, {"test_plans": ["Test plan", "other-plan"]}),
+            (False, {"test_plans": ["other-plan"]}),
+        ],
+    },
+    {
         "label": "match_test_case_name",
         "attachment_rules": [
             (True, {"test_case_names": ["camera/detect"]}),
@@ -222,6 +230,7 @@ def test_query_matching_test_result_attachment_rules(
             artefact_stages=spec.get("artefact_stages", []),
             artefact_tracks=spec.get("artefact_tracks", []),
             environment_names=spec.get("environment_names", []),
+            test_plans=spec.get("test_plans", []),
             test_case_names=spec.get("test_case_names", []),
             template_ids=spec.get("template_ids", []),
             execution_metadata=[

--- a/backend/tests/controllers/test_executions/test_get_test_results.py
+++ b/backend/tests/controllers/test_executions/test_get_test_results.py
@@ -269,6 +269,7 @@ def test_attachment_rule_listed_in_issue_attachment(
                 "artefact_stages": [],
                 "artefact_tracks": [],
                 "environment_names": [test_execution.environment.name],
+                "test_plans": [],
                 "test_case_names": ["test"],
                 "template_ids": ["test-template-id"],
                 "test_result_statuses": [],

--- a/backend/tests/controllers/test_executions/test_search.py
+++ b/backend/tests/controllers/test_executions/test_search.py
@@ -245,6 +245,26 @@ class TestSearchTestExecutions:
         assert te_a.id in te_ids
         assert te_b.id not in te_ids
 
+    def test_filter_by_test_plan(self, test_client: TestClient, generator: DataGenerator):
+        artefact = generator.gen_artefact(name=_uid("artefact"))
+        build = generator.gen_artefact_build(artefact)
+        env = generator.gen_environment(name=_uid("env"))
+        plan_a = _uid("plan_a")
+        plan_b = _uid("plan_b")
+
+        te_a = generator.gen_test_execution(build, env, test_plan=plan_a)
+        te_b = generator.gen_test_execution(build, env, test_plan=plan_b)
+
+        response = make_authenticated_request(
+            lambda: test_client.get(f"/v1/test-executions?test_result=none&test_plans={plan_a}"),
+            Permission.view_test,
+        )
+
+        assert response.status_code == 200
+        te_ids = {item["id"] for item in response.json()["test_executions"]}
+        assert te_a.id in te_ids
+        assert te_b.id not in te_ids
+
     def test_filter_by_artefact_version(self, test_client: TestClient, generator: DataGenerator):
         artefact_a = generator.gen_artefact(name=_uid("artefact"), version="1.0")
         artefact_b = generator.gen_artefact(name=_uid("artefact"), version="2.0")

--- a/backend/tests/controllers/test_plans/test_test_plans.py
+++ b/backend/tests/controllers/test_plans/test_test_plans.py
@@ -1,0 +1,221 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import uuid
+
+from fastapi.testclient import TestClient
+
+from test_observer.common.enums import Permission
+from test_observer.data_access.models_enums import FamilyName
+from tests.conftest import make_authenticated_request
+from tests.data_generator import DataGenerator
+
+
+def generate_unique_name(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+def _seed_test_plans(generator: DataGenerator, count: int, prefix: str = "test_plan") -> list[str]:
+    """Helper to create test executions with distinct test plans."""
+    art = generator.gen_artefact(name=generate_unique_name("artefact"))
+    art_build = generator.gen_artefact_build(art)
+    env = generator.gen_environment(name=generate_unique_name("environment"))
+
+    names: list[str] = []
+    for i in range(count):
+        name = f"{prefix}_{i:03d}_{uuid.uuid4().hex[:6]}"
+        generator.gen_test_execution(art_build, env, test_plan=name)
+        names.append(name)
+    return names
+
+
+def test_get_test_plans(test_client: TestClient):
+    """Test getting test plans endpoint"""
+    response = make_authenticated_request(
+        lambda: test_client.get("/v1/test-plans"),
+        Permission.view_test,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "test_plans" in data
+    assert isinstance(data["test_plans"], list)
+
+
+def test_create_test_plan_and_validate_returned(test_client: TestClient, generator: DataGenerator):
+    """Test that creates a test plan and validates it is returned in the response"""
+    unique_plan_name = f"test_validation_plan_{uuid.uuid4().hex[:8]}"
+
+    artefact = generator.gen_artefact(name=generate_unique_name("plan_validation_artefact"))
+    artefact_build = generator.gen_artefact_build(artefact)
+    environment = generator.gen_environment(name=generate_unique_name("plan_validation_env"))
+    generator.gen_test_execution(artefact_build, environment, test_plan=unique_plan_name)
+
+    response = make_authenticated_request(
+        lambda: test_client.get("/v1/test-plans"),
+        Permission.view_test,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert unique_plan_name in data["test_plans"]
+
+
+def test_search_filter_q_ilike(test_client: TestClient, generator: DataGenerator):
+    """Search should filter by name (ILIKE)."""
+    unique_marker = uuid.uuid4().hex[:8]
+    target_name = f"special_search_{unique_marker}"
+    other_name = f"other_plan_{unique_marker}"
+
+    art = generator.gen_artefact(name=generate_unique_name("artefact"))
+    art_build = generator.gen_artefact_build(art)
+    env = generator.gen_environment(name=generate_unique_name("environment"))
+    generator.gen_test_execution(art_build, env, test_plan=target_name)
+    generator.gen_test_execution(art_build, env, test_plan=other_name)
+
+    resp = make_authenticated_request(
+        lambda: test_client.get("/v1/test-plans", params={"q": "special_search"}),
+        Permission.view_test,
+    )
+    assert resp.status_code == 200
+    got = resp.json()["test_plans"]
+    assert target_name in got
+    assert other_name not in got
+
+
+def test_search_case_insensitive(test_client: TestClient, generator: DataGenerator):
+    """Search should be case-insensitive."""
+    unique_marker = uuid.uuid4().hex[:8]
+    plan_name = f"MixedCase_Plan_{unique_marker}"
+
+    art = generator.gen_artefact(name=generate_unique_name("artefact"))
+    art_build = generator.gen_artefact_build(art)
+    env = generator.gen_environment(name=generate_unique_name("environment"))
+    generator.gen_test_execution(art_build, env, test_plan=plan_name)
+
+    for search_term in ["mixedcase", "MIXEDCASE", "MixedCase"]:
+        resp = make_authenticated_request(
+            lambda: test_client.get("/v1/test-plans", params={"q": search_term}),  # noqa: B023
+            Permission.view_test,
+        )
+        assert resp.status_code == 200
+        assert plan_name in resp.json()["test_plans"]
+
+
+def test_filter_by_family(test_client: TestClient, generator: DataGenerator):
+    """Test plans should be filterable by artefact family."""
+    unique_marker = uuid.uuid4().hex[:8]
+    snap_plan = f"snap_plan_{unique_marker}"
+    charm_plan = f"charm_plan_{unique_marker}"
+
+    env = generator.gen_environment(name=generate_unique_name("environment"))
+
+    snap_artefact = generator.gen_artefact(name=generate_unique_name("snap_artefact"), family=FamilyName.snap)
+    snap_build = generator.gen_artefact_build(snap_artefact)
+    generator.gen_test_execution(snap_build, env, test_plan=snap_plan)
+
+    charm_artefact = generator.gen_artefact(name=generate_unique_name("charm_artefact"), family=FamilyName.charm)
+    charm_build = generator.gen_artefact_build(charm_artefact)
+    generator.gen_test_execution(charm_build, env, test_plan=charm_plan)
+
+    resp = make_authenticated_request(
+        lambda: test_client.get("/v1/test-plans", params={"families": ["snap"]}),
+        Permission.view_test,
+    )
+    assert resp.status_code == 200
+    got = resp.json()["test_plans"]
+    assert snap_plan in got
+    assert charm_plan not in got
+
+
+def test_pagination_limits(test_client: TestClient):
+    """Test pagination parameter validation"""
+    response = make_authenticated_request(
+        lambda: test_client.get("/v1/test-plans?limit=1001"),
+        Permission.view_test,
+    )
+    assert response.status_code == 422
+
+    response = make_authenticated_request(
+        lambda: test_client.get("/v1/test-plans?offset=-1"),
+        Permission.view_test,
+    )
+    assert response.status_code == 422
+
+    response = make_authenticated_request(
+        lambda: test_client.get("/v1/test-plans?limit=0"),
+        Permission.view_test,
+    )
+    assert response.status_code == 422
+
+
+def test_empty_search_returns_empty_list(test_client: TestClient):
+    """Test search with no results returns empty list."""
+    resp = make_authenticated_request(
+        lambda: test_client.get("/v1/test-plans", params={"q": "nonexistent_plan_xyz_123"}),
+        Permission.view_test,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["test_plans"] == []
+
+
+def test_search_with_pagination(test_client: TestClient, generator: DataGenerator):
+    """Search results should respect pagination parameters."""
+    unique_marker = uuid.uuid4().hex[:8]
+    names = _seed_test_plans(generator, 10, prefix=f"paginated_plan_{unique_marker}")
+    expected_sorted = sorted(names)
+
+    resp = make_authenticated_request(
+        lambda: test_client.get(
+            "/v1/test-plans",
+            params={"q": f"paginated_plan_{unique_marker}", "limit": 3, "offset": 0},
+        ),
+        Permission.view_test,
+    )
+    assert resp.status_code == 200
+    page1 = resp.json()["test_plans"]
+    assert page1 == expected_sorted[0:3]
+
+    resp = make_authenticated_request(
+        lambda: test_client.get(
+            "/v1/test-plans",
+            params={"q": f"paginated_plan_{unique_marker}", "limit": 3, "offset": 3},
+        ),
+        Permission.view_test,
+    )
+    assert resp.status_code == 200
+    page2 = resp.json()["test_plans"]
+    assert page2 == expected_sorted[3:6]
+
+
+def test_get_test_plans_pagination_metadata(test_client: TestClient, generator: DataGenerator):
+    """count reflects total results, limit and offset echo back the used values"""
+    unique_marker = uuid.uuid4().hex[:8]
+    _seed_test_plans(generator, count=5, prefix=f"meta_plan_{unique_marker}")
+
+    resp = make_authenticated_request(
+        lambda: test_client.get(
+            "/v1/test-plans",
+            params={"q": f"meta_plan_{unique_marker}", "limit": 2, "offset": 1},
+        ),
+        Permission.view_test,
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 5
+    assert data["limit"] == 2
+    assert data["offset"] == 1
+    assert len(data["test_plans"]) == 2

--- a/backend/tests/controllers/test_results/test_test_results.py
+++ b/backend/tests/controllers/test_results/test_test_results.py
@@ -976,6 +976,32 @@ class TestSearchTestResults:
         assert test_result.id in result_ids
         assert other_result.id not in result_ids
 
+    def test_search_by_test_plan(self, test_client: TestClient, generator: DataGenerator):
+        """Test filtering by test plan name"""
+        unique_marker = uuid.uuid4().hex[:8]
+
+        environment = generator.gen_environment()
+        test_case = generator.gen_test_case(name=generate_unique_name("test_plan"))
+        artefact = generator.gen_artefact(name=generate_unique_name(f"artefact_{unique_marker}"))
+        artefact_build = generator.gen_artefact_build(artefact)
+        plan_name = f"plan_{unique_marker}"
+        test_execution = generator.gen_test_execution(artefact_build, environment, test_plan=plan_name)
+        test_result = generator.gen_test_result(test_case, test_execution)
+
+        # Create a result under a different test plan that should be excluded
+        other_execution = generator.gen_test_execution(artefact_build, environment, test_plan=f"other_{unique_marker}")
+        other_result = generator.gen_test_result(test_case, other_execution)
+
+        response = make_authenticated_request(
+            lambda: test_client.get(f"/v1/test-results?test_plans={plan_name}"),
+            Permission.view_test,
+        )
+
+        assert response.status_code == 200
+        result_ids = {tr["test_result"]["id"] for tr in response.json()["test_results"]}
+        assert test_result.id in result_ids
+        assert other_result.id not in result_ids
+
     def test_search_by_artefact_stage(self, test_client: TestClient, generator: DataGenerator):
         """Test filtering by artefact stage"""
         unique_marker = uuid.uuid4().hex[:8]

--- a/frontend/lib/models/attachment_rule.dart
+++ b/frontend/lib/models/attachment_rule.dart
@@ -29,9 +29,16 @@ abstract class AttachmentRule with _$AttachmentRule {
     required int id,
     required bool enabled,
     @JsonKey(name: 'families') @Default([]) List<String> families,
+    @JsonKey(name: 'artefacts') @Default([]) List<String> artefacts,
+    @JsonKey(name: 'artefact_versions')
+    @Default([])
+    List<String> artefactVersions,
+    @JsonKey(name: 'artefact_stages') @Default([]) List<String> artefactStages,
+    @JsonKey(name: 'artefact_tracks') @Default([]) List<String> artefactTracks,
     @JsonKey(name: 'environment_names')
     @Default([])
     List<String> environmentNames,
+    @JsonKey(name: 'test_plans') @Default([]) List<String> testPlans,
     @JsonKey(name: 'test_case_names') @Default([]) List<String> testCaseNames,
     @JsonKey(name: 'template_ids') @Default([]) List<String> templateIds,
     @JsonKey(name: 'execution_metadata')
@@ -48,7 +55,12 @@ abstract class AttachmentRule with _$AttachmentRule {
   AttachmentRuleFilters toFilters() {
     return AttachmentRuleFilters(
       families: families,
+      artefacts: artefacts,
+      artefactVersions: artefactVersions,
+      artefactStages: artefactStages,
+      artefactTracks: artefactTracks,
       environmentNames: environmentNames,
+      testPlans: testPlans,
       testCaseNames: testCaseNames,
       templateIds: templateIds,
       testResultStatuses: testResultStatuses,

--- a/frontend/lib/models/attachment_rule_filters.dart
+++ b/frontend/lib/models/attachment_rule_filters.dart
@@ -29,9 +29,16 @@ abstract class AttachmentRuleFilters with _$AttachmentRuleFilters {
   @JsonSerializable(explicitToJson: true)
   const factory AttachmentRuleFilters({
     @JsonKey(name: 'families') @Default([]) List<String> families,
+    @JsonKey(name: 'artefacts') @Default([]) List<String> artefacts,
+    @JsonKey(name: 'artefact_versions')
+    @Default([])
+    List<String> artefactVersions,
+    @JsonKey(name: 'artefact_stages') @Default([]) List<String> artefactStages,
+    @JsonKey(name: 'artefact_tracks') @Default([]) List<String> artefactTracks,
     @JsonKey(name: 'environment_names')
     @Default([])
     List<String> environmentNames,
+    @JsonKey(name: 'test_plans') @Default([]) List<String> testPlans,
     @JsonKey(name: 'test_case_names') @Default([]) List<String> testCaseNames,
     @JsonKey(name: 'template_ids') @Default([]) List<String> templateIds,
     @JsonKey(name: 'test_result_statuses')
@@ -50,7 +57,12 @@ abstract class AttachmentRuleFilters with _$AttachmentRuleFilters {
   ) {
     return AttachmentRuleFilters(
       families: filters.families,
+      artefacts: filters.artefacts,
+      artefactVersions: filters.artefactVersions,
+      artefactStages: filters.artefactStages,
+      artefactTracks: filters.artefactTracks,
       environmentNames: filters.environments,
+      testPlans: filters.testPlans,
       testCaseNames: filters.testCases,
       templateIds: filters.templateIds,
       testResultStatuses: filters.testResultStatuses,
@@ -61,7 +73,12 @@ abstract class AttachmentRuleFilters with _$AttachmentRuleFilters {
   TestResultsFilters toTestResultsFilters() {
     return TestResultsFilters(
       families: families,
+      artefacts: artefacts,
+      artefactVersions: artefactVersions,
+      artefactStages: artefactStages,
+      artefactTracks: artefactTracks,
       environments: environmentNames,
+      testPlans: testPlans,
       testCases: testCaseNames,
       templateIds: templateIds,
       testResultStatuses: testResultStatuses,
@@ -79,7 +96,12 @@ abstract class AttachmentRuleFilters with _$AttachmentRuleFilters {
   factory AttachmentRuleFilters.fromAttachmentRule(AttachmentRule rule) {
     return AttachmentRuleFilters(
       families: rule.families,
+      artefacts: rule.artefacts,
+      artefactVersions: rule.artefactVersions,
+      artefactStages: rule.artefactStages,
+      artefactTracks: rule.artefactTracks,
       environmentNames: rule.environmentNames,
+      testPlans: rule.testPlans,
       testCaseNames: rule.testCaseNames,
       templateIds: rule.templateIds,
       testResultStatuses: rule.testResultStatuses,
@@ -89,7 +111,12 @@ abstract class AttachmentRuleFilters with _$AttachmentRuleFilters {
 
   get hasFilters {
     return families.isNotEmpty ||
+        artefacts.isNotEmpty ||
+        artefactVersions.isNotEmpty ||
+        artefactStages.isNotEmpty ||
+        artefactTracks.isNotEmpty ||
         environmentNames.isNotEmpty ||
+        testPlans.isNotEmpty ||
         testCaseNames.isNotEmpty ||
         templateIds.isNotEmpty ||
         executionMetadata.isNotEmpty ||

--- a/frontend/lib/models/test_results_filters.dart
+++ b/frontend/lib/models/test_results_filters.dart
@@ -127,10 +127,16 @@ abstract class TestResultsFilters with _$TestResultsFilters {
     @Default([])
     List<TestResultStatus> testResultStatuses,
     @Default([]) List<String> artefacts,
+    @JsonKey(name: 'artefact_versions')
+    @Default([])
+    List<String> artefactVersions,
+    @JsonKey(name: 'artefact_stages') @Default([]) List<String> artefactStages,
+    @JsonKey(name: 'artefact_tracks') @Default([]) List<String> artefactTracks,
     @JsonKey(name: 'artefact_is_archived') bool? artefactIsArchived,
     @JsonKey(name: 'rerun_is_requested') bool? rerunIsRequested,
     @JsonKey(name: 'execution_is_latest') bool? executionIsLatest,
     @Default([]) List<String> environments,
+    @JsonKey(name: 'test_plans') @Default([]) List<String> testPlans,
     @JsonKey(name: 'test_cases') @Default([]) List<String> testCases,
     @JsonKey(name: 'template_ids') @Default([]) List<String> templateIds,
     @JsonKey(name: 'execution_metadata')
@@ -174,6 +180,9 @@ abstract class TestResultsFilters with _$TestResultsFilters {
         .map((s) => TestResultStatus.fromString(s))
         .toList();
     final artefacts = parseParam(parameters['artefacts']);
+    final artefactVersions = parseParam(parameters['artefact_versions']);
+    final artefactStages = parseParam(parameters['artefact_stages']);
+    final artefactTracks = parseParam(parameters['artefact_tracks']);
     final artefactIsArchived = parseParam(parameters['artefact_is_archived'])
         .map((s) => s.toLowerCase() == 'true')
         .firstOrNull;
@@ -184,6 +193,7 @@ abstract class TestResultsFilters with _$TestResultsFilters {
         .map((s) => s.toLowerCase() == 'true')
         .firstOrNull;
     final environments = parseParam(parameters['environments']);
+    final testPlans = parseParam(parameters['test_plans']);
     final testCases = parseParam(parameters['test_cases']);
     final templateIds = parseParam(parameters['template_ids']);
     final executionMetadata = ExecutionMetadata.fromQueryParams(
@@ -212,10 +222,14 @@ abstract class TestResultsFilters with _$TestResultsFilters {
       families: families,
       testResultStatuses: testResultStatuses,
       artefacts: artefacts,
+      artefactVersions: artefactVersions,
+      artefactStages: artefactStages,
+      artefactTracks: artefactTracks,
       artefactIsArchived: artefactIsArchived,
       rerunIsRequested: rerunIsRequested,
       executionIsLatest: executionIsLatest,
       environments: environments,
+      testPlans: testPlans,
       testCases: testCases,
       templateIds: templateIds,
       executionMetadata: executionMetadata,
@@ -240,6 +254,15 @@ abstract class TestResultsFilters with _$TestResultsFilters {
     if (artefacts.isNotEmpty) {
       params['artefacts'] = artefacts;
     }
+    if (artefactVersions.isNotEmpty) {
+      params['artefact_versions'] = artefactVersions;
+    }
+    if (artefactStages.isNotEmpty) {
+      params['artefact_stages'] = artefactStages;
+    }
+    if (artefactTracks.isNotEmpty) {
+      params['artefact_tracks'] = artefactTracks;
+    }
     if (artefactIsArchived != null) {
       params['artefact_is_archived'] = [artefactIsArchived.toString()];
     }
@@ -251,6 +274,9 @@ abstract class TestResultsFilters with _$TestResultsFilters {
     }
     if (environments.isNotEmpty) {
       params['environments'] = environments;
+    }
+    if (testPlans.isNotEmpty) {
+      params['test_plans'] = testPlans;
     }
     if (testCases.isNotEmpty) {
       params['test_cases'] = testCases;
@@ -288,10 +314,14 @@ abstract class TestResultsFilters with _$TestResultsFilters {
       families.isNotEmpty ||
       testResultStatuses.isNotEmpty ||
       artefacts.isNotEmpty ||
+      artefactVersions.isNotEmpty ||
+      artefactStages.isNotEmpty ||
+      artefactTracks.isNotEmpty ||
       artefactIsArchived != null ||
       rerunIsRequested != null ||
       executionIsLatest != null ||
       environments.isNotEmpty ||
+      testPlans.isNotEmpty ||
       testCases.isNotEmpty ||
       templateIds.isNotEmpty ||
       executionMetadata.isNotEmpty ||

--- a/frontend/lib/providers/test_results_test_plans.dart
+++ b/frontend/lib/providers/test_results_test_plans.dart
@@ -1,0 +1,39 @@
+// Copyright 2026 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'api.dart';
+
+part 'test_results_test_plans.g.dart';
+
+@riverpod
+Future<List<String>> suggestedTestPlans(
+  Ref ref,
+  String query,
+  List<String> families,
+) async {
+  // Only search if query is long enough
+  if (query.trim().length < 2) {
+    return [];
+  }
+
+  final api = ref.watch(apiProvider);
+  return await api.searchTestPlans(
+    query: query.trim(),
+    limit: 50,
+    families: families.isNotEmpty ? families : null,
+  );
+}

--- a/frontend/lib/repositories/api_repository.dart
+++ b/frontend/lib/repositories/api_repository.dart
@@ -355,6 +355,32 @@ class ApiRepository {
     return environments.cast<String>();
   }
 
+  Future<List<String>> searchTestPlans({
+    String? query,
+    List<String>? families,
+    int limit = 50,
+    int offset = 0,
+  }) async {
+    final queryParams = <String, dynamic>{
+      'limit': limit,
+      'offset': offset,
+    };
+
+    if (query != null && query.trim().isNotEmpty) {
+      queryParams['q'] = query.trim();
+    }
+
+    if (families != null && families.isNotEmpty) {
+      queryParams['families'] = families;
+    }
+
+    final response =
+        await dio.get('/v1/test-plans', queryParameters: queryParams);
+    final Map<String, dynamic> data = response.data;
+    final List<dynamic> testPlans = data['test_plans'] ?? [];
+    return testPlans.cast<String>();
+  }
+
   Future<List<String>> searchTestCases({
     String? query,
     List<String>? families,

--- a/frontend/lib/ui/artefact_page/issue_attachments/issue_forms/attach_issue_form.dart
+++ b/frontend/lib/ui/artefact_page/issue_attachments/issue_forms/attach_issue_form.dart
@@ -184,18 +184,21 @@ class _AttachIssueFormState extends ConsumerState<AttachIssueForm> {
                     // Create the attachment rule if requested.
                     AttachmentRule? attachmentRule;
                     if (_createAttachmentRule) {
-                      if (_attachmentRuleFilters
-                              .testResultStatuses.isNotEmpty &&
-                          context.mounted &&
+                      if (context.mounted &&
                           (_attachToNewerResults || _attachToOlderResults)) {
+                        final hasStatusFilter = _attachmentRuleFilters
+                            .testResultStatuses.isNotEmpty;
                         final confirmed = await showDialog<bool>(
                           context: context,
                           builder: (BuildContext dialogContext) {
                             return AlertDialog(
                               title: const Text('Confirm Attachment Rule'),
-                              content: const Text(
-                                'The attachment rule will apply to all test results with the selected status and filters.\n\n'
-                                'Do you want to continue?',
+                              content: Text(
+                                hasStatusFilter
+                                    ? 'The attachment rule will apply to all test results with the selected status and filters.\n\n'
+                                        'Do you want to continue?'
+                                    : 'The attachment rule will apply to all test results matching the selected filters, regardless of status.\n\n'
+                                        'Do you want to continue?',
                               ),
                               actions: [
                                 TextButton(

--- a/frontend/lib/ui/artefact_page/issue_attachments/issue_forms/attachment_rule_section.dart
+++ b/frontend/lib/ui/artefact_page/issue_attachments/issue_forms/attachment_rule_section.dart
@@ -43,6 +43,10 @@ class AttachmentRuleSection extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final artefact = ref.read(artefactProvider(artefactId)).value;
     final familyName = artefact?.family ?? '';
+    final artefactName = artefact?.name ?? '';
+    final artefactVersion = artefact?.version ?? '';
+    final artefactStage = artefact?.stage.name ?? '';
+    final artefactTrack = artefact?.track ?? '';
     final templateId = testResult?.templateId ?? '';
     final testCaseName = testResult?.name ?? '';
     final testExecution = ref
@@ -59,8 +63,14 @@ class AttachmentRuleSection extends ConsumerWidget {
         .value;
     final executionMetadata =
         testExecution?.executionMetadata ?? ExecutionMetadata();
+    final testPlan = testExecution?.testPlan ?? '';
     final filters = AttachmentRuleFilters(
       families: familyName.isNotEmpty ? [familyName] : [],
+      artefacts: artefactName.isNotEmpty ? [artefactName] : [],
+      artefactVersions: artefactVersion.isNotEmpty ? [artefactVersion] : [],
+      artefactStages: artefactStage.isNotEmpty ? [artefactStage] : [],
+      artefactTracks: artefactTrack.isNotEmpty ? [artefactTrack] : [],
+      testPlans: testPlan.isNotEmpty ? [testPlan] : [],
       testCaseNames: testCaseName.isNotEmpty ? [testCaseName] : [],
       templateIds: templateId.isNotEmpty ? [templateId] : [],
       executionMetadata: executionMetadata,

--- a/frontend/lib/ui/attachment_rule.dart
+++ b/frontend/lib/ui/attachment_rule.dart
@@ -110,6 +110,57 @@ class AttachmentRuleFiltersWidget extends StatelessWidget {
               ),
               _buildFilterSection(
                 context: context,
+                label: 'Artefacts',
+                allValues: filters.artefacts,
+                selectedValues: selected.artefacts.toSet(),
+                onChanged: (newArtefacts) {
+                  final newFilters =
+                      selected.copyWith(artefacts: newArtefacts.toList());
+                  field.didChange(newFilters);
+                  onChanged?.call(newFilters);
+                },
+              ),
+              _buildFilterSection(
+                context: context,
+                label: 'Artefact Versions',
+                allValues: filters.artefactVersions,
+                selectedValues: selected.artefactVersions.toSet(),
+                onChanged: (newArtefactVersions) {
+                  final newFilters = selected.copyWith(
+                    artefactVersions: newArtefactVersions.toList(),
+                  );
+                  field.didChange(newFilters);
+                  onChanged?.call(newFilters);
+                },
+              ),
+              _buildFilterSection(
+                context: context,
+                label: 'Artefact Stages',
+                allValues: filters.artefactStages,
+                selectedValues: selected.artefactStages.toSet(),
+                onChanged: (newArtefactStages) {
+                  final newFilters = selected.copyWith(
+                    artefactStages: newArtefactStages.toList(),
+                  );
+                  field.didChange(newFilters);
+                  onChanged?.call(newFilters);
+                },
+              ),
+              _buildFilterSection(
+                context: context,
+                label: 'Artefact Tracks',
+                allValues: filters.artefactTracks,
+                selectedValues: selected.artefactTracks.toSet(),
+                onChanged: (newArtefactTracks) {
+                  final newFilters = selected.copyWith(
+                    artefactTracks: newArtefactTracks.toList(),
+                  );
+                  field.didChange(newFilters);
+                  onChanged?.call(newFilters);
+                },
+              ),
+              _buildFilterSection(
+                context: context,
                 label: 'Environments',
                 allValues: filters.environmentNames,
                 selectedValues: selected.environmentNames.toSet(),
@@ -117,6 +168,18 @@ class AttachmentRuleFiltersWidget extends StatelessWidget {
                   final newFilters = selected.copyWith(
                     environmentNames: newEnvironments.toList(),
                   );
+                  field.didChange(newFilters);
+                  onChanged?.call(newFilters);
+                },
+              ),
+              _buildFilterSection(
+                context: context,
+                label: 'Test Plans',
+                allValues: filters.testPlans,
+                selectedValues: selected.testPlans.toSet(),
+                onChanged: (newTestPlans) {
+                  final newFilters =
+                      selected.copyWith(testPlans: newTestPlans.toList());
                   field.didChange(newFilters);
                   onChanged?.call(newFilters);
                 },

--- a/frontend/lib/ui/test_results_page/test_results_filters_view.dart
+++ b/frontend/lib/ui/test_results_page/test_results_filters_view.dart
@@ -21,6 +21,7 @@ import 'package:yaru/yaru.dart';
 import '../../models/execution_metadata.dart';
 import '../../models/family_name.dart';
 import '../../models/issue.dart';
+import '../../models/stage_name.dart';
 import '../../models/test_result.dart';
 import '../../models/test_results_filters.dart';
 import '../../models/user.dart';
@@ -29,6 +30,7 @@ import '../../providers/issues.dart';
 import '../../providers/test_results_artefacts.dart';
 import '../../providers/test_results_environments.dart';
 import '../../providers/test_results_test_cases.dart';
+import '../../providers/test_results_test_plans.dart';
 import '../../providers/users.dart';
 import '../issues.dart';
 import '../page_filters/date_time_selector.dart';
@@ -41,11 +43,15 @@ enum FilterType {
   issues,
   reviewers,
   artefacts,
+  artefactVersions,
+  artefactStages,
+  artefactTracks,
   artefactIsArchived,
   rerunIsRequested,
   executionIsLatest,
   environments,
   testCases,
+  testPlans,
   templateIds,
   metadata,
   dateRange,
@@ -234,6 +240,10 @@ class _TestResultsFiltersViewState
     final allFamilyOptions = FamilyName.values.map((f) => f.name).toList();
     final allTestResultStatusesOptions =
         TestResultStatus.values.map((s) => s.name).toList();
+    final allArtefactStageOptions = StageName.values
+        .where((s) => !s.isEmpty)
+        .map((s) => s.name)
+        .toList();
     final executionMetadata = ref.watch(executionMetadataProvider).value ??
         ExecutionMetadata(data: {});
 
@@ -399,6 +409,80 @@ class _TestResultsFiltersViewState
               },
             ),
           ),
+        if (_isFilterEnabled(FilterType.artefactVersions))
+          _box(
+            MultiSelectCombobox<String>(
+              title: 'Artefact Version',
+              initialSelected: _selectedFilters.artefactVersions.toSet(),
+              // No backend search endpoint for versions, so we allow the
+              // user to type an exact version and add it directly.
+              asyncSuggestionsCallback: (pattern) async {
+                final trimmed = pattern.trim();
+                return trimmed.isEmpty ? [] : [trimmed];
+              },
+              minCharsForAsyncSearch: 1,
+              onChanged: (val, isSelected) {
+                setState(() {
+                  _selectedFilters = _selectedFilters.copyWith(
+                    artefactVersions: [
+                      ..._selectedFilters.artefactVersions
+                          .where((v) => v != val),
+                      if (isSelected) val,
+                    ],
+                  );
+                  _notifyChanged(_selectedFilters);
+                });
+              },
+            ),
+          ),
+        if (_isFilterEnabled(FilterType.artefactStages))
+          _box(
+            MultiSelectCombobox<String>(
+              title: 'Artefact Stage',
+              allOptions: allArtefactStageOptions,
+              showAllOptionsWithoutSearch: true,
+              itemToString: (stage) => stage,
+              initialSelected: _selectedFilters.artefactStages.toSet(),
+              onChanged: (val, isSelected) {
+                setState(() {
+                  _selectedFilters = _selectedFilters.copyWith(
+                    artefactStages: [
+                      ..._selectedFilters.artefactStages
+                          .where((s) => s != val),
+                      if (isSelected) val,
+                    ],
+                  );
+                  _notifyChanged(_selectedFilters);
+                });
+              },
+            ),
+          ),
+        if (_isFilterEnabled(FilterType.artefactTracks))
+          _box(
+            MultiSelectCombobox<String>(
+              title: 'Artefact Track',
+              initialSelected: _selectedFilters.artefactTracks.toSet(),
+              // No backend search endpoint for tracks, so we allow the
+              // user to type an exact track and add it directly.
+              asyncSuggestionsCallback: (pattern) async {
+                final trimmed = pattern.trim();
+                return trimmed.isEmpty ? [] : [trimmed];
+              },
+              minCharsForAsyncSearch: 1,
+              onChanged: (val, isSelected) {
+                setState(() {
+                  _selectedFilters = _selectedFilters.copyWith(
+                    artefactTracks: [
+                      ..._selectedFilters.artefactTracks
+                          .where((t) => t != val),
+                      if (isSelected) val,
+                    ],
+                  );
+                  _notifyChanged(_selectedFilters);
+                });
+              },
+            ),
+          ),
         if (_isFilterEnabled(FilterType.artefactIsArchived))
           _box(
             MultiSelectCombobox<bool>(
@@ -511,6 +595,32 @@ class _TestResultsFiltersViewState
                         ? (_selectedFilters.testCases + [val])
                         : _selectedFilters.testCases
                             .where((tc) => tc != val)
+                            .toList(),
+                  );
+                  _notifyChanged(_selectedFilters);
+                });
+              },
+            ),
+          ),
+        if (_isFilterEnabled(FilterType.testPlans))
+          _box(
+            MultiSelectCombobox<String>(
+              title: 'Test Plan',
+              initialSelected: _selectedFilters.testPlans.toSet(),
+              asyncSuggestionsCallback: (pattern) async {
+                return await ref.read(
+                  suggestedTestPlansProvider(pattern, _selectedFilters.families)
+                      .future,
+                );
+              },
+              minCharsForAsyncSearch: 2,
+              onChanged: (val, isSelected) {
+                setState(() {
+                  _selectedFilters = _selectedFilters.copyWith(
+                    testPlans: isSelected
+                        ? (_selectedFilters.testPlans + [val])
+                        : _selectedFilters.testPlans
+                            .where((tp) => tp != val)
                             .toList(),
                   );
                   _notifyChanged(_selectedFilters);


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Attachment rules and the general test results search were missing `test_plan` matching, and the frontend was missing filter controls for several fields already supported by the backend (`artefact_versions`, `artefact_stages`, `artefact_tracks`). This PR closes those gaps:

- Add `test_plans` matching to attachment rules (backend model/migration/matching logic, frontend model + UI).
- Add missing `artefacts`, `artefact_versions`, `artefact_stages`, `artefact_tracks` fields/UI to attachment rules on the frontend.
- Add `test_plans` filter to the general test-execution/test-result search (backend + frontend).
- Add new `GET /v1/test-plans` search endpoint (mirrors `/v1/environments`) to support autocomplete for the new filter.
- Wire up `test_plans`, artefact version, artefact stage, and artefact track filter controls on the Test Results search page UI.
- Fix a bug where the "Confirm Attachment Rule" dialog only warned when a status filter was set, skipping the broadest (highest-impact) case of an empty status filter.

## Resolved issues

N/A

## Documentation

N/A - no user-facing docs affected beyond in-app filter UI, which is self-explanatory.

## Web service API changes

- New endpoint: `GET /v1/test-plans` — searches distinct test plan names for autocomplete, with `q`, `families`, `limit`/`offset` params, following the same pattern as `/v1/environments`. Versioned under `/v1/`, requires `view_test` permission.
- `GET /v1/test-executions` and `GET /v1/test-results` gain an optional `test_plans` query param.
- `POST` attachment rule endpoints accept a new optional `test_plans` field.
- New Alembic migration adds a `test_plans` array column (default `{}`) to `issue_test_result_attachment_rule`.

## Tests

- Backend: `ruff check`, `ruff format --check`, `mypy`, and full `pytest` suite (1012 passed, 3 skipped), including new tests for `/v1/test-plans` and `test_plans` filtering on attachment rules/search endpoints.
- Frontend: `flutter analyze` (clean) and `flutter test --platform chrome` (170 passed).
