### PR TITLE
feat: add test_plans filter to test-execution/test-result search (2/6)

### DIFF
--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -755,6 +755,27 @@
             "description": "Filter by environment names"
           },
           {
+            "name": "test_plans",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by test plan names",
+              "title": "Test Plans"
+            },
+            "description": "Filter by test plan names"
+          },
+          {
             "name": "test_execution_statuses",
             "in": "query",
             "required": false,
@@ -3439,6 +3460,27 @@
               "title": "Environments"
             },
             "description": "Filter by environment names"
+          },
+          {
+            "name": "test_plans",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by test plan names",
+              "title": "Test Plans"
+            },
+            "description": "Filter by test plan names"
           },
           {
             "name": "test_cases",
@@ -8901,6 +8943,13 @@
             "type": "array",
             "title": "Environments"
           },
+          "test_plans": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Test Plans"
+          },
           "test_execution_statuses": {
             "items": {
               "$ref": "#/components/schemas/TestExecutionStatus"
@@ -9575,6 +9624,13 @@
             },
             "type": "array",
             "title": "Template Ids"
+          },
+          "test_plans": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Test Plans"
           },
           "execution_metadata": {
             "$ref": "#/components/schemas/ExecutionMetadata"

--- a/backend/test_observer/controllers/test_executions/execution_filters.py
+++ b/backend/test_observer/controllers/test_executions/execution_filters.py
@@ -36,11 +36,12 @@ from test_observer.data_access.models import (
     TestExecution,
     TestExecutionMetadata,
     TestExecutionRerunRequest,
+    TestPlan,
     User,
     test_execution_metadata_association_table,
 )
 
-JoinName = Literal["artefact_build", "artefact", "environment"]
+JoinName = Literal["artefact_build", "artefact", "environment", "test_plan"]
 
 
 def filter_execution_metadata(
@@ -97,6 +98,10 @@ def build_execution_filters(
     if filters.environments:
         query_filters.append(Environment.name.in_(filters.environments))
         joins_needed.add("environment")
+
+    if filters.test_plans:
+        query_filters.append(TestPlan.name.in_(filters.test_plans))
+        joins_needed.add("test_plan")
 
     if filters.execution_metadata and len(filters.execution_metadata) > 0:
         query_filters.append(filter_execution_metadata(filters.execution_metadata))
@@ -174,4 +179,6 @@ def apply_te_joins(query: Select, joins_needed: set[JoinName]) -> Select:
         query = query.join(ArtefactBuild.artefact)
     if "environment" in joins_needed:
         query = query.join(TestExecution.environment)
+    if "test_plan" in joins_needed:
+        query = query.join(TestExecution.test_plan)
     return query

--- a/backend/test_observer/controllers/test_executions/search.py
+++ b/backend/test_observer/controllers/test_executions/search.py
@@ -246,6 +246,10 @@ def search_test_executions(
         list[str] | None,
         Query(description="Filter by environment names"),
     ] = None,
+    test_plans: Annotated[
+        list[str] | None,
+        Query(description="Filter by test plan names"),
+    ] = None,
     execution_metadata: Annotated[ExecutionMetadata | None, Depends(parse_execution_metadata)] = None,
     test_execution_statuses: Annotated[
         list[TestExecutionStatus] | None,
@@ -320,6 +324,7 @@ def search_test_executions(
         artefact_tracks=artefact_tracks or [],
         artefact_is_archived=artefact_is_archived,
         environments=environments or [],
+        test_plans=test_plans or [],
         execution_metadata=execution_metadata or ExecutionMetadata(),
         test_execution_statuses=test_execution_statuses or [],
         reviewer_ids=parse_list_or_query_value(reviewer_ids),  # type: ignore[arg-type]

--- a/backend/test_observer/controllers/test_executions/shared_models.py
+++ b/backend/test_observer/controllers/test_executions/shared_models.py
@@ -71,6 +71,7 @@ class TestExecutionFilterBase(BaseModel):
     artefact_tracks: list[str] = Field(default_factory=list)
     artefact_is_archived: bool | None = None
     environments: list[str] = Field(default_factory=list)
+    test_plans: list[str] = Field(default_factory=list)
     test_execution_statuses: list[TestExecutionStatus] = Field(default_factory=list)
     execution_metadata: ExecutionMetadata = Field(default_factory=ExecutionMetadata)
     reviewer_ids: list[int] | Literal[QueryValue.ANY, QueryValue.NONE] = Field(default_factory=list)

--- a/backend/test_observer/controllers/test_results/filter_test_results.py
+++ b/backend/test_observer/controllers/test_results/filter_test_results.py
@@ -29,6 +29,7 @@ from test_observer.data_access.models import (
     TestExecution,
     TestExecutionMetadata,
     TestExecutionRerunRequest,
+    TestPlan,
     TestResult,
     User,
     test_execution_metadata_association_table,
@@ -91,6 +92,10 @@ def build_query_filters_and_joins(
     if len(filters.environments) > 0:
         query_filters.append(Environment.name.in_(filters.environments))
         joins_needed.update(["test_execution", "environment"])
+
+    if len(filters.test_plans) > 0:
+        query_filters.append(TestPlan.name.in_(filters.test_plans))
+        joins_needed.update(["test_execution", "test_plan"])
 
     if len(filters.test_cases) > 0:
         query_filters.append(TestCase.name.in_(filters.test_cases))
@@ -200,6 +205,9 @@ def apply_joins(query: Select, joins_needed: set[str]) -> Select:
 
     if "test_case" in joins_needed:
         query = query.join(TestResult.test_case)
+
+    if "test_plan" in joins_needed:
+        query = query.join(TestExecution.test_plan)
 
     return query
 

--- a/backend/test_observer/controllers/test_results/shared_models.py
+++ b/backend/test_observer/controllers/test_results/shared_models.py
@@ -37,6 +37,7 @@ class TestResultSearchFilters(BaseModel):
     environments: list[str] = Field(default_factory=list)
     test_cases: list[str] = Field(default_factory=list)
     template_ids: list[str] = Field(default_factory=list)
+    test_plans: list[str] = Field(default_factory=list)
     execution_metadata: ExecutionMetadata = Field(default_factory=ExecutionMetadata)
     issues: list[int] | Literal[QueryValue.ANY, QueryValue.NONE] = Field(default_factory=list)
     test_result_statuses: list[TestResultStatus] = Field(default_factory=list)

--- a/backend/test_observer/controllers/test_results/test_results.py
+++ b/backend/test_observer/controllers/test_results/test_results.py
@@ -195,6 +195,10 @@ def search_test_results(
         list[str] | None,
         Query(description="Filter by environment names"),
     ] = None,
+    test_plans: Annotated[
+        list[str] | None,
+        Query(description="Filter by test plan names"),
+    ] = None,
     test_cases: Annotated[
         list[str] | None,
         Query(description="Filter by test case names"),
@@ -254,6 +258,7 @@ def search_test_results(
         environments=environments or [],
         test_cases=test_cases or [],
         template_ids=template_ids or [],
+        test_plans=test_plans or [],
         execution_metadata=execution_metadata or ExecutionMetadata(),
         issues=parse_list_or_query_value(issues),  # type: ignore[arg-type]
         test_result_statuses=test_result_statuses or [],

--- a/backend/tests/controllers/test_executions/test_search.py
+++ b/backend/tests/controllers/test_executions/test_search.py
@@ -245,6 +245,26 @@ class TestSearchTestExecutions:
         assert te_a.id in te_ids
         assert te_b.id not in te_ids
 
+    def test_filter_by_test_plan(self, test_client: TestClient, generator: DataGenerator):
+        artefact = generator.gen_artefact(name=_uid("artefact"))
+        build = generator.gen_artefact_build(artefact)
+        env = generator.gen_environment(name=_uid("env"))
+        plan_a = _uid("plan_a")
+        plan_b = _uid("plan_b")
+
+        te_a = generator.gen_test_execution(build, env, test_plan=plan_a)
+        te_b = generator.gen_test_execution(build, env, test_plan=plan_b)
+
+        response = make_authenticated_request(
+            lambda: test_client.get(f"/v1/test-executions?test_result=none&test_plans={plan_a}"),
+            Permission.view_test,
+        )
+
+        assert response.status_code == 200
+        te_ids = {item["id"] for item in response.json()["test_executions"]}
+        assert te_a.id in te_ids
+        assert te_b.id not in te_ids
+
     def test_filter_by_artefact_version(self, test_client: TestClient, generator: DataGenerator):
         artefact_a = generator.gen_artefact(name=_uid("artefact"), version="1.0")
         artefact_b = generator.gen_artefact(name=_uid("artefact"), version="2.0")

--- a/backend/tests/controllers/test_results/test_test_results.py
+++ b/backend/tests/controllers/test_results/test_test_results.py
@@ -976,6 +976,32 @@ class TestSearchTestResults:
         assert test_result.id in result_ids
         assert other_result.id not in result_ids
 
+    def test_search_by_test_plan(self, test_client: TestClient, generator: DataGenerator):
+        """Test filtering by test plan name"""
+        unique_marker = uuid.uuid4().hex[:8]
+
+        environment = generator.gen_environment()
+        test_case = generator.gen_test_case(name=generate_unique_name("test_plan"))
+        artefact = generator.gen_artefact(name=generate_unique_name(f"artefact_{unique_marker}"))
+        artefact_build = generator.gen_artefact_build(artefact)
+        plan_name = f"plan_{unique_marker}"
+        test_execution = generator.gen_test_execution(artefact_build, environment, test_plan=plan_name)
+        test_result = generator.gen_test_result(test_case, test_execution)
+
+        # Create a result under a different test plan that should be excluded
+        other_execution = generator.gen_test_execution(artefact_build, environment, test_plan=f"other_{unique_marker}")
+        other_result = generator.gen_test_result(test_case, other_execution)
+
+        response = make_authenticated_request(
+            lambda: test_client.get(f"/v1/test-results?test_plans={plan_name}"),
+            Permission.view_test,
+        )
+
+        assert response.status_code == 200
+        result_ids = {tr["test_result"]["id"] for tr in response.json()["test_results"]}
+        assert test_result.id in result_ids
+        assert other_result.id not in result_ids
+
     def test_search_by_artefact_stage(self, test_client: TestClient, generator: DataGenerator):
         """Test filtering by artefact stage"""
         unique_marker = uuid.uuid4().hex[:8]


### PR DESCRIPTION
Part 2 of 6 in the test_plans/filter-parity stack (see #855 for full context). Stacked on #856.

Adds a `test_plans` query parameter to the general test-execution and test-result search endpoints, matching the pattern of existing artefact/environment filters.

Stack:
1. backend: test_plans matching in attachment rules
2. **This PR** — backend: test_plans filter in test-execution/test-result search
3. backend: new `GET /v1/test-plans` endpoint
4. frontend: TestResultsFilters model parity (artefact_versions/stages/tracks, test_plans)
5. frontend: attachment rule filter parity
6. frontend: Test Results page UI filters + dialog fix