### PR TITLE
feat: add artefact_versions/stages/tracks and test_plans to TestResultsFilters (4/6)

### DIFF
--- a/frontend/lib/models/test_results_filters.dart
+++ b/frontend/lib/models/test_results_filters.dart
@@ -127,10 +127,16 @@ abstract class TestResultsFilters with _$TestResultsFilters {
     @Default([])
     List<TestResultStatus> testResultStatuses,
     @Default([]) List<String> artefacts,
+    @JsonKey(name: 'artefact_versions')
+    @Default([])
+    List<String> artefactVersions,
+    @JsonKey(name: 'artefact_stages') @Default([]) List<String> artefactStages,
+    @JsonKey(name: 'artefact_tracks') @Default([]) List<String> artefactTracks,
     @JsonKey(name: 'artefact_is_archived') bool? artefactIsArchived,
     @JsonKey(name: 'rerun_is_requested') bool? rerunIsRequested,
     @JsonKey(name: 'execution_is_latest') bool? executionIsLatest,
     @Default([]) List<String> environments,
+    @JsonKey(name: 'test_plans') @Default([]) List<String> testPlans,
     @JsonKey(name: 'test_cases') @Default([]) List<String> testCases,
     @JsonKey(name: 'template_ids') @Default([]) List<String> templateIds,
     @JsonKey(name: 'execution_metadata')
@@ -174,6 +180,9 @@ abstract class TestResultsFilters with _$TestResultsFilters {
         .map((s) => TestResultStatus.fromString(s))
         .toList();
     final artefacts = parseParam(parameters['artefacts']);
+    final artefactVersions = parseParam(parameters['artefact_versions']);
+    final artefactStages = parseParam(parameters['artefact_stages']);
+    final artefactTracks = parseParam(parameters['artefact_tracks']);
     final artefactIsArchived = parseParam(parameters['artefact_is_archived'])
         .map((s) => s.toLowerCase() == 'true')
         .firstOrNull;
@@ -184,6 +193,7 @@ abstract class TestResultsFilters with _$TestResultsFilters {
         .map((s) => s.toLowerCase() == 'true')
         .firstOrNull;
     final environments = parseParam(parameters['environments']);
+    final testPlans = parseParam(parameters['test_plans']);
     final testCases = parseParam(parameters['test_cases']);
     final templateIds = parseParam(parameters['template_ids']);
     final executionMetadata = ExecutionMetadata.fromQueryParams(
@@ -212,10 +222,14 @@ abstract class TestResultsFilters with _$TestResultsFilters {
       families: families,
       testResultStatuses: testResultStatuses,
       artefacts: artefacts,
+      artefactVersions: artefactVersions,
+      artefactStages: artefactStages,
+      artefactTracks: artefactTracks,
       artefactIsArchived: artefactIsArchived,
       rerunIsRequested: rerunIsRequested,
       executionIsLatest: executionIsLatest,
       environments: environments,
+      testPlans: testPlans,
       testCases: testCases,
       templateIds: templateIds,
       executionMetadata: executionMetadata,
@@ -240,6 +254,15 @@ abstract class TestResultsFilters with _$TestResultsFilters {
     if (artefacts.isNotEmpty) {
       params['artefacts'] = artefacts;
     }
+    if (artefactVersions.isNotEmpty) {
+      params['artefact_versions'] = artefactVersions;
+    }
+    if (artefactStages.isNotEmpty) {
+      params['artefact_stages'] = artefactStages;
+    }
+    if (artefactTracks.isNotEmpty) {
+      params['artefact_tracks'] = artefactTracks;
+    }
     if (artefactIsArchived != null) {
       params['artefact_is_archived'] = [artefactIsArchived.toString()];
     }
@@ -251,6 +274,9 @@ abstract class TestResultsFilters with _$TestResultsFilters {
     }
     if (environments.isNotEmpty) {
       params['environments'] = environments;
+    }
+    if (testPlans.isNotEmpty) {
+      params['test_plans'] = testPlans;
     }
     if (testCases.isNotEmpty) {
       params['test_cases'] = testCases;
@@ -288,10 +314,14 @@ abstract class TestResultsFilters with _$TestResultsFilters {
       families.isNotEmpty ||
       testResultStatuses.isNotEmpty ||
       artefacts.isNotEmpty ||
+      artefactVersions.isNotEmpty ||
+      artefactStages.isNotEmpty ||
+      artefactTracks.isNotEmpty ||
       artefactIsArchived != null ||
       rerunIsRequested != null ||
       executionIsLatest != null ||
       environments.isNotEmpty ||
+      testPlans.isNotEmpty ||
       testCases.isNotEmpty ||
       templateIds.isNotEmpty ||
       executionMetadata.isNotEmpty ||

--- a/frontend/test/models/test_results_filters_test.dart
+++ b/frontend/test/models/test_results_filters_test.dart
@@ -390,8 +390,12 @@ void main() {
           'families': ['family1,family2'],
           'test_result_statuses': ['PASSED,FAILED'],
           'artefacts': ['artefact1'],
+          'artefact_versions': ['1.0,2.0'],
+          'artefact_stages': ['beta,stable'],
+          'artefact_tracks': ['latest,22'],
           'environments': ['env1,env2'],
           'test_cases': ['test1'],
+          'test_plans': ['plan1,plan2'],
           'template_ids': ['template1,template2'],
           'execution_metadata': [
             '${base64Encode(utf8.encode('key'))}:${base64Encode(utf8.encode('value'))}',
@@ -412,8 +416,12 @@ void main() {
           equals([TestResultStatus.passed, TestResultStatus.failed]),
         );
         expect(filters.artefacts, equals(['artefact1']));
+        expect(filters.artefactVersions, equals(['1.0', '2.0']));
+        expect(filters.artefactStages, equals(['beta', 'stable']));
+        expect(filters.artefactTracks, equals(['latest', '22']));
         expect(filters.environments, equals(['env1', 'env2']));
         expect(filters.testCases, equals(['test1']));
+        expect(filters.testPlans, equals(['plan1', 'plan2']));
         expect(filters.templateIds, equals(['template1', 'template2']));
         expect(filters.issues.values, equals([1, 2, 3]));
         expect(filters.reviewers.isAny, isTrue);
@@ -463,8 +471,12 @@ void main() {
           families: ['family1', 'family2'],
           testResultStatuses: [TestResultStatus.passed],
           artefacts: ['artefact1'],
+          artefactVersions: ['1.0'],
+          artefactStages: ['beta'],
+          artefactTracks: ['latest'],
           environments: ['env1'],
           testCases: ['test1'],
+          testPlans: ['plan1'],
           templateIds: ['template1'],
           executionMetadata: ExecutionMetadata(
             data: {
@@ -484,8 +496,12 @@ void main() {
         expect(params['families'], equals(['family1', 'family2']));
         expect(params['test_result_statuses'], equals(['PASSED']));
         expect(params['artefacts'], equals(['artefact1']));
+        expect(params['artefact_versions'], equals(['1.0']));
+        expect(params['artefact_stages'], equals(['beta']));
+        expect(params['artefact_tracks'], equals(['latest']));
         expect(params['environments'], equals(['env1']));
         expect(params['test_cases'], equals(['test1']));
+        expect(params['test_plans'], equals(['plan1']));
         expect(params['template_ids'], equals(['template1']));
         expect(
           params['execution_metadata'],
@@ -509,6 +525,10 @@ void main() {
         expect(params.containsKey('test_result_statuses'), isFalse);
         expect(params.containsKey('issues'), isFalse);
         expect(params.containsKey('from_date'), isFalse);
+        expect(params.containsKey('artefact_versions'), isFalse);
+        expect(params.containsKey('artefact_stages'), isFalse);
+        expect(params.containsKey('artefact_tracks'), isFalse);
+        expect(params.containsKey('test_plans'), isFalse);
       });
 
       test('toQueryParams handles IntListFilter variants', () {
@@ -603,6 +623,26 @@ void main() {
 
       test('returns true when artefacts is not empty', () {
         const filters = TestResultsFilters(artefacts: ['artefact1']);
+        expect(filters.hasFilters, isTrue);
+      });
+
+      test('returns true when artefactVersions is not empty', () {
+        const filters = TestResultsFilters(artefactVersions: ['1.0']);
+        expect(filters.hasFilters, isTrue);
+      });
+
+      test('returns true when artefactStages is not empty', () {
+        const filters = TestResultsFilters(artefactStages: ['beta']);
+        expect(filters.hasFilters, isTrue);
+      });
+
+      test('returns true when artefactTracks is not empty', () {
+        const filters = TestResultsFilters(artefactTracks: ['latest']);
+        expect(filters.hasFilters, isTrue);
+      });
+
+      test('returns true when testPlans is not empty', () {
+        const filters = TestResultsFilters(testPlans: ['plan1']);
         expect(filters.hasFilters, isTrue);
       });
 


### PR DESCRIPTION
Part 4 of 6 in the test_plans/filter-parity stack (see #855 for full context). Stacked on #858.

Adds `artefactVersions`, `artefactStages`, `artefactTracks`, and `testPlans` fields to the `TestResultsFilters` model for parity with backend filter support (PRs 1-3).

Stack: 1 (#856) → 2 (#857) → 3 (#858) → **4 (this)** → 5 (#860) → 6 (#861)