### PR TITLE
feat: add filter parity to attachment rules (frontend) (5/6)

### DIFF
--- a/frontend/lib/models/attachment_rule.dart
+++ b/frontend/lib/models/attachment_rule.dart
@@ -29,9 +29,16 @@ abstract class AttachmentRule with _$AttachmentRule {
     required int id,
     required bool enabled,
     @JsonKey(name: 'families') @Default([]) List<String> families,
+    @JsonKey(name: 'artefacts') @Default([]) List<String> artefacts,
+    @JsonKey(name: 'artefact_versions')
+    @Default([])
+    List<String> artefactVersions,
+    @JsonKey(name: 'artefact_stages') @Default([]) List<String> artefactStages,
+    @JsonKey(name: 'artefact_tracks') @Default([]) List<String> artefactTracks,
     @JsonKey(name: 'environment_names')
     @Default([])
     List<String> environmentNames,
+    @JsonKey(name: 'test_plans') @Default([]) List<String> testPlans,
     @JsonKey(name: 'test_case_names') @Default([]) List<String> testCaseNames,
     @JsonKey(name: 'template_ids') @Default([]) List<String> templateIds,
     @JsonKey(name: 'execution_metadata')
@@ -48,7 +55,12 @@ abstract class AttachmentRule with _$AttachmentRule {
   AttachmentRuleFilters toFilters() {
     return AttachmentRuleFilters(
       families: families,
+      artefacts: artefacts,
+      artefactVersions: artefactVersions,
+      artefactStages: artefactStages,
+      artefactTracks: artefactTracks,
       environmentNames: environmentNames,
+      testPlans: testPlans,
       testCaseNames: testCaseNames,
       templateIds: templateIds,
       testResultStatuses: testResultStatuses,

--- a/frontend/lib/models/attachment_rule_filters.dart
+++ b/frontend/lib/models/attachment_rule_filters.dart
@@ -29,9 +29,16 @@ abstract class AttachmentRuleFilters with _$AttachmentRuleFilters {
   @JsonSerializable(explicitToJson: true)
   const factory AttachmentRuleFilters({
     @JsonKey(name: 'families') @Default([]) List<String> families,
+    @JsonKey(name: 'artefacts') @Default([]) List<String> artefacts,
+    @JsonKey(name: 'artefact_versions')
+    @Default([])
+    List<String> artefactVersions,
+    @JsonKey(name: 'artefact_stages') @Default([]) List<String> artefactStages,
+    @JsonKey(name: 'artefact_tracks') @Default([]) List<String> artefactTracks,
     @JsonKey(name: 'environment_names')
     @Default([])
     List<String> environmentNames,
+    @JsonKey(name: 'test_plans') @Default([]) List<String> testPlans,
     @JsonKey(name: 'test_case_names') @Default([]) List<String> testCaseNames,
     @JsonKey(name: 'template_ids') @Default([]) List<String> templateIds,
     @JsonKey(name: 'test_result_statuses')
@@ -50,7 +57,12 @@ abstract class AttachmentRuleFilters with _$AttachmentRuleFilters {
   ) {
     return AttachmentRuleFilters(
       families: filters.families,
+      artefacts: filters.artefacts,
+      artefactVersions: filters.artefactVersions,
+      artefactStages: filters.artefactStages,
+      artefactTracks: filters.artefactTracks,
       environmentNames: filters.environments,
+      testPlans: filters.testPlans,
       testCaseNames: filters.testCases,
       templateIds: filters.templateIds,
       testResultStatuses: filters.testResultStatuses,
@@ -61,7 +73,12 @@ abstract class AttachmentRuleFilters with _$AttachmentRuleFilters {
   TestResultsFilters toTestResultsFilters() {
     return TestResultsFilters(
       families: families,
+      artefacts: artefacts,
+      artefactVersions: artefactVersions,
+      artefactStages: artefactStages,
+      artefactTracks: artefactTracks,
       environments: environmentNames,
+      testPlans: testPlans,
       testCases: testCaseNames,
       templateIds: templateIds,
       testResultStatuses: testResultStatuses,
@@ -79,7 +96,12 @@ abstract class AttachmentRuleFilters with _$AttachmentRuleFilters {
   factory AttachmentRuleFilters.fromAttachmentRule(AttachmentRule rule) {
     return AttachmentRuleFilters(
       families: rule.families,
+      artefacts: rule.artefacts,
+      artefactVersions: rule.artefactVersions,
+      artefactStages: rule.artefactStages,
+      artefactTracks: rule.artefactTracks,
       environmentNames: rule.environmentNames,
+      testPlans: rule.testPlans,
       testCaseNames: rule.testCaseNames,
       templateIds: rule.templateIds,
       testResultStatuses: rule.testResultStatuses,
@@ -89,7 +111,12 @@ abstract class AttachmentRuleFilters with _$AttachmentRuleFilters {
 
   get hasFilters {
     return families.isNotEmpty ||
+        artefacts.isNotEmpty ||
+        artefactVersions.isNotEmpty ||
+        artefactStages.isNotEmpty ||
+        artefactTracks.isNotEmpty ||
         environmentNames.isNotEmpty ||
+        testPlans.isNotEmpty ||
         testCaseNames.isNotEmpty ||
         templateIds.isNotEmpty ||
         executionMetadata.isNotEmpty ||

--- a/frontend/lib/models/attachment_rule_filters.dart
+++ b/frontend/lib/models/attachment_rule_filters.dart
@@ -109,7 +109,7 @@ abstract class AttachmentRuleFilters with _$AttachmentRuleFilters {
     );
   }
 
-  get hasFilters {
+  bool get hasFilters {
     return families.isNotEmpty ||
         artefacts.isNotEmpty ||
         artefactVersions.isNotEmpty ||

--- a/frontend/lib/models/stage_name.dart
+++ b/frontend/lib/models/stage_name.dart
@@ -30,6 +30,10 @@ enum StageName {
   empty;
 
   bool get isEmpty => this == empty;
+
+  /// The value used when this stage is serialized to/from JSON and the API
+  /// (an empty string for [StageName.empty], the enum name otherwise).
+  String get apiValue => isEmpty ? '' : name;
 }
 
 List<StageName> familyStages(FamilyName family) {

--- a/frontend/lib/ui/artefact_page/issue_attachments/issue_forms/attachment_rule_section.dart
+++ b/frontend/lib/ui/artefact_page/issue_attachments/issue_forms/attachment_rule_section.dart
@@ -43,6 +43,10 @@ class AttachmentRuleSection extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final artefact = ref.read(artefactProvider(artefactId)).value;
     final familyName = artefact?.family ?? '';
+    final artefactName = artefact?.name ?? '';
+    final artefactVersion = artefact?.version ?? '';
+    final artefactStage = artefact?.stage.name ?? '';
+    final artefactTrack = artefact?.track ?? '';
     final templateId = testResult?.templateId ?? '';
     final testCaseName = testResult?.name ?? '';
     final testExecution = ref
@@ -59,8 +63,14 @@ class AttachmentRuleSection extends ConsumerWidget {
         .value;
     final executionMetadata =
         testExecution?.executionMetadata ?? ExecutionMetadata();
+    final testPlan = testExecution?.testPlan ?? '';
     final filters = AttachmentRuleFilters(
       families: familyName.isNotEmpty ? [familyName] : [],
+      artefacts: artefactName.isNotEmpty ? [artefactName] : [],
+      artefactVersions: artefactVersion.isNotEmpty ? [artefactVersion] : [],
+      artefactStages: artefactStage.isNotEmpty ? [artefactStage] : [],
+      artefactTracks: artefactTrack.isNotEmpty ? [artefactTrack] : [],
+      testPlans: testPlan.isNotEmpty ? [testPlan] : [],
       testCaseNames: testCaseName.isNotEmpty ? [testCaseName] : [],
       templateIds: templateId.isNotEmpty ? [templateId] : [],
       executionMetadata: executionMetadata,

--- a/frontend/lib/ui/artefact_page/issue_attachments/issue_forms/attachment_rule_section.dart
+++ b/frontend/lib/ui/artefact_page/issue_attachments/issue_forms/attachment_rule_section.dart
@@ -45,7 +45,9 @@ class AttachmentRuleSection extends ConsumerWidget {
     final familyName = artefact?.family ?? '';
     final artefactName = artefact?.name ?? '';
     final artefactVersion = artefact?.version ?? '';
-    final artefactStage = artefact?.stage.name ?? '';
+    final artefactStage = (artefact != null && !artefact.stage.isEmpty)
+        ? artefact.stage.name
+        : '';
     final artefactTrack = artefact?.track ?? '';
     final templateId = testResult?.templateId ?? '';
     final testCaseName = testResult?.name ?? '';

--- a/frontend/lib/ui/attachment_rule.dart
+++ b/frontend/lib/ui/attachment_rule.dart
@@ -110,6 +110,57 @@ class AttachmentRuleFiltersWidget extends StatelessWidget {
               ),
               _buildFilterSection(
                 context: context,
+                label: 'Artefacts',
+                allValues: filters.artefacts,
+                selectedValues: selected.artefacts.toSet(),
+                onChanged: (newArtefacts) {
+                  final newFilters =
+                      selected.copyWith(artefacts: newArtefacts.toList());
+                  field.didChange(newFilters);
+                  onChanged?.call(newFilters);
+                },
+              ),
+              _buildFilterSection(
+                context: context,
+                label: 'Artefact Versions',
+                allValues: filters.artefactVersions,
+                selectedValues: selected.artefactVersions.toSet(),
+                onChanged: (newArtefactVersions) {
+                  final newFilters = selected.copyWith(
+                    artefactVersions: newArtefactVersions.toList(),
+                  );
+                  field.didChange(newFilters);
+                  onChanged?.call(newFilters);
+                },
+              ),
+              _buildFilterSection(
+                context: context,
+                label: 'Artefact Stages',
+                allValues: filters.artefactStages,
+                selectedValues: selected.artefactStages.toSet(),
+                onChanged: (newArtefactStages) {
+                  final newFilters = selected.copyWith(
+                    artefactStages: newArtefactStages.toList(),
+                  );
+                  field.didChange(newFilters);
+                  onChanged?.call(newFilters);
+                },
+              ),
+              _buildFilterSection(
+                context: context,
+                label: 'Artefact Tracks',
+                allValues: filters.artefactTracks,
+                selectedValues: selected.artefactTracks.toSet(),
+                onChanged: (newArtefactTracks) {
+                  final newFilters = selected.copyWith(
+                    artefactTracks: newArtefactTracks.toList(),
+                  );
+                  field.didChange(newFilters);
+                  onChanged?.call(newFilters);
+                },
+              ),
+              _buildFilterSection(
+                context: context,
                 label: 'Environments',
                 allValues: filters.environmentNames,
                 selectedValues: selected.environmentNames.toSet(),
@@ -117,6 +168,18 @@ class AttachmentRuleFiltersWidget extends StatelessWidget {
                   final newFilters = selected.copyWith(
                     environmentNames: newEnvironments.toList(),
                   );
+                  field.didChange(newFilters);
+                  onChanged?.call(newFilters);
+                },
+              ),
+              _buildFilterSection(
+                context: context,
+                label: 'Test Plans',
+                allValues: filters.testPlans,
+                selectedValues: selected.testPlans.toSet(),
+                onChanged: (newTestPlans) {
+                  final newFilters =
+                      selected.copyWith(testPlans: newTestPlans.toList());
                   field.didChange(newFilters);
                   onChanged?.call(newFilters);
                 },

--- a/frontend/test/models/attachment_rule_filters_test.dart
+++ b/frontend/test/models/attachment_rule_filters_test.dart
@@ -1,0 +1,178 @@
+// Copyright 2026 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:testcase_dashboard/models/attachment_rule_filters.dart';
+import 'package:testcase_dashboard/models/test_result.dart';
+import 'package:testcase_dashboard/models/test_results_filters.dart';
+
+void main() {
+  group('AttachmentRuleFilters', () {
+    const filters = AttachmentRuleFilters(
+      families: ['snap'],
+      artefacts: ['artefact1'],
+      artefactVersions: ['1.0'],
+      artefactStages: ['beta'],
+      artefactTracks: ['latest'],
+      environmentNames: ['env1'],
+      testPlans: ['plan1'],
+      testCaseNames: ['test1'],
+      templateIds: ['template1'],
+      testResultStatuses: [TestResultStatus.passed],
+    );
+
+    group('JSON serialization', () {
+      test('serializes all fields to JSON', () {
+        final json = filters.toJson();
+
+        expect(json['families'], equals(['snap']));
+        expect(json['artefacts'], equals(['artefact1']));
+        expect(json['artefact_versions'], equals(['1.0']));
+        expect(json['artefact_stages'], equals(['beta']));
+        expect(json['artefact_tracks'], equals(['latest']));
+        expect(json['environment_names'], equals(['env1']));
+        expect(json['test_plans'], equals(['plan1']));
+        expect(json['test_case_names'], equals(['test1']));
+        expect(json['template_ids'], equals(['template1']));
+        expect(json['test_result_statuses'], equals(['PASSED']));
+      });
+
+      test('deserializes all fields from JSON', () {
+        final restored = AttachmentRuleFilters.fromJson(filters.toJson());
+
+        expect(restored, equals(filters));
+      });
+
+      test('deserializes with missing optional fields', () {
+        final restored = AttachmentRuleFilters.fromJson({});
+
+        expect(restored.families, equals([]));
+        expect(restored.artefactVersions, equals([]));
+        expect(restored.artefactStages, equals([]));
+        expect(restored.artefactTracks, equals([]));
+        expect(restored.testPlans, equals([]));
+      });
+    });
+
+    group('TestResultsFilters conversion', () {
+      test('fromTestResultsFilters copies all matching fields', () {
+        const testResultsFilters = TestResultsFilters(
+          families: ['snap'],
+          artefacts: ['artefact1'],
+          artefactVersions: ['1.0'],
+          artefactStages: ['beta'],
+          artefactTracks: ['latest'],
+          environments: ['env1'],
+          testPlans: ['plan1'],
+          testCases: ['test1'],
+          templateIds: ['template1'],
+          testResultStatuses: [TestResultStatus.passed],
+        );
+
+        final converted = AttachmentRuleFilters.fromTestResultsFilters(
+          testResultsFilters,
+        );
+
+        expect(converted.families, equals(testResultsFilters.families));
+        expect(converted.artefacts, equals(testResultsFilters.artefacts));
+        expect(
+          converted.artefactVersions,
+          equals(testResultsFilters.artefactVersions),
+        );
+        expect(
+          converted.artefactStages,
+          equals(testResultsFilters.artefactStages),
+        );
+        expect(
+          converted.artefactTracks,
+          equals(testResultsFilters.artefactTracks),
+        );
+        expect(
+          converted.environmentNames,
+          equals(testResultsFilters.environments),
+        );
+        expect(converted.testPlans, equals(testResultsFilters.testPlans));
+        expect(converted.testCaseNames, equals(testResultsFilters.testCases));
+        expect(
+          converted.templateIds,
+          equals(testResultsFilters.templateIds),
+        );
+        expect(
+          converted.testResultStatuses,
+          equals(testResultsFilters.testResultStatuses),
+        );
+      });
+
+      test('toTestResultsFilters copies all matching fields back', () {
+        final converted = filters.toTestResultsFilters();
+
+        expect(converted.families, equals(filters.families));
+        expect(converted.artefacts, equals(filters.artefacts));
+        expect(converted.artefactVersions, equals(filters.artefactVersions));
+        expect(converted.artefactStages, equals(filters.artefactStages));
+        expect(converted.artefactTracks, equals(filters.artefactTracks));
+        expect(converted.environments, equals(filters.environmentNames));
+        expect(converted.testPlans, equals(filters.testPlans));
+        expect(converted.testCases, equals(filters.testCaseNames));
+        expect(converted.templateIds, equals(filters.templateIds));
+        expect(
+          converted.testResultStatuses,
+          equals(filters.testResultStatuses),
+        );
+      });
+
+      test('round-trips through TestResultsFilters without data loss', () {
+        final roundTripped = AttachmentRuleFilters.fromTestResultsFilters(
+          filters.toTestResultsFilters(),
+        );
+
+        expect(roundTripped, equals(filters));
+      });
+
+      test('areFiltersCompatible returns true for a round-trippable filter',
+          () {
+        final testResultsFilters = filters.toTestResultsFilters();
+
+        expect(
+          AttachmentRuleFilters.areFiltersCompatible(testResultsFilters),
+          isTrue,
+        );
+      });
+    });
+
+    group('hasFilters', () {
+      test('returns false for empty filters', () {
+        const emptyFilters = AttachmentRuleFilters();
+        expect(emptyFilters.hasFilters, isFalse);
+      });
+
+      test('returns true when any field is set', () {
+        expect(filters.hasFilters, isTrue);
+      });
+
+      test('returns true when only testPlans is set', () {
+        const testPlanFilters = AttachmentRuleFilters(testPlans: ['plan1']);
+        expect(testPlanFilters.hasFilters, isTrue);
+      });
+
+      test('returns true when only artefactVersions is set', () {
+        const versionFilters = AttachmentRuleFilters(
+          artefactVersions: ['1.0'],
+        );
+        expect(versionFilters.hasFilters, isTrue);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Part 5 of 6 in the test_plans/filter-parity stack (see #855 for full context). Stacked on #859.

Extends the attachment rule model, filters, and UI to support the new `artefactVersions`/`artefactStages`/`artefactTracks` and `testPlans` filters, matching `TestResultsFilters` (added in #859).

Stack: 1 (#856) → 2 (#857) → 3 (#858) → 4 (#859) → **5 (this)** → 6 (#861)