### PR TITLE
feat: add GET /v1/test-plans search endpoint (3/6)

### DIFF
--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -2690,7 +2690,7 @@
           "test-plans"
         ],
         "summary": "Get Test Plans",
-        "description": "Returns list of distinct test plan names that have been used in test executions.\n\nSupports pagination and search filtering.",
+        "description": "Returns list of distinct test plan names.\n\nSupports pagination and search filtering.",
         "operationId": "get_test_plans_v1_test_plans_get",
         "parameters": [
           {

--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -2684,6 +2684,109 @@
         ]
       }
     },
+    "/v1/test-plans": {
+      "get": {
+        "tags": [
+          "test-plans"
+        ],
+        "summary": "Get Test Plans",
+        "description": "Returns list of distinct test plan names that have been used in test executions.\n\nSupports pagination and search filtering.",
+        "operationId": "get_test_plans_v1_test_plans_get",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Search term for test plan names",
+              "title": "Q"
+            },
+            "description": "Search term for test plan names"
+          },
+          {
+            "name": "families",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FamilyName"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by artefact families",
+              "title": "Families"
+            },
+            "description": "Filter by artefact families"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "description": "Maximum number of results (defaults to 50 if not specified)",
+              "default": 50,
+              "title": "Limit"
+            },
+            "description": "Maximum number of results (defaults to 50 if not specified)"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Number of results to skip for pagination",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Number of results to skip for pagination"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestPlansResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-permissions": [
+          "view_test"
+        ]
+      }
+    },
     "/v1/issues/{issue_id}/attach": {
       "post": {
         "tags": [
@@ -9349,6 +9452,38 @@
         },
         "type": "object",
         "title": "TestExecutionsPatchRequest"
+      },
+      "TestPlansResponse": {
+        "properties": {
+          "test_plans": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Test Plans"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          }
+        },
+        "type": "object",
+        "required": [
+          "test_plans",
+          "count",
+          "limit",
+          "offset"
+        ],
+        "title": "TestPlansResponse",
+        "description": "Response model for test plans endpoint"
       },
       "TestReportedIssueRequest": {
         "properties": {

--- a/backend/test_observer/controllers/router.py
+++ b/backend/test_observer/controllers/router.py
@@ -33,6 +33,7 @@ from . import (
     reports,
     test_cases,
     test_executions,
+    test_plans,
     test_results,
 )
 from .application import version
@@ -49,6 +50,7 @@ router.include_router(artefacts.router, prefix="/v1/artefacts")
 router.include_router(reports.router, prefix="/v1/reports")
 router.include_router(test_cases.router, prefix="/v1/test-cases")
 router.include_router(environments.router, prefix="/v1/environments")
+router.include_router(test_plans.router, prefix="/v1/test-plans")
 router.include_router(issues.router, prefix="/v1/issues")
 router.include_router(test_results.router, prefix="/v1/test-results")
 router.include_router(execution_metadata.router, prefix="/v1/execution-metadata")

--- a/backend/test_observer/controllers/test_plans/__init__.py
+++ b/backend/test_observer/controllers/test_plans/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from .test_plans import router
+
+__all__ = ["router"]

--- a/backend/test_observer/controllers/test_plans/models.py
+++ b/backend/test_observer/controllers/test_plans/models.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from pydantic import BaseModel
+
+
+class TestPlansResponse(BaseModel):
+    """Response model for test plans endpoint"""
+
+    test_plans: list[str]
+    count: int
+    limit: int
+    offset: int

--- a/backend/test_observer/controllers/test_plans/test_plans.py
+++ b/backend/test_observer/controllers/test_plans/test_plans.py
@@ -68,11 +68,7 @@ def get_test_plans(
 
     Supports pagination and search filtering.
     """
-    query = (
-        select(distinct(TestPlan.name))
-        .join(TestExecution, TestExecution.test_plan_id == TestPlan.id)
-        .order_by(TestPlan.name)
-    )
+    query = select(distinct(TestPlan.name)).join(TestExecution, TestExecution.test_plan_id == TestPlan.id)
 
     # Filter by families if provided
     if families and len(families) > 0:
@@ -86,12 +82,12 @@ def get_test_plans(
         search_term = f"%{q.strip()}%"
         query = query.where(TestPlan.name.ilike(search_term))
 
-    # Count total before pagination
+    # Count total before pagination (ordering is irrelevant for a count)
     count_query = select(func.count()).select_from(query.subquery())
     total_count = db.execute(count_query).scalar() or 0
 
-    # Apply pagination
-    query = query.offset(offset).limit(limit)
+    # Apply ordering and pagination
+    query = query.order_by(TestPlan.name).offset(offset).limit(limit)
 
     test_plans = db.execute(query).scalars().all()
     return TestPlansResponse(

--- a/backend/test_observer/controllers/test_plans/test_plans.py
+++ b/backend/test_observer/controllers/test_plans/test_plans.py
@@ -1,0 +1,100 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query, Security
+from sqlalchemy import distinct, func, select
+from sqlalchemy.orm import Session
+
+from test_observer.common.enums import Permission
+from test_observer.common.permissions import permission_checker
+from test_observer.data_access.models import (
+    Artefact,
+    ArtefactBuild,
+    TestExecution,
+    TestPlan,
+)
+from test_observer.data_access.models_enums import FamilyName
+from test_observer.data_access.setup import get_db
+
+from .models import TestPlansResponse
+
+router = APIRouter(tags=["test-plans"])
+
+
+@router.get(
+    "",
+    response_model=TestPlansResponse,
+    dependencies=[Security(permission_checker, scopes=[Permission.view_test])],
+)
+def get_test_plans(
+    q: Annotated[
+        str | None,
+        Query(description="Search term for test plan names"),
+    ] = None,
+    families: Annotated[
+        list[FamilyName] | None,
+        Query(description="Filter by artefact families"),
+    ] = None,
+    limit: Annotated[
+        int,
+        Query(
+            ge=1,
+            le=1000,
+            description="Maximum number of results (defaults to 50 if not specified)",
+        ),
+    ] = 50,
+    offset: Annotated[
+        int,
+        Query(ge=0, description="Number of results to skip for pagination"),
+    ] = 0,
+    db: Session = Depends(get_db),
+) -> TestPlansResponse:
+    """
+    Returns list of distinct test plan names that have been used in test executions.
+
+    Supports pagination and search filtering.
+    """
+    query = select(distinct(TestPlan.name)).order_by(TestPlan.name)
+
+    # Filter by families if provided
+    if families and len(families) > 0:
+        query = (
+            query.join(TestExecution, TestExecution.test_plan_id == TestPlan.id)
+            .join(ArtefactBuild, ArtefactBuild.id == TestExecution.artefact_build_id)
+            .join(Artefact, Artefact.id == ArtefactBuild.artefact_id)
+            .where(Artefact.family.in_(families))
+        )
+
+    # Apply search filter if provided
+    if q and q.strip():
+        search_term = f"%{q.strip()}%"
+        query = query.where(TestPlan.name.ilike(search_term))
+
+    # Count total before pagination
+    count_query = select(func.count()).select_from(query.subquery())
+    total_count = db.execute(count_query).scalar() or 0
+
+    # Apply pagination
+    query = query.offset(offset).limit(limit)
+
+    test_plans = db.execute(query).scalars().all()
+    return TestPlansResponse(
+        test_plans=list(test_plans),
+        count=total_count,
+        limit=limit,
+        offset=offset,
+    )

--- a/backend/test_observer/controllers/test_plans/test_plans.py
+++ b/backend/test_observer/controllers/test_plans/test_plans.py
@@ -68,16 +68,18 @@ def get_test_plans(
 
     Supports pagination and search filtering.
     """
-    query = select(distinct(TestPlan.name)).order_by(TestPlan.name)
+    query = (
+        select(distinct(TestPlan.name))
+        .join(TestExecution, TestExecution.test_plan_id == TestPlan.id)
+        .order_by(TestPlan.name)
+    )
 
     # Filter by families if provided
     if families and len(families) > 0:
-        query = (
-            query.join(TestExecution, TestExecution.test_plan_id == TestPlan.id)
-            .join(ArtefactBuild, ArtefactBuild.id == TestExecution.artefact_build_id)
-            .join(Artefact, Artefact.id == ArtefactBuild.artefact_id)
-            .where(Artefact.family.in_(families))
+        query = query.join(ArtefactBuild, ArtefactBuild.id == TestExecution.artefact_build_id).join(
+            Artefact, Artefact.id == ArtefactBuild.artefact_id
         )
+        query = query.where(Artefact.family.in_(families))
 
     # Apply search filter if provided
     if q and q.strip():

--- a/backend/test_observer/controllers/test_plans/test_plans.py
+++ b/backend/test_observer/controllers/test_plans/test_plans.py
@@ -64,14 +64,17 @@ def get_test_plans(
     db: Session = Depends(get_db),
 ) -> TestPlansResponse:
     """
-    Returns list of distinct test plan names that have been used in test executions.
+    Returns list of distinct test plan names.
 
     Supports pagination and search filtering.
     """
-    query = select(distinct(TestPlan.name)).join(TestExecution, TestExecution.test_plan_id == TestPlan.id)
+    query = select(distinct(TestPlan.name))
 
-    # Filter by families if provided
+    # Family filtering requires joining through TestExecution/ArtefactBuild/
+    # Artefact, so it inherently limits results to test plans that have been
+    # used in a test execution with a matching family.
     if families and len(families) > 0:
+        query = query.join(TestExecution, TestExecution.test_plan_id == TestPlan.id)
         query = query.join(ArtefactBuild, ArtefactBuild.id == TestExecution.artefact_build_id).join(
             Artefact, Artefact.id == ArtefactBuild.artefact_id
         )

--- a/backend/tests/controllers/test_plans/test_test_plans.py
+++ b/backend/tests/controllers/test_plans/test_test_plans.py
@@ -1,0 +1,221 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import uuid
+
+from fastapi.testclient import TestClient
+
+from test_observer.common.enums import Permission
+from test_observer.data_access.models_enums import FamilyName
+from tests.conftest import make_authenticated_request
+from tests.data_generator import DataGenerator
+
+
+def generate_unique_name(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+def _seed_test_plans(generator: DataGenerator, count: int, prefix: str = "test_plan") -> list[str]:
+    """Helper to create test executions with distinct test plans."""
+    art = generator.gen_artefact(name=generate_unique_name("artefact"))
+    art_build = generator.gen_artefact_build(art)
+    env = generator.gen_environment(name=generate_unique_name("environment"))
+
+    names: list[str] = []
+    for i in range(count):
+        name = f"{prefix}_{i:03d}_{uuid.uuid4().hex[:6]}"
+        generator.gen_test_execution(art_build, env, test_plan=name)
+        names.append(name)
+    return names
+
+
+def test_get_test_plans(test_client: TestClient):
+    """Test getting test plans endpoint"""
+    response = make_authenticated_request(
+        lambda: test_client.get("/v1/test-plans"),
+        Permission.view_test,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "test_plans" in data
+    assert isinstance(data["test_plans"], list)
+
+
+def test_create_test_plan_and_validate_returned(test_client: TestClient, generator: DataGenerator):
+    """Test that creates a test plan and validates it is returned in the response"""
+    unique_plan_name = f"test_validation_plan_{uuid.uuid4().hex[:8]}"
+
+    artefact = generator.gen_artefact(name=generate_unique_name("plan_validation_artefact"))
+    artefact_build = generator.gen_artefact_build(artefact)
+    environment = generator.gen_environment(name=generate_unique_name("plan_validation_env"))
+    generator.gen_test_execution(artefact_build, environment, test_plan=unique_plan_name)
+
+    response = make_authenticated_request(
+        lambda: test_client.get("/v1/test-plans"),
+        Permission.view_test,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert unique_plan_name in data["test_plans"]
+
+
+def test_search_filter_q_ilike(test_client: TestClient, generator: DataGenerator):
+    """Search should filter by name (ILIKE)."""
+    unique_marker = uuid.uuid4().hex[:8]
+    target_name = f"special_search_{unique_marker}"
+    other_name = f"other_plan_{unique_marker}"
+
+    art = generator.gen_artefact(name=generate_unique_name("artefact"))
+    art_build = generator.gen_artefact_build(art)
+    env = generator.gen_environment(name=generate_unique_name("environment"))
+    generator.gen_test_execution(art_build, env, test_plan=target_name)
+    generator.gen_test_execution(art_build, env, test_plan=other_name)
+
+    resp = make_authenticated_request(
+        lambda: test_client.get("/v1/test-plans", params={"q": "special_search"}),
+        Permission.view_test,
+    )
+    assert resp.status_code == 200
+    got = resp.json()["test_plans"]
+    assert target_name in got
+    assert other_name not in got
+
+
+def test_search_case_insensitive(test_client: TestClient, generator: DataGenerator):
+    """Search should be case-insensitive."""
+    unique_marker = uuid.uuid4().hex[:8]
+    plan_name = f"MixedCase_Plan_{unique_marker}"
+
+    art = generator.gen_artefact(name=generate_unique_name("artefact"))
+    art_build = generator.gen_artefact_build(art)
+    env = generator.gen_environment(name=generate_unique_name("environment"))
+    generator.gen_test_execution(art_build, env, test_plan=plan_name)
+
+    for search_term in ["mixedcase", "MIXEDCASE", "MixedCase"]:
+        resp = make_authenticated_request(
+            lambda: test_client.get("/v1/test-plans", params={"q": search_term}),  # noqa: B023
+            Permission.view_test,
+        )
+        assert resp.status_code == 200
+        assert plan_name in resp.json()["test_plans"]
+
+
+def test_filter_by_family(test_client: TestClient, generator: DataGenerator):
+    """Test plans should be filterable by artefact family."""
+    unique_marker = uuid.uuid4().hex[:8]
+    snap_plan = f"snap_plan_{unique_marker}"
+    charm_plan = f"charm_plan_{unique_marker}"
+
+    env = generator.gen_environment(name=generate_unique_name("environment"))
+
+    snap_artefact = generator.gen_artefact(name=generate_unique_name("snap_artefact"), family=FamilyName.snap)
+    snap_build = generator.gen_artefact_build(snap_artefact)
+    generator.gen_test_execution(snap_build, env, test_plan=snap_plan)
+
+    charm_artefact = generator.gen_artefact(name=generate_unique_name("charm_artefact"), family=FamilyName.charm)
+    charm_build = generator.gen_artefact_build(charm_artefact)
+    generator.gen_test_execution(charm_build, env, test_plan=charm_plan)
+
+    resp = make_authenticated_request(
+        lambda: test_client.get("/v1/test-plans", params={"families": ["snap"]}),
+        Permission.view_test,
+    )
+    assert resp.status_code == 200
+    got = resp.json()["test_plans"]
+    assert snap_plan in got
+    assert charm_plan not in got
+
+
+def test_pagination_limits(test_client: TestClient):
+    """Test pagination parameter validation"""
+    response = make_authenticated_request(
+        lambda: test_client.get("/v1/test-plans?limit=1001"),
+        Permission.view_test,
+    )
+    assert response.status_code == 422
+
+    response = make_authenticated_request(
+        lambda: test_client.get("/v1/test-plans?offset=-1"),
+        Permission.view_test,
+    )
+    assert response.status_code == 422
+
+    response = make_authenticated_request(
+        lambda: test_client.get("/v1/test-plans?limit=0"),
+        Permission.view_test,
+    )
+    assert response.status_code == 422
+
+
+def test_empty_search_returns_empty_list(test_client: TestClient):
+    """Test search with no results returns empty list."""
+    resp = make_authenticated_request(
+        lambda: test_client.get("/v1/test-plans", params={"q": "nonexistent_plan_xyz_123"}),
+        Permission.view_test,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["test_plans"] == []
+
+
+def test_search_with_pagination(test_client: TestClient, generator: DataGenerator):
+    """Search results should respect pagination parameters."""
+    unique_marker = uuid.uuid4().hex[:8]
+    names = _seed_test_plans(generator, 10, prefix=f"paginated_plan_{unique_marker}")
+    expected_sorted = sorted(names)
+
+    resp = make_authenticated_request(
+        lambda: test_client.get(
+            "/v1/test-plans",
+            params={"q": f"paginated_plan_{unique_marker}", "limit": 3, "offset": 0},
+        ),
+        Permission.view_test,
+    )
+    assert resp.status_code == 200
+    page1 = resp.json()["test_plans"]
+    assert page1 == expected_sorted[0:3]
+
+    resp = make_authenticated_request(
+        lambda: test_client.get(
+            "/v1/test-plans",
+            params={"q": f"paginated_plan_{unique_marker}", "limit": 3, "offset": 3},
+        ),
+        Permission.view_test,
+    )
+    assert resp.status_code == 200
+    page2 = resp.json()["test_plans"]
+    assert page2 == expected_sorted[3:6]
+
+
+def test_get_test_plans_pagination_metadata(test_client: TestClient, generator: DataGenerator):
+    """count reflects total results, limit and offset echo back the used values"""
+    unique_marker = uuid.uuid4().hex[:8]
+    _seed_test_plans(generator, count=5, prefix=f"meta_plan_{unique_marker}")
+
+    resp = make_authenticated_request(
+        lambda: test_client.get(
+            "/v1/test-plans",
+            params={"q": f"meta_plan_{unique_marker}", "limit": 2, "offset": 1},
+        ),
+        Permission.view_test,
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 5
+    assert data["limit"] == 2
+    assert data["offset"] == 1
+    assert len(data["test_plans"]) == 2

--- a/backend/tests/controllers/test_plans/test_test_plans.py
+++ b/backend/tests/controllers/test_plans/test_test_plans.py
@@ -73,6 +73,21 @@ def test_create_test_plan_and_validate_returned(test_client: TestClient, generat
     assert unique_plan_name in data["test_plans"]
 
 
+def test_excludes_test_plans_without_test_executions(test_client: TestClient, generator: DataGenerator):
+    """Test plans with no associated test executions should not be returned."""
+    orphaned_plan_name = f"orphaned_plan_{uuid.uuid4().hex[:8]}"
+    generator.gen_test_plan(name=orphaned_plan_name)
+
+    response = make_authenticated_request(
+        lambda: test_client.get("/v1/test-plans"),
+        Permission.view_test,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert orphaned_plan_name not in data["test_plans"]
+
+
 def test_search_filter_q_ilike(test_client: TestClient, generator: DataGenerator):
     """Search should filter by name (ILIKE)."""
     unique_marker = uuid.uuid4().hex[:8]

--- a/backend/tests/controllers/test_plans/test_test_plans.py
+++ b/backend/tests/controllers/test_plans/test_test_plans.py
@@ -73,19 +73,19 @@ def test_create_test_plan_and_validate_returned(test_client: TestClient, generat
     assert unique_plan_name in data["test_plans"]
 
 
-def test_excludes_test_plans_without_test_executions(test_client: TestClient, generator: DataGenerator):
-    """Test plans with no associated test executions should not be returned."""
+def test_includes_test_plans_without_test_executions(test_client: TestClient, generator: DataGenerator):
+    """Test plans with no associated test executions should still be returned."""
     orphaned_plan_name = f"orphaned_plan_{uuid.uuid4().hex[:8]}"
     generator.gen_test_plan(name=orphaned_plan_name)
 
     response = make_authenticated_request(
-        lambda: test_client.get("/v1/test-plans"),
+        lambda: test_client.get("/v1/test-plans", params={"q": orphaned_plan_name}),
         Permission.view_test,
     )
 
     assert response.status_code == 200
     data = response.json()
-    assert orphaned_plan_name not in data["test_plans"]
+    assert orphaned_plan_name in data["test_plans"]
 
 
 def test_search_filter_q_ilike(test_client: TestClient, generator: DataGenerator):


### PR DESCRIPTION
Part 3 of 6 in the test_plans/filter-parity stack (see #855 for full context). Stacked on #857.

Adds a new `GET /v1/test-plans` endpoint to search distinct test plan names, used to power test_plans filter dropdowns/autocomplete in the frontend. This completes the backend portion of the stack.

Stack:
1. backend: test_plans matching in attachment rules
2. backend: test_plans filter in test-execution/test-result search
3. **This PR** — backend: new `GET /v1/test-plans` endpoint
4. frontend: TestResultsFilters model parity (artefact_versions/stages/tracks, test_plans)
5. frontend: attachment rule filter parity
6. frontend: Test Results page UI filters + dialog fix