### PR TITLE
feat: add test_plans and additional filters to Test Results page UI (6/6)

### DIFF
--- a/frontend/lib/providers/test_results_test_plans.dart
+++ b/frontend/lib/providers/test_results_test_plans.dart
@@ -1,0 +1,39 @@
+// Copyright 2026 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'api.dart';
+
+part 'test_results_test_plans.g.dart';
+
+@riverpod
+Future<List<String>> suggestedTestPlans(
+  Ref ref,
+  String query,
+  List<String> families,
+) async {
+  // Only search if query is long enough
+  if (query.trim().length < 2) {
+    return [];
+  }
+
+  final api = ref.watch(apiProvider);
+  return await api.searchTestPlans(
+    query: query.trim(),
+    limit: 50,
+    families: families.isNotEmpty ? families : null,
+  );
+}

--- a/frontend/lib/repositories/api_repository.dart
+++ b/frontend/lib/repositories/api_repository.dart
@@ -355,6 +355,32 @@ class ApiRepository {
     return environments.cast<String>();
   }
 
+  Future<List<String>> searchTestPlans({
+    String? query,
+    List<String>? families,
+    int limit = 50,
+    int offset = 0,
+  }) async {
+    final queryParams = <String, dynamic>{
+      'limit': limit,
+      'offset': offset,
+    };
+
+    if (query != null && query.trim().isNotEmpty) {
+      queryParams['q'] = query.trim();
+    }
+
+    if (families != null && families.isNotEmpty) {
+      queryParams['families'] = families;
+    }
+
+    final response =
+        await dio.get('/v1/test-plans', queryParameters: queryParams);
+    final Map<String, dynamic> data = response.data;
+    final List<dynamic> testPlans = data['test_plans'] ?? [];
+    return testPlans.cast<String>();
+  }
+
   Future<List<String>> searchTestCases({
     String? query,
     List<String>? families,

--- a/frontend/lib/ui/artefact_page/issue_attachments/issue_forms/attach_issue_form.dart
+++ b/frontend/lib/ui/artefact_page/issue_attachments/issue_forms/attach_issue_form.dart
@@ -184,18 +184,21 @@ class _AttachIssueFormState extends ConsumerState<AttachIssueForm> {
                     // Create the attachment rule if requested.
                     AttachmentRule? attachmentRule;
                     if (_createAttachmentRule) {
-                      if (_attachmentRuleFilters
-                              .testResultStatuses.isNotEmpty &&
-                          context.mounted &&
+                      if (context.mounted &&
                           (_attachToNewerResults || _attachToOlderResults)) {
+                        final hasStatusFilter = _attachmentRuleFilters
+                            .testResultStatuses.isNotEmpty;
                         final confirmed = await showDialog<bool>(
                           context: context,
                           builder: (BuildContext dialogContext) {
                             return AlertDialog(
                               title: const Text('Confirm Attachment Rule'),
-                              content: const Text(
-                                'The attachment rule will apply to all test results with the selected status and filters.\n\n'
-                                'Do you want to continue?',
+                              content: Text(
+                                hasStatusFilter
+                                    ? 'The attachment rule will apply to all test results with the selected status and filters.\n\n'
+                                        'Do you want to continue?'
+                                    : 'The attachment rule will apply to all test results matching the selected filters, regardless of status.\n\n'
+                                        'Do you want to continue?',
                               ),
                               actions: [
                                 TextButton(

--- a/frontend/lib/ui/test_results_page/test_results_filters_view.dart
+++ b/frontend/lib/ui/test_results_page/test_results_filters_view.dart
@@ -21,6 +21,7 @@ import 'package:yaru/yaru.dart';
 import '../../models/execution_metadata.dart';
 import '../../models/family_name.dart';
 import '../../models/issue.dart';
+import '../../models/stage_name.dart';
 import '../../models/test_result.dart';
 import '../../models/test_results_filters.dart';
 import '../../models/user.dart';
@@ -29,6 +30,7 @@ import '../../providers/issues.dart';
 import '../../providers/test_results_artefacts.dart';
 import '../../providers/test_results_environments.dart';
 import '../../providers/test_results_test_cases.dart';
+import '../../providers/test_results_test_plans.dart';
 import '../../providers/users.dart';
 import '../issues.dart';
 import '../page_filters/date_time_selector.dart';
@@ -41,11 +43,15 @@ enum FilterType {
   issues,
   reviewers,
   artefacts,
+  artefactVersions,
+  artefactStages,
+  artefactTracks,
   artefactIsArchived,
   rerunIsRequested,
   executionIsLatest,
   environments,
   testCases,
+  testPlans,
   templateIds,
   metadata,
   dateRange,
@@ -234,6 +240,10 @@ class _TestResultsFiltersViewState
     final allFamilyOptions = FamilyName.values.map((f) => f.name).toList();
     final allTestResultStatusesOptions =
         TestResultStatus.values.map((s) => s.name).toList();
+    final allArtefactStageOptions = StageName.values
+        .where((s) => !s.isEmpty)
+        .map((s) => s.name)
+        .toList();
     final executionMetadata = ref.watch(executionMetadataProvider).value ??
         ExecutionMetadata(data: {});
 
@@ -399,6 +409,80 @@ class _TestResultsFiltersViewState
               },
             ),
           ),
+        if (_isFilterEnabled(FilterType.artefactVersions))
+          _box(
+            MultiSelectCombobox<String>(
+              title: 'Artefact Version',
+              initialSelected: _selectedFilters.artefactVersions.toSet(),
+              // No backend search endpoint for versions, so we allow the
+              // user to type an exact version and add it directly.
+              asyncSuggestionsCallback: (pattern) async {
+                final trimmed = pattern.trim();
+                return trimmed.isEmpty ? [] : [trimmed];
+              },
+              minCharsForAsyncSearch: 1,
+              onChanged: (val, isSelected) {
+                setState(() {
+                  _selectedFilters = _selectedFilters.copyWith(
+                    artefactVersions: [
+                      ..._selectedFilters.artefactVersions
+                          .where((v) => v != val),
+                      if (isSelected) val,
+                    ],
+                  );
+                  _notifyChanged(_selectedFilters);
+                });
+              },
+            ),
+          ),
+        if (_isFilterEnabled(FilterType.artefactStages))
+          _box(
+            MultiSelectCombobox<String>(
+              title: 'Artefact Stage',
+              allOptions: allArtefactStageOptions,
+              showAllOptionsWithoutSearch: true,
+              itemToString: (stage) => stage,
+              initialSelected: _selectedFilters.artefactStages.toSet(),
+              onChanged: (val, isSelected) {
+                setState(() {
+                  _selectedFilters = _selectedFilters.copyWith(
+                    artefactStages: [
+                      ..._selectedFilters.artefactStages
+                          .where((s) => s != val),
+                      if (isSelected) val,
+                    ],
+                  );
+                  _notifyChanged(_selectedFilters);
+                });
+              },
+            ),
+          ),
+        if (_isFilterEnabled(FilterType.artefactTracks))
+          _box(
+            MultiSelectCombobox<String>(
+              title: 'Artefact Track',
+              initialSelected: _selectedFilters.artefactTracks.toSet(),
+              // No backend search endpoint for tracks, so we allow the
+              // user to type an exact track and add it directly.
+              asyncSuggestionsCallback: (pattern) async {
+                final trimmed = pattern.trim();
+                return trimmed.isEmpty ? [] : [trimmed];
+              },
+              minCharsForAsyncSearch: 1,
+              onChanged: (val, isSelected) {
+                setState(() {
+                  _selectedFilters = _selectedFilters.copyWith(
+                    artefactTracks: [
+                      ..._selectedFilters.artefactTracks
+                          .where((t) => t != val),
+                      if (isSelected) val,
+                    ],
+                  );
+                  _notifyChanged(_selectedFilters);
+                });
+              },
+            ),
+          ),
         if (_isFilterEnabled(FilterType.artefactIsArchived))
           _box(
             MultiSelectCombobox<bool>(
@@ -511,6 +595,32 @@ class _TestResultsFiltersViewState
                         ? (_selectedFilters.testCases + [val])
                         : _selectedFilters.testCases
                             .where((tc) => tc != val)
+                            .toList(),
+                  );
+                  _notifyChanged(_selectedFilters);
+                });
+              },
+            ),
+          ),
+        if (_isFilterEnabled(FilterType.testPlans))
+          _box(
+            MultiSelectCombobox<String>(
+              title: 'Test Plan',
+              initialSelected: _selectedFilters.testPlans.toSet(),
+              asyncSuggestionsCallback: (pattern) async {
+                return await ref.read(
+                  suggestedTestPlansProvider(pattern, _selectedFilters.families)
+                      .future,
+                );
+              },
+              minCharsForAsyncSearch: 2,
+              onChanged: (val, isSelected) {
+                setState(() {
+                  _selectedFilters = _selectedFilters.copyWith(
+                    testPlans: isSelected
+                        ? (_selectedFilters.testPlans + [val])
+                        : _selectedFilters.testPlans
+                            .where((tp) => tp != val)
                             .toList(),
                   );
                   _notifyChanged(_selectedFilters);

--- a/frontend/lib/ui/test_results_page/test_results_filters_view.dart
+++ b/frontend/lib/ui/test_results_page/test_results_filters_view.dart
@@ -240,10 +240,8 @@ class _TestResultsFiltersViewState
     final allFamilyOptions = FamilyName.values.map((f) => f.name).toList();
     final allTestResultStatusesOptions =
         TestResultStatus.values.map((s) => s.name).toList();
-    final allArtefactStageOptions = StageName.values
-        .where((s) => !s.isEmpty)
-        .map((s) => s.name)
-        .toList();
+    final allArtefactStageOptions =
+        StageName.values.map((s) => s.apiValue).toList();
     final executionMetadata = ref.watch(executionMetadataProvider).value ??
         ExecutionMetadata(data: {});
 
@@ -447,8 +445,7 @@ class _TestResultsFiltersViewState
                 setState(() {
                   _selectedFilters = _selectedFilters.copyWith(
                     artefactStages: [
-                      ..._selectedFilters.artefactStages
-                          .where((s) => s != val),
+                      ..._selectedFilters.artefactStages.where((s) => s != val),
                       if (isSelected) val,
                     ],
                   );
@@ -473,8 +470,7 @@ class _TestResultsFiltersViewState
                 setState(() {
                   _selectedFilters = _selectedFilters.copyWith(
                     artefactTracks: [
-                      ..._selectedFilters.artefactTracks
-                          .where((t) => t != val),
+                      ..._selectedFilters.artefactTracks.where((t) => t != val),
                       if (isSelected) val,
                     ],
                   );

--- a/frontend/lib/ui/test_results_page/test_results_filters_view.dart
+++ b/frontend/lib/ui/test_results_page/test_results_filters_view.dart
@@ -439,7 +439,7 @@ class _TestResultsFiltersViewState
               title: 'Artefact Stage',
               allOptions: allArtefactStageOptions,
               showAllOptionsWithoutSearch: true,
-              itemToString: (stage) => stage,
+              itemToString: (stage) => stage.isEmpty ? '(none)' : stage,
               initialSelected: _selectedFilters.artefactStages.toSet(),
               onChanged: (val, isSelected) {
                 setState(() {
@@ -613,11 +613,10 @@ class _TestResultsFiltersViewState
               onChanged: (val, isSelected) {
                 setState(() {
                   _selectedFilters = _selectedFilters.copyWith(
-                    testPlans: isSelected
-                        ? (_selectedFilters.testPlans + [val])
-                        : _selectedFilters.testPlans
-                            .where((tp) => tp != val)
-                            .toList(),
+                    testPlans: [
+                      ..._selectedFilters.testPlans.where((tp) => tp != val),
+                      if (isSelected) val,
+                    ],
                   );
                   _notifyChanged(_selectedFilters);
                 });


### PR DESCRIPTION
Part 6 of 6 (final) in the test_plans/filter-parity stack (see #855 for full context). Stacked on #860.

- Adds a `test_plans` search provider/repository method (calls the `/v1/test-plans` endpoint from #858)
- Wires up the new `artefact_versions`/`stages`/`tracks` and `test_plans` filters in the Test Results page UI
- Fixes the 'Confirm Attachment Rule' dialog to also prompt when zero test result statuses are selected

Stack: 1 (#856) → 2 (#857) → 3 (#858) → 4 (#859) → 5 (#860) → **6 (this)**