### PR TITLE
feat: add test_plans matching to attachment rules (1/6)

### DIFF
--- a/backend/migrations/versions/2026_08_25_1653-a2cce585712b_add_test_plans_to_attachment_rules.py
+++ b/backend/migrations/versions/2026_08_25_1653-a2cce585712b_add_test_plans_to_attachment_rules.py
@@ -1,0 +1,43 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Add test_plans to attachment rules
+
+Revision ID: a2cce585712b
+Revises: eba1d1c92dba
+Create Date: 2026-08-25 16:53:14.299864+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "a2cce585712b"
+down_revision = "6e262c3c6c8f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "issue_test_result_attachment_rule",
+        sa.Column("test_plans", postgresql.ARRAY(sa.String()), nullable=False, server_default="{}"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("issue_test_result_attachment_rule", "test_plans")

--- a/backend/migrations/versions/2026_08_25_1653-a2cce585712b_add_test_plans_to_attachment_rules.py
+++ b/backend/migrations/versions/2026_08_25_1653-a2cce585712b_add_test_plans_to_attachment_rules.py
@@ -16,7 +16,7 @@
 """Add test_plans to attachment rules
 
 Revision ID: a2cce585712b
-Revises: eba1d1c92dba
+Revises: 6e262c3c6c8f
 Create Date: 2026-08-25 16:53:14.299864+00:00
 
 """

--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -7395,6 +7395,13 @@
             "type": "array",
             "title": "Environment Names"
           },
+          "test_plans": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Test Plans"
+          },
           "test_case_names": {
             "items": {
               "type": "string"
@@ -7592,6 +7599,13 @@
             "type": "array",
             "title": "Environment Names"
           },
+          "test_plans": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Test Plans"
+          },
           "test_case_names": {
             "items": {
               "type": "string"
@@ -7627,6 +7641,7 @@
           "artefact_stages",
           "artefact_tracks",
           "environment_names",
+          "test_plans",
           "test_case_names",
           "template_ids",
           "test_result_statuses",

--- a/backend/test_observer/controllers/issues/attachment_rules.py
+++ b/backend/test_observer/controllers/issues/attachment_rules.py
@@ -59,6 +59,7 @@ def post_attachment_rule(
         artefact_stages=request.artefact_stages,
         artefact_tracks=request.artefact_tracks,
         environment_names=request.environment_names,
+        test_plans=request.test_plans,
         test_case_names=request.test_case_names,
         template_ids=request.template_ids,
         test_result_statuses=request.test_result_statuses,

--- a/backend/test_observer/controllers/issues/attachment_rules_logic.py
+++ b/backend/test_observer/controllers/issues/attachment_rules_logic.py
@@ -153,6 +153,14 @@ def query_matching_test_result_attachment_rules(
         )
     )
 
+    # Filter test_plans
+    stmt = stmt.where(
+        _array_empty_or_contains(
+            IssueTestResultAttachmentRule.test_plans,
+            literal(test_result.test_execution.test_plan.name),
+        )
+    )
+
     # Filter test_case_names
     stmt = stmt.where(
         _array_empty_or_contains(

--- a/backend/test_observer/controllers/issues/models.py
+++ b/backend/test_observer/controllers/issues/models.py
@@ -63,6 +63,7 @@ class IssueTestResultAttachmentRulePostRequest(BaseModel):
     artefact_stages: list[str] = Field(default_factory=list)
     artefact_tracks: list[str] = Field(default_factory=list)
     environment_names: list[str] = Field(default_factory=list)
+    test_plans: list[str] = Field(default_factory=list)
     test_case_names: list[str] = Field(default_factory=list)
     template_ids: list[str] = Field(default_factory=list)
     test_result_statuses: list[TestResultStatus] = Field(default_factory=list)

--- a/backend/test_observer/controllers/issues/shared_models.py
+++ b/backend/test_observer/controllers/issues/shared_models.py
@@ -63,6 +63,7 @@ class MinimalIssueTestResultAttachmentRuleResponse(BaseModel):
     artefact_stages: list[str]
     artefact_tracks: list[str]
     environment_names: list[str]
+    test_plans: list[str]
     test_case_names: list[str]
     template_ids: list[str]
     test_result_statuses: list[TestResultStatus]

--- a/backend/test_observer/data_access/models.py
+++ b/backend/test_observer/data_access/models.py
@@ -962,6 +962,7 @@ class IssueTestResultAttachmentRule(Base):
     artefact_stages: Mapped[list[str]] = mapped_column(ARRAY(String), nullable=False, default=list)
     artefact_tracks: Mapped[list[str]] = mapped_column(ARRAY(String), nullable=False, default=list)
     environment_names: Mapped[list[str]] = mapped_column(ARRAY(String), nullable=False, default=list)
+    test_plans: Mapped[list[str]] = mapped_column(ARRAY(String), nullable=False, default=list)
     test_case_names: Mapped[list[str]] = mapped_column(ARRAY(String), nullable=False, default=list)
     template_ids: Mapped[list[str]] = mapped_column(ARRAY(String), nullable=False, default=list)
     execution_metadata: Mapped[list["IssueTestResultAttachmentRuleExecutionMetadata"]] = relationship(

--- a/backend/tests/controllers/issues/test_attachment_rules.py
+++ b/backend/tests/controllers/issues/test_attachment_rules.py
@@ -49,6 +49,7 @@ def post_attachment_rule():
         "enabled": True,
         "families": ["charm"],
         "environment_names": ["environment-1"],
+        "test_plans": ["test-plan-1"],
         "test_case_names": ["test-case-1"],
         "template_ids": ["template-id-1"],
         "execution_metadata": {"category-1": ["value-1", "value-2"]},
@@ -69,6 +70,7 @@ def _assert_attachment_rule_response(
         "artefact_stages",
         "artefact_tracks",
         "environment_names",
+        "test_plans",
         "test_case_names",
         "template_ids",
         "test_result_statuses",
@@ -78,6 +80,7 @@ def _assert_attachment_rule_response(
     assert json["enabled"] == model.enabled
     assert sorted(json["families"]) == sorted(model.families)
     assert sorted(json["environment_names"]) == sorted(model.environment_names)
+    assert sorted(json["test_plans"]) == sorted(model.test_plans)
     assert sorted(json["test_case_names"]) == sorted(model.test_case_names)
     assert sorted(json["template_ids"]) == sorted(model.template_ids)
     assert [s.name for s in sorted(json["test_result_statuses"])] == [

--- a/backend/tests/controllers/issues/test_attachment_rules_logic.py
+++ b/backend/tests/controllers/issues/test_attachment_rules_logic.py
@@ -61,6 +61,14 @@ params_query_matching_test_result_attachment_rules: list[dict] = [
         ],
     },
     {
+        "label": "match_test_plan",
+        "attachment_rules": [
+            (True, {"test_plans": ["Test plan"]}),
+            (True, {"test_plans": ["Test plan", "other-plan"]}),
+            (False, {"test_plans": ["other-plan"]}),
+        ],
+    },
+    {
         "label": "match_test_case_name",
         "attachment_rules": [
             (True, {"test_case_names": ["camera/detect"]}),
@@ -222,6 +230,7 @@ def test_query_matching_test_result_attachment_rules(
             artefact_stages=spec.get("artefact_stages", []),
             artefact_tracks=spec.get("artefact_tracks", []),
             environment_names=spec.get("environment_names", []),
+            test_plans=spec.get("test_plans", []),
             test_case_names=spec.get("test_case_names", []),
             template_ids=spec.get("template_ids", []),
             execution_metadata=[

--- a/backend/tests/controllers/test_executions/test_get_test_results.py
+++ b/backend/tests/controllers/test_executions/test_get_test_results.py
@@ -269,6 +269,7 @@ def test_attachment_rule_listed_in_issue_attachment(
                 "artefact_stages": [],
                 "artefact_tracks": [],
                 "environment_names": [test_execution.environment.name],
+                "test_plans": [],
                 "test_case_names": ["test"],
                 "template_ids": ["test-template-id"],
                 "test_result_statuses": [],


### PR DESCRIPTION
Part 1 of 6 in the test_plans/filter-parity stack (see #855 for full context).

Adds a `test_plans` column to `IssueTestResultAttachmentRule`, allowing attachment rules to match on a test result's test plan in addition to existing artefact/environment filters.

- New migration adding `test_plans` column
- Matching logic updated in `attachment_rules_logic.py`
- Request/response schema updated

Stack:
1. **This PR** — backend: test_plans matching in attachment rules
2. backend: test_plans filter in test-execution/test-result search
3. backend: new `GET /v1/test-plans` endpoint
4. frontend: TestResultsFilters model parity (artefact_versions/stages/tracks, test_plans)
5. frontend: attachment rule filter parity
6. frontend: Test Results page UI filters + dialog fix