### PR TITLE
TO 431/adding reruns page

### DIFF
--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -503,6 +503,91 @@
         ]
       }
     },
+    "/v1/test-executions/reruns/details": {
+      "get": {
+        "tags": [
+          "test-executions"
+        ],
+        "summary": "Get Rerun Details",
+        "operationId": "get_rerun_details_v1_test_executions_reruns_details_get",
+        "parameters": [
+          {
+            "name": "family",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/FamilyName"
+            }
+          },
+          {
+            "name": "priority",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "maximum": 1000000,
+                  "minimum": -1000000
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Priority"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 50,
+              "minimum": 1,
+              "default": 50,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RerunDetailsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-permissions": [
+          "view_rerun"
+        ]
+      }
+    },
     "/v1/test-executions/{id}": {
       "get": {
         "tags": [
@@ -7841,6 +7926,114 @@
         ],
         "title": "PreviousTestResult"
       },
+      "RerunDetail": {
+        "properties": {
+          "test_plan_name": {
+            "type": "string",
+            "title": "Test Plan Name"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "priority": {
+            "type": "integer",
+            "title": "Priority"
+          },
+          "architecture": {
+            "type": "string",
+            "title": "Architecture"
+          },
+          "environment_name": {
+            "type": "string",
+            "title": "Environment Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "test_plan_name",
+          "created_at",
+          "priority",
+          "architecture",
+          "environment_name"
+        ],
+        "title": "RerunDetail"
+      },
+      "RerunDetailsResponse": {
+        "properties": {
+          "priority_summaries": {
+            "items": {
+              "$ref": "#/components/schemas/RerunPrioritySummary"
+            },
+            "type": "array",
+            "title": "Priority Summaries"
+          },
+          "selected_priority": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selected Priority"
+          },
+          "total_count": {
+            "type": "integer",
+            "title": "Total Count"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          },
+          "reruns": {
+            "items": {
+              "$ref": "#/components/schemas/RerunDetail"
+            },
+            "type": "array",
+            "title": "Reruns"
+          }
+        },
+        "type": "object",
+        "required": [
+          "priority_summaries",
+          "selected_priority",
+          "total_count",
+          "count",
+          "limit",
+          "offset",
+          "reruns"
+        ],
+        "title": "RerunDetailsResponse"
+      },
+      "RerunPrioritySummary": {
+        "properties": {
+          "priority": {
+            "type": "integer",
+            "title": "Priority"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "priority",
+          "count"
+        ],
+        "title": "RerunPrioritySummary"
+      },
       "RerunRequest": {
         "properties": {
           "test_execution_ids": {
@@ -7875,8 +8068,8 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 1000000,
-                "minimum": -1000000
+                "maximum": 1000000.0,
+                "minimum": -1000000.0
               },
               {
                 "type": "null"

--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -8234,8 +8234,8 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 1000000.0,
-                "minimum": -1000000.0
+                "maximum": 1000000,
+                "minimum": -1000000
               },
               {
                 "type": "null"

--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -369,6 +369,29 @@ class PendingRerun(BaseModel):
     created_at: datetime
 
 
+class RerunPrioritySummary(BaseModel):
+    priority: int
+    count: int
+
+
+class RerunDetail(BaseModel):
+    test_plan_name: str
+    created_at: datetime
+    priority: int
+    architecture: str
+    environment_name: str
+
+
+class RerunDetailsResponse(BaseModel):
+    priority_summaries: list[RerunPrioritySummary]
+    selected_priority: int | None
+    total_count: int
+    count: int
+    limit: int
+    offset: int
+    reruns: list[RerunDetail]
+
+
 class DeleteReruns(BaseModel):
     test_execution_ids: set[int] = Field(default_factory=set)
     test_results_filters: TestResultSearchFilters | None = None

--- a/backend/test_observer/controllers/test_executions/reruns.py
+++ b/backend/test_observer/controllers/test_executions/reruns.py
@@ -387,7 +387,7 @@ def get_rerun_details(
 
     available_priorities = {s.priority for s in priority_summaries}
     # Default to the highest priority present when the caller doesn't request one.
-    selected_priority = priority if priority in available_priorities else max(available_priorities)
+    selected_priority = priority if priority is not None else max(available_priorities)
     selected_count = next(s.count for s in priority_summaries if s.priority == selected_priority)
 
     detail_rows = db.execute(

--- a/backend/test_observer/controllers/test_executions/reruns.py
+++ b/backend/test_observer/controllers/test_executions/reruns.py
@@ -388,7 +388,7 @@ def get_rerun_details(
     available_priorities = {s.priority for s in priority_summaries}
     # Default to the highest priority present when the caller doesn't request one.
     selected_priority = priority if priority is not None else max(available_priorities)
-    selected_count = next(s.count for s in priority_summaries if s.priority == selected_priority)
+    selected_count = next((s.count for s in priority_summaries if s.priority == selected_priority), 0)
 
     detail_rows = db.execute(
         select(

--- a/backend/test_observer/controllers/test_executions/reruns.py
+++ b/backend/test_observer/controllers/test_executions/reruns.py
@@ -18,7 +18,7 @@ from typing import Annotated
 
 from fastapi import Depends, HTTPException, Query, Response, Security, status
 from fastapi.security import SecurityScopes
-from sqlalchemy import Select, and_, asc, delete, desc, literal, or_, select, tuple_
+from sqlalchemy import Select, and_, asc, delete, desc, func, literal, or_, select, tuple_
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session, selectinload
 
@@ -47,6 +47,7 @@ from test_observer.data_access.models import (
     FamilyName,
     TestExecution,
     TestExecutionRerunRequest,
+    TestPlan,
     TestResult,
     User,
 )
@@ -54,7 +55,16 @@ from test_observer.data_access.repository import get_or_create
 from test_observer.data_access.setup import get_db
 from test_observer.users.user_injection import get_current_user
 
-from .models import DeleteReruns, PendingRerun, RerunRequest
+from .models import (
+    RERUN_PRIORITY_MAX,
+    RERUN_PRIORITY_MIN,
+    DeleteReruns,
+    PendingRerun,
+    RerunDetail,
+    RerunDetailsResponse,
+    RerunPrioritySummary,
+    RerunRequest,
+)
 from .router import router
 
 
@@ -338,6 +348,92 @@ def get_rerun_requests(
         stmt = stmt.limit(limit)
 
     return db.scalars(stmt)
+
+
+@router.get(
+    "/reruns/details",
+    response_model=RerunDetailsResponse,
+    dependencies=[Security(permission_checker, scopes=[Permission.view_rerun])],
+)
+def get_rerun_details(
+    family: FamilyName,
+    priority: Annotated[int | None, Query(ge=RERUN_PRIORITY_MIN, le=RERUN_PRIORITY_MAX)] = None,
+    limit: Annotated[int, Query(ge=1, le=50)] = 50,
+    offset: Annotated[int, Query(ge=0)] = 0,
+    db: Session = Depends(get_db),
+):
+    summary_rows = db.execute(
+        select(TestExecutionRerunRequest.priority, func.count())
+        .join(TestExecutionRerunRequest.artefact_build)
+        .join(ArtefactBuild.artefact)
+        .where(Artefact.family == family)
+        .group_by(TestExecutionRerunRequest.priority)
+        .order_by(TestExecutionRerunRequest.priority)
+    ).all()
+
+    priority_summaries = [RerunPrioritySummary(priority=p, count=c) for p, c in summary_rows]
+    total_count = sum(s.count for s in priority_summaries)
+
+    if not priority_summaries:
+        return RerunDetailsResponse(
+            priority_summaries=[],
+            selected_priority=None,
+            total_count=0,
+            count=0,
+            limit=limit,
+            offset=offset,
+            reruns=[],
+        )
+
+    available_priorities = {s.priority for s in priority_summaries}
+    # Default to the highest priority present when the caller doesn't request one.
+    selected_priority = priority if priority in available_priorities else max(available_priorities)
+    selected_count = next(s.count for s in priority_summaries if s.priority == selected_priority)
+
+    detail_rows = db.execute(
+        select(
+            TestPlan.name,
+            TestExecutionRerunRequest.created_at,
+            TestExecutionRerunRequest.priority,
+            Environment.architecture,
+            Environment.name,
+        )
+        .join(TestExecutionRerunRequest.artefact_build)
+        .join(ArtefactBuild.artefact)
+        .join(TestExecutionRerunRequest.environment)
+        .join(TestExecutionRerunRequest.test_plan)
+        .where(
+            Artefact.family == family,
+            TestExecutionRerunRequest.priority == selected_priority,
+        )
+        .order_by(
+            asc(TestExecutionRerunRequest.created_at),
+            asc(TestExecutionRerunRequest.id),
+        )
+        .offset(offset)
+        .limit(limit)
+    ).all()
+
+    reruns = [
+        RerunDetail(
+            test_plan_name=test_plan_name,
+            created_at=created_at,
+            priority=row_priority,
+            architecture=architecture,
+            environment_name=environment_name,
+        )
+        for test_plan_name, created_at, row_priority, architecture, environment_name in detail_rows
+    ]
+
+    return RerunDetailsResponse(
+        priority_summaries=priority_summaries,
+        selected_priority=selected_priority,
+        total_count=total_count,
+        count=selected_count,
+        limit=limit,
+        offset=offset,
+        reruns=reruns,
+    )
 
 
 @router.delete(

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -1963,3 +1963,99 @@ def test_post_priority_at_max_is_accepted(post: Post, get: Get, test_execution: 
 def test_post_priority_at_min_is_accepted(post: Post, get: Get, test_execution: TestExecution):
     post({"test_execution_ids": [test_execution.id], "priority": -1_000_000})
     assert get().json()[0]["priority"] == -1_000_000
+
+
+# ==============================================================================
+# GET /reruns/details
+# ==============================================================================
+
+details_url = "/v1/test-executions/reruns/details"
+
+
+def _get_details(test_client: TestClient, **params: Any) -> Response:  # noqa: ANN401
+    return make_authenticated_request(
+        lambda: test_client.get(details_url, params=params),
+        Permission.view_rerun,
+    )
+
+
+def test_details_groups_counts_by_priority_and_defaults_to_highest(test_client: TestClient, generator: DataGenerator):
+    a = generator.gen_artefact(StageName.beta, family=FamilyName.charm)
+    ab = generator.gen_artefact_build(a)
+    # Distinct environments so each rerun is its own (test_plan, build, environment) group.
+    for i, priority in enumerate([5, 5, 0, -3]):
+        e = generator.gen_environment(f"charm-env-{i}")
+        te = generator.gen_test_execution(ab, e)
+        generator.gen_rerun_request(te, priority=priority)
+
+    body = _get_details(test_client, family="charm").json()
+
+    assert body["priority_summaries"] == [
+        {"priority": -3, "count": 1},
+        {"priority": 0, "count": 1},
+        {"priority": 5, "count": 2},
+    ]
+    assert body["total_count"] == 4
+    assert body["selected_priority"] == 5
+    assert body["count"] == 2
+    assert {r["priority"] for r in body["reruns"]} == {5}
+
+
+def test_details_selected_priority_returns_fields_and_paginates(test_client: TestClient, generator: DataGenerator):
+    a = generator.gen_artefact(StageName.beta, family=FamilyName.charm)
+    ab = generator.gen_artefact_build(a)
+    total = 55
+    for i in range(total):
+        e = generator.gen_environment(f"page-env-{i}", architecture="arm64")
+        te = generator.gen_test_execution(ab, e, test_plan="page-plan")
+        generator.gen_rerun_request(te, priority=7)
+
+    first = _get_details(test_client, family="charm", priority=7).json()
+    assert first["selected_priority"] == 7
+    assert first["count"] == total
+    assert first["limit"] == 50
+    assert first["offset"] == 0
+    assert len(first["reruns"]) == 50
+
+    row = first["reruns"][0]
+    assert set(row.keys()) == {
+        "test_plan_name",
+        "created_at",
+        "priority",
+        "architecture",
+        "environment_name",
+    }
+    assert row["test_plan_name"] == "page-plan"
+    assert row["priority"] == 7
+    assert row["architecture"] == "arm64"
+    assert row["environment_name"].startswith("page-env-")
+
+    second = _get_details(test_client, family="charm", priority=7, offset=50).json()
+    assert second["offset"] == 50
+    assert len(second["reruns"]) == total - 50
+
+
+def test_details_filters_by_family_and_is_empty_when_none_exist(test_client: TestClient, generator: DataGenerator):
+    charm = generator.gen_artefact(StageName.beta, family=FamilyName.charm)
+    snap = generator.gen_artefact(StageName.beta, family=FamilyName.snap)
+    e = generator.gen_environment("family-env")
+    for artefact in (charm, snap):
+        ab = generator.gen_artefact_build(artefact)
+        te = generator.gen_test_execution(ab, e)
+        generator.gen_rerun_request(te, priority=1)
+
+    charm_body = _get_details(test_client, family="charm").json()
+    assert charm_body["total_count"] == 1
+    assert [s["priority"] for s in charm_body["priority_summaries"]] == [1]
+
+    deb_body = _get_details(test_client, family="deb").json()
+    assert deb_body["priority_summaries"] == []
+    assert deb_body["selected_priority"] is None
+    assert deb_body["total_count"] == 0
+    assert deb_body["reruns"] == []
+
+
+def test_details_rejects_out_of_range_priority_and_limit(test_client: TestClient):
+    with override_permissions(Permission.view_rerun):
+        assert test_client.get(details_url, params={"family": "charm", "priority": 1_000_001}).status_code == 422
+        assert test_client.get(details_url, params={"family": "charm", "limit": 51}).status_code == 422

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -2060,3 +2060,16 @@ def test_details_rejects_out_of_range_priority_and_limit(test_client: TestClient
     with override_permissions(Permission.view_rerun):
         assert test_client.get(details_url, params={"family": "charm", "priority": 1_000_001}).status_code == 422
         assert test_client.get(details_url, params={"family": "charm", "limit": 51}).status_code == 422
+
+
+def test_details_requires_view_rerun_permission(test_client: TestClient):
+    # Unauthenticated request is rejected.
+    assert test_client.get(details_url, params={"family": "charm"}).status_code == 403
+
+    # Authenticated without view_rerun is rejected.
+    with override_permissions(Permission.view_test):
+        assert test_client.get(details_url, params={"family": "charm"}).status_code == 403
+
+    # view_rerun grants access.
+    with override_permissions(Permission.view_rerun):
+        assert test_client.get(details_url, params={"family": "charm"}).status_code == 200

--- a/frontend/lib/models/rerun_details.dart
+++ b/frontend/lib/models/rerun_details.dart
@@ -1,0 +1,61 @@
+// Copyright 2026 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'rerun_details.freezed.dart';
+part 'rerun_details.g.dart';
+
+@freezed
+abstract class RerunPrioritySummary with _$RerunPrioritySummary {
+  const factory RerunPrioritySummary({
+    required int priority,
+    required int count,
+  }) = _RerunPrioritySummary;
+
+  factory RerunPrioritySummary.fromJson(Map<String, Object?> json) =>
+      _$RerunPrioritySummaryFromJson(json);
+}
+
+@freezed
+abstract class RerunDetail with _$RerunDetail {
+  const factory RerunDetail({
+    @JsonKey(name: 'test_plan_name') required String testPlanName,
+    @JsonKey(name: 'created_at') required DateTime createdAt,
+    required int priority,
+    required String architecture,
+    @JsonKey(name: 'environment_name') required String environmentName,
+  }) = _RerunDetail;
+
+  factory RerunDetail.fromJson(Map<String, Object?> json) =>
+      _$RerunDetailFromJson(json);
+}
+
+@freezed
+abstract class RerunDetailsResponse with _$RerunDetailsResponse {
+  const factory RerunDetailsResponse({
+    @JsonKey(name: 'priority_summaries')
+    required List<RerunPrioritySummary> prioritySummaries,
+    @JsonKey(name: 'selected_priority') int? selectedPriority,
+    @JsonKey(name: 'total_count') required int totalCount,
+    required int count,
+    required int limit,
+    required int offset,
+    required List<RerunDetail> reruns,
+  }) = _RerunDetailsResponse;
+
+  factory RerunDetailsResponse.fromJson(Map<String, Object?> json) =>
+      _$RerunDetailsResponseFromJson(json);
+}

--- a/frontend/lib/providers/rerun_details.dart
+++ b/frontend/lib/providers/rerun_details.dart
@@ -22,6 +22,8 @@ import 'api.dart';
 
 part 'rerun_details.g.dart';
 
+const rerunsPageSize = 50;
+
 @riverpod
 Future<RerunDetailsResponse> rerunDetails(
   Ref ref, {
@@ -34,6 +36,7 @@ Future<RerunDetailsResponse> rerunDetails(
   return api.getRerunDetails(
     family: family,
     priority: priority,
-    offset: (safePage - 1) * 50,
+    limit: rerunsPageSize,
+    offset: (safePage - 1) * rerunsPageSize,
   );
 }

--- a/frontend/lib/providers/rerun_details.dart
+++ b/frontend/lib/providers/rerun_details.dart
@@ -1,0 +1,38 @@
+// Copyright 2026 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../models/family_name.dart';
+import '../models/rerun_details.dart';
+import 'api.dart';
+
+part 'rerun_details.g.dart';
+
+@riverpod
+Future<RerunDetailsResponse> rerunDetails(
+  Ref ref, {
+  required FamilyName family,
+  int? priority,
+  int page = 1,
+}) async {
+  final api = ref.watch(apiProvider);
+  return api.getRerunDetails(
+    family: family,
+    priority: priority,
+    offset: (page - 1) * 50,
+  );
+}

--- a/frontend/lib/providers/rerun_details.dart
+++ b/frontend/lib/providers/rerun_details.dart
@@ -30,9 +30,10 @@ Future<RerunDetailsResponse> rerunDetails(
   int page = 1,
 }) async {
   final api = ref.watch(apiProvider);
+  final safePage = page < 1 ? 1 : page;
   return api.getRerunDetails(
     family: family,
     priority: priority,
-    offset: (page - 1) * 50,
+    offset: (safePage - 1) * 50,
   );
 }

--- a/frontend/lib/repositories/api_repository.dart
+++ b/frontend/lib/repositories/api_repository.dart
@@ -201,6 +201,27 @@ class ApiRepository {
     return RerunDetailsResponse.fromJson(response.data);
   }
 
+  Future<({FamilyName family, int artefactId, int testExecutionId})?>
+      getLatestTestExecutionForTestPlan(String testPlanName) async {
+    final response = await dio.get(
+      '/v1/test-executions',
+      queryParameters: {
+        'test_plans': testPlanName,
+        'limit': 1,
+      },
+    );
+    final List executions = response.data['test_executions'] ?? [];
+    if (executions.isEmpty) return null;
+
+    final te = executions.first as Map<String, dynamic>;
+    final artefact = te['artefact'] as Map<String, dynamic>;
+    return (
+      family: FamilyName.values.firstWhere((f) => f.name == artefact['family']),
+      artefactId: artefact['id'] as int,
+      testExecutionId: te['id'] as int,
+    );
+  }
+
   Future<List<TestIssue>> getTestIssues() async {
     final response = await dio.get('/v1/test-cases/reported-issues');
     final List issuesJson = response.data;

--- a/frontend/lib/repositories/api_repository.dart
+++ b/frontend/lib/repositories/api_repository.dart
@@ -216,7 +216,10 @@ class ApiRepository {
     final te = executions.first as Map<String, dynamic>;
     final artefact = te['artefact'] as Map<String, dynamic>;
     return (
-      family: FamilyName.values.firstWhere((f) => f.name == artefact['family']),
+      family: FamilyName.values.firstWhere(
+        (f) => f.name == artefact['family'],
+        orElse: () => FamilyName.values.first,
+      ),
       artefactId: artefact['id'] as int,
       testExecutionId: te['id'] as int,
     );

--- a/frontend/lib/repositories/api_repository.dart
+++ b/frontend/lib/repositories/api_repository.dart
@@ -26,6 +26,7 @@ import '../models/environment_review.dart';
 import '../models/execution_metadata.dart';
 import '../models/family_name.dart';
 import '../models/issue.dart';
+import '../models/rerun_details.dart';
 import '../models/test_event.dart';
 import '../models/test_issue.dart';
 import '../models/test_result.dart';
@@ -178,6 +179,26 @@ class ApiRepository {
       '/v1/test-executions/reruns',
       data: data,
     );
+  }
+
+  Future<RerunDetailsResponse> getRerunDetails({
+    required FamilyName family,
+    int? priority,
+    int limit = 50,
+    int offset = 0,
+  }) async {
+    final queryParams = <String, dynamic>{
+      'family': family.name,
+      'limit': limit,
+      'offset': offset,
+    };
+    if (priority != null) queryParams['priority'] = priority;
+
+    final response = await dio.get(
+      '/v1/test-executions/reruns/details',
+      queryParameters: queryParams,
+    );
+    return RerunDetailsResponse.fromJson(response.data);
   }
 
   Future<List<TestIssue>> getTestIssues() async {

--- a/frontend/lib/routing.dart
+++ b/frontend/lib/routing.dart
@@ -27,6 +27,7 @@ import 'ui/issue_page/issue_page.dart';
 import 'ui/issues_page/issues_page.dart';
 import 'ui/login.dart';
 import 'ui/notifications_page/notifications_page.dart';
+import 'ui/reruns_page/reruns_page.dart';
 import 'ui/skeleton.dart';
 import 'ui/test_results_page/test_results_page.dart';
 import 'utils/dio.dart';
@@ -165,6 +166,12 @@ final appRouter = GoRouter(
           ),
         ),
         GoRoute(
+          path: AppRoutes.reruns,
+          pageBuilder: (_, __) => const NoTransitionPage(
+            child: RerunsPage(),
+          ),
+        ),
+        GoRoute(
           path: '/notifications',
           pageBuilder: (_, __) => const NoTransitionPage(
             child: NotificationsPage(),
@@ -235,6 +242,7 @@ class AppRoutes {
   static const images = '/images';
   static const solutions = '/solutions';
   static const testResults = '/test-results';
+  static const reruns = '/reruns';
 
   static Uri uriFromContext(BuildContext context) =>
       GoRouterState.of(context).uri;

--- a/frontend/lib/ui/navbar.dart
+++ b/frontend/lib/ui/navbar.dart
@@ -50,6 +50,9 @@ class Navbar extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final user = ref.watch(currentUserProvider).valueOrNull;
+    final currentPath = GoRouterState.of(context).uri.path;
+    final isTrackingSelected = currentPath.startsWith('/issues') ||
+        currentPath.startsWith(AppRoutes.reruns);
 
     return Container(
       color: YaruColors.coolGrey,
@@ -96,9 +99,19 @@ class Navbar extends ConsumerWidget {
                     title: 'Search',
                     route: AppRoutes.testResults,
                   ),
-                  const _NavbarEntry(
-                    title: 'Issues',
-                    route: '/issues',
+                  _NavbarDropdownEntry(
+                    label: 'Tracking',
+                    isSelected: isTrackingSelected,
+                    dropdownChildren: [
+                      _NavbarDropdownItem(
+                        label: 'Issues',
+                        onPressed: () => context.go('/issues'),
+                      ),
+                      _NavbarDropdownItem(
+                        label: 'Reruns',
+                        onPressed: () => context.go(AppRoutes.reruns),
+                      ),
+                    ],
                   ),
                   _NavbarDropdownEntry(
                     label: 'Help',
@@ -176,10 +189,12 @@ class _NavbarDropdownEntry extends StatelessWidget {
   const _NavbarDropdownEntry({
     required this.dropdownChildren,
     required this.label,
+    this.isSelected = false,
   });
 
   final String label;
   final List<Widget> dropdownChildren;
+  final bool isSelected;
 
   @override
   Widget build(BuildContext context) {
@@ -192,7 +207,14 @@ class _NavbarDropdownEntry extends StatelessWidget {
             backgroundColor: WidgetStatePropertyAll(YaruColors.coolGrey),
           ),
           menuChildren: dropdownChildren,
-          child: Padding(
+          child: Container(
+            decoration: isSelected
+                ? const BoxDecoration(
+                    border: Border(
+                      bottom: BorderSide(color: Colors.white, width: 2),
+                    ),
+                  )
+                : null,
             padding: const EdgeInsets.all(Spacing.level4),
             child: Text(
               label,

--- a/frontend/lib/ui/reruns_page/rerun_priority_chart.dart
+++ b/frontend/lib/ui/reruns_page/rerun_priority_chart.dart
@@ -1,0 +1,166 @@
+// Copyright 2026 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:yaru/yaru.dart';
+
+import '../../models/rerun_details.dart';
+import '../spacing.dart';
+
+/// Bar chart of rerun counts per priority.
+///
+/// Bars sit at sequential x indices and are labelled with the real (signed)
+/// priority, so only priorities that actually have reruns are shown and they
+/// are spaced evenly regardless of the numeric gaps between them.
+class RerunPriorityChart extends StatelessWidget {
+  const RerunPriorityChart({
+    super.key,
+    required this.summaries,
+    required this.selectedPriority,
+    required this.onBarTap,
+  });
+
+  final List<RerunPrioritySummary> summaries;
+  final int? selectedPriority;
+  final void Function(int priority) onBarTap;
+
+  static const _barWidth = 28.0;
+  static const _spacePerBar = 72.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final maxCount =
+        summaries.map((s) => s.count).fold<int>(0, (a, b) => a > b ? a : b);
+    final maxY = (maxCount + 1).toDouble();
+    final rawInterval = (maxY / 5).ceilToDouble();
+    final leftInterval = rawInterval < 1 ? 1.0 : rawInterval;
+
+    return SizedBox(
+      height: 320,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final contentWidth = summaries.length * _spacePerBar;
+          final width = contentWidth < constraints.maxWidth
+              ? constraints.maxWidth
+              : contentWidth;
+
+          return SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: SizedBox(
+              width: width,
+              child: BarChart(
+                BarChartData(
+                  alignment: BarChartAlignment.spaceAround,
+                  minY: 0,
+                  maxY: maxY,
+                  barTouchData: BarTouchData(
+                    touchCallback: (event, response) {
+                      if (event is! FlTapUpEvent) return;
+                      final index = response?.spot?.touchedBarGroupIndex;
+                      if (index != null &&
+                          index >= 0 &&
+                          index < summaries.length) {
+                        onBarTap(summaries[index].priority);
+                      }
+                    },
+                    touchTooltipData: BarTouchTooltipData(
+                      getTooltipItem: (group, groupIndex, rod, rodIndex) {
+                        final summary = summaries[group.x];
+                        return BarTooltipItem(
+                          'Priority ${summary.priority}\n'
+                          '${summary.count} rerun(s)',
+                          const TextStyle(color: Colors.white),
+                        );
+                      },
+                    ),
+                  ),
+                  titlesData: FlTitlesData(
+                    rightTitles: const AxisTitles(
+                      sideTitles: SideTitles(showTitles: false),
+                    ),
+                    topTitles: const AxisTitles(
+                      sideTitles: SideTitles(showTitles: false),
+                    ),
+                    leftTitles: AxisTitles(
+                      axisNameWidget: const Text('Number of reruns'),
+                      sideTitles: SideTitles(
+                        showTitles: true,
+                        reservedSize: 40,
+                        interval: leftInterval,
+                        getTitlesWidget: (value, meta) {
+                          if (value != value.roundToDouble()) {
+                            return const SizedBox.shrink();
+                          }
+                          return Text(
+                            '${value.toInt()}',
+                            style: Theme.of(context).textTheme.bodySmall,
+                          );
+                        },
+                      ),
+                    ),
+                    bottomTitles: AxisTitles(
+                      axisNameWidget: const Text('Priority'),
+                      sideTitles: SideTitles(
+                        showTitles: true,
+                        reservedSize: 32,
+                        getTitlesWidget: (value, meta) {
+                          final index = value.toInt();
+                          if (index < 0 || index >= summaries.length) {
+                            return const SizedBox.shrink();
+                          }
+                          return Padding(
+                            padding: const EdgeInsets.only(top: Spacing.level2),
+                            child: Text(
+                              '${summaries[index].priority}',
+                              style: Theme.of(context).textTheme.bodySmall,
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  ),
+                  gridData: const FlGridData(
+                    show: true,
+                    drawVerticalLine: false,
+                  ),
+                  borderData: FlBorderData(show: false),
+                  barGroups: [
+                    for (var i = 0; i < summaries.length; i++)
+                      BarChartGroupData(
+                        x: i,
+                        barRods: [
+                          BarChartRodData(
+                            toY: summaries[i].count.toDouble(),
+                            width: _barWidth,
+                            color: summaries[i].priority == selectedPriority
+                                ? YaruColors.orange
+                                : Theme.of(context).colorScheme.primary,
+                            borderRadius: const BorderRadius.vertical(
+                              top: Radius.circular(4),
+                            ),
+                          ),
+                        ],
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/frontend/lib/ui/reruns_page/reruns_page.dart
+++ b/frontend/lib/ui/reruns_page/reruns_page.dart
@@ -20,6 +20,7 @@ import 'package:yaru/yaru.dart';
 
 import '../../models/family_name.dart';
 import '../../models/rerun_details.dart';
+import '../../providers/api.dart';
 import '../../providers/rerun_details.dart';
 import '../../routing.dart';
 import '../spacing.dart';
@@ -222,37 +223,78 @@ class _RerunsContent extends StatelessWidget {
   }
 }
 
-class _RerunsTable extends StatelessWidget {
+class _RerunsTable extends ConsumerWidget {
   const _RerunsTable({required this.reruns});
 
   final List<RerunDetail> reruns;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
-      child: DataTable(
-        columns: const [
-          DataColumn(label: Text('Test plan')),
-          DataColumn(label: Text('Created at')),
-          DataColumn(label: Text('Priority')),
-          DataColumn(label: Text('Architecture')),
-          DataColumn(label: Text('Environment')),
-        ],
-        rows: [
-          for (final r in reruns)
-            DataRow(
-              cells: [
-                DataCell(Text(r.testPlanName)),
-                DataCell(Text(_formatDate(r.createdAt))),
-                DataCell(Text('${r.priority}')),
-                DataCell(Text(r.architecture)),
-                DataCell(Text(r.environmentName)),
-              ],
-            ),
-        ],
+      // The app wraps pages in a SelectionArea; disable selection here so row
+      // taps aren't swallowed by text selection.
+      child: SelectionContainer.disabled(
+        child: DataTable(
+          showCheckboxColumn: false,
+          columns: const [
+            DataColumn(label: Text('Test plan')),
+            DataColumn(label: Text('Created at')),
+            DataColumn(label: Text('Priority')),
+            DataColumn(label: Text('Architecture')),
+            DataColumn(label: Text('Environment')),
+          ],
+          rows: [
+            for (final r in reruns)
+              DataRow(
+                onSelectChanged: (_) =>
+                    _openLatestExecution(context, ref, r.testPlanName),
+                cells: [
+                  DataCell(Text(r.testPlanName)),
+                  DataCell(Text(_formatDate(r.createdAt))),
+                  DataCell(Text('${r.priority}')),
+                  DataCell(Text(r.architecture)),
+                  DataCell(Text(r.environmentName)),
+                ],
+              ),
+          ],
+        ),
       ),
     );
+  }
+
+  // Query only runs on click: find the latest execution for the row's test plan.
+  Future<void> _openLatestExecution(
+    BuildContext context,
+    WidgetRef ref,
+    String testPlanName,
+  ) async {
+    final router = GoRouter.of(context);
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final result = await ref
+          .read(apiProvider)
+          .getLatestTestExecutionForTestPlan(testPlanName);
+      if (result == null) {
+        messenger.showSnackBar(
+          const SnackBar(
+            content: Text('No test execution found for this test plan.'),
+          ),
+        );
+        return;
+      }
+      router.go(
+        getArtefactPagePathForFamily(
+          result.family,
+          result.artefactId,
+          testExecutionId: result.testExecutionId,
+        ),
+      );
+    } catch (e) {
+      messenger.showSnackBar(
+        SnackBar(content: Text('Failed to open test execution: $e')),
+      );
+    }
   }
 
   static String _formatDate(DateTime dt) {

--- a/frontend/lib/ui/reruns_page/reruns_page.dart
+++ b/frontend/lib/ui/reruns_page/reruns_page.dart
@@ -275,6 +275,7 @@ class _RerunsTable extends ConsumerWidget {
       final result = await ref
           .read(apiProvider)
           .getLatestTestExecutionForTestPlan(testPlanName);
+      if (!context.mounted) return;
       if (result == null) {
         messenger.showSnackBar(
           const SnackBar(
@@ -291,8 +292,11 @@ class _RerunsTable extends ConsumerWidget {
         ),
       );
     } catch (e) {
+      debugPrint('Failed to open test execution: $e');
       messenger.showSnackBar(
-        SnackBar(content: Text('Failed to open test execution: $e')),
+        const SnackBar(
+          content: Text('Could not open the test execution. Please try again.'),
+        ),
       );
     }
   }
@@ -345,15 +349,16 @@ class _ErrorView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    debugPrint('Failed to load reruns: $error');
     return Padding(
       padding: const EdgeInsets.all(Spacing.level6),
       child: Center(
         child: Column(
           mainAxisSize: MainAxisSize.min,
-          children: [
-            const Icon(Icons.error_outline, size: 48, color: Colors.red),
-            const SizedBox(height: Spacing.level3),
-            Text('Failed to load reruns: $error'),
+          children: const [
+            Icon(Icons.error_outline, size: 48, color: Colors.red),
+            SizedBox(height: Spacing.level3),
+            Text('Could not load reruns. Please try again later.'),
           ],
         ),
       ),

--- a/frontend/lib/ui/reruns_page/reruns_page.dart
+++ b/frontend/lib/ui/reruns_page/reruns_page.dart
@@ -1,0 +1,320 @@
+// Copyright 2026 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:yaru/yaru.dart';
+
+import '../../models/family_name.dart';
+import '../../models/rerun_details.dart';
+import '../../providers/rerun_details.dart';
+import '../../routing.dart';
+import '../spacing.dart';
+import 'rerun_priority_chart.dart';
+
+class RerunsPage extends ConsumerWidget {
+  const RerunsPage({super.key});
+
+  // Default product shown before the user picks one.
+  static const _defaultFamily = FamilyName.charm;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final uri = AppRoutes.uriFromContext(context);
+    final family = _familyFromUri(uri);
+    final priority = _intParam(uri, 'priority');
+    final page = _intParam(uri, 'page') ?? 1;
+
+    final detailsAsync = ref.watch(
+      rerunDetailsProvider(family: family, priority: priority, page: page),
+    );
+
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.only(
+          left: Spacing.pageHorizontalPadding,
+          right: Spacing.pageHorizontalPadding,
+          top: Spacing.level5,
+          bottom: Spacing.level5,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          spacing: Spacing.level4,
+          children: [
+            Row(
+              children: [
+                Text(
+                  'Reruns',
+                  style: Theme.of(context).textTheme.headlineLarge,
+                ),
+                const SizedBox(width: Spacing.level5),
+                _FamilyDropdown(
+                  family: family,
+                  onChanged: (newFamily) => _goWith(
+                    context,
+                    uri,
+                    family: newFamily,
+                    priority: null,
+                    page: 1,
+                  ),
+                ),
+              ],
+            ),
+            detailsAsync.when(
+              loading: () => const Padding(
+                padding: EdgeInsets.all(Spacing.level6),
+                child: Center(child: YaruCircularProgressIndicator()),
+              ),
+              error: (error, _) => _ErrorView(error: error),
+              data: (data) => _RerunsContent(
+                data: data,
+                onSelectPriority: (p) => _goWith(
+                  context,
+                  uri,
+                  family: family,
+                  priority: p,
+                  page: 1,
+                ),
+                onPageChanged: (p) => _goWith(
+                  context,
+                  uri,
+                  family: family,
+                  priority: data.selectedPriority,
+                  page: p,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static FamilyName _familyFromUri(Uri uri) {
+    final raw = uri.queryParameters['family'];
+    return FamilyName.values.firstWhere(
+      (f) => f.name == raw,
+      orElse: () => _defaultFamily,
+    );
+  }
+
+  static int? _intParam(Uri uri, String key) {
+    final raw = uri.queryParameters[key];
+    return raw == null ? null : int.tryParse(raw);
+  }
+
+  void _goWith(
+    BuildContext context,
+    Uri uri, {
+    required FamilyName family,
+    required int? priority,
+    required int page,
+  }) {
+    final params = <String, String>{
+      'family': family.name,
+      if (priority != null) 'priority': priority.toString(),
+      if (page > 1) 'page': page.toString(),
+    };
+    context.go(uri.replace(queryParameters: params).toString());
+  }
+}
+
+class _FamilyDropdown extends StatelessWidget {
+  const _FamilyDropdown({required this.family, required this.onChanged});
+
+  final FamilyName family;
+  final void Function(FamilyName family) onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return DropdownButton<FamilyName>(
+      value: family,
+      onChanged: (value) {
+        if (value != null) onChanged(value);
+      },
+      items: [
+        for (final f in FamilyName.values)
+          DropdownMenuItem(value: f, child: Text(_familyLabel(f))),
+      ],
+    );
+  }
+
+  static String _familyLabel(FamilyName family) {
+    final name = family.name;
+    return name.isEmpty ? name : name[0].toUpperCase() + name.substring(1);
+  }
+}
+
+class _RerunsContent extends StatelessWidget {
+  const _RerunsContent({
+    required this.data,
+    required this.onSelectPriority,
+    required this.onPageChanged,
+  });
+
+  final RerunDetailsResponse data;
+  final void Function(int priority) onSelectPriority;
+  final void Function(int page) onPageChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    if (data.prioritySummaries.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.all(Spacing.level6),
+        child: Center(child: Text('No reruns found for this product.')),
+      );
+    }
+
+    final selected = data.selectedPriority;
+    final totalPages =
+        data.count == 0 ? 1 : ((data.count + data.limit - 1) ~/ data.limit);
+    final currentPage = (data.offset ~/ data.limit) + 1;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '${data.totalCount} pending rerun(s)',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        const SizedBox(height: Spacing.level4),
+        RerunPriorityChart(
+          summaries: data.prioritySummaries,
+          selectedPriority: selected,
+          onBarTap: onSelectPriority,
+        ),
+        const SizedBox(height: Spacing.level5),
+        if (selected != null) ...[
+          Text(
+            'Priority $selected — ${data.count} rerun(s)',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: Spacing.level3),
+          if (data.reruns.isEmpty)
+            const Padding(
+              padding: EdgeInsets.all(Spacing.level5),
+              child: Text('No reruns for the selected priority.'),
+            )
+          else
+            _RerunsTable(reruns: data.reruns),
+          const SizedBox(height: Spacing.level4),
+          _PaginationControls(
+            currentPage: currentPage,
+            totalPages: totalPages,
+            onPageChanged: onPageChanged,
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _RerunsTable extends StatelessWidget {
+  const _RerunsTable({required this.reruns});
+
+  final List<RerunDetail> reruns;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: DataTable(
+        columns: const [
+          DataColumn(label: Text('Test plan')),
+          DataColumn(label: Text('Created at')),
+          DataColumn(label: Text('Priority')),
+          DataColumn(label: Text('Architecture')),
+          DataColumn(label: Text('Environment')),
+        ],
+        rows: [
+          for (final r in reruns)
+            DataRow(
+              cells: [
+                DataCell(Text(r.testPlanName)),
+                DataCell(Text(_formatDate(r.createdAt))),
+                DataCell(Text('${r.priority}')),
+                DataCell(Text(r.architecture)),
+                DataCell(Text(r.environmentName)),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+
+  static String _formatDate(DateTime dt) {
+    final local = dt.toLocal();
+    String two(int n) => n.toString().padLeft(2, '0');
+    return '${local.year}-${two(local.month)}-${two(local.day)} '
+        '${two(local.hour)}:${two(local.minute)}';
+  }
+}
+
+class _PaginationControls extends StatelessWidget {
+  const _PaginationControls({
+    required this.currentPage,
+    required this.totalPages,
+    required this.onPageChanged,
+  });
+
+  final int currentPage;
+  final int totalPages;
+  final void Function(int page) onPageChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        IconButton(
+          icon: const Icon(Icons.chevron_left),
+          onPressed:
+              currentPage > 1 ? () => onPageChanged(currentPage - 1) : null,
+        ),
+        Text('Page $currentPage of $totalPages'),
+        IconButton(
+          icon: const Icon(Icons.chevron_right),
+          onPressed: currentPage < totalPages
+              ? () => onPageChanged(currentPage + 1)
+              : null,
+        ),
+      ],
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({required this.error});
+
+  final Object error;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(Spacing.level6),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.error_outline, size: 48, color: Colors.red),
+            const SizedBox(height: Spacing.level3),
+            Text('Failed to load reruns: $error'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/ui/reruns_page/reruns_page.dart
+++ b/frontend/lib/ui/reruns_page/reruns_page.dart
@@ -182,7 +182,8 @@ class _RerunsContent extends StatelessWidget {
     final selected = data.selectedPriority;
     final totalPages =
         data.count == 0 ? 1 : ((data.count + data.limit - 1) ~/ data.limit);
-    final currentPage = (data.offset ~/ data.limit) + 1;
+    final rawPage = (data.offset ~/ data.limit) + 1;
+    final currentPage = rawPage > totalPages ? totalPages : rawPage;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -293,6 +294,7 @@ class _RerunsTable extends ConsumerWidget {
       );
     } catch (e) {
       debugPrint('Failed to open test execution: $e');
+      if (!context.mounted) return;
       messenger.showSnackBar(
         const SnackBar(
           content: Text('Could not open the test execution. Please try again.'),

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -321,6 +321,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "3bce007a596ff8b3119c45d68aaef631272537c03d30e5d4534dd24bf4c5eaa2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -353,6 +361,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  fl_chart:
+    dependency: "direct main"
+    description:
+      name: fl_chart
+      sha256: "5276944c6ffc975ae796569a826c38a62d2abcf264e26b88fa6f482e107f4237"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.70.2"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -8,6 +8,7 @@ dependencies:
   dartx: ^1.2.0
   dio: ^5.8.0+1
   dio_smart_retry: ^7.0.1
+  fl_chart: ^0.70.0
   flutter:
     sdk: flutter
   flutter_riverpod: ^2.6.1


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

This PR adds a **Reruns** page to the frontend that surfaces the current pending rerun requests in the database, plus a backend endpoint to power it.

**Navigation:** the top-level **Issues** tab is replaced by a hoverable **Tracking** dropdown containing **Issues** and **Reruns**.

**Reruns page (`/reruns`):**
- A **product filter** (artefact family) dropdown that defaults to **Charm**.
- A **bar chart** of rerun counts grouped by priority. Priorities are rendered as **evenly-spaced categorical columns** (only priorities that actually have reruns appear), supporting both negative and positive values including extremes such as ±1,000,000. Clicking a column selects that priority.
- A **paginated table** (50 rows/page) of reruns for the selected priority, showing test plan, created-at, priority, architecture and environment.
- On first load, the **highest priority present** is selected automatically.
- Clicking a table row navigates to the **latest test execution for that row's test plan** on the artefact page (e.g. `/#/charms/409283?testExecutionId=900710`). This lookup runs **only on click**.

State (family / priority / page) is URL-driven so views are shareable and refreshable. The page is family-agnostic — the dropdown is driven by `FamilyName.values` with no per-family branching; Charm is only a default selection.

The backend serves a single read-only endpoint that returns both the per-priority aggregates and the current page of rerun details in one response, avoiding the heavy nested payload of the existing rerun queue endpoint.

**Notes for reviewers:**
- New Flutter dependency **`fl_chart`**, pinned to **`^0.70.0`** (not 1.x): fl_chart ≥ 1.0 calls `Matrix4.translateByDouble` / `scaleByDouble`, which require `vector_math 2.2.0`, but the Flutter SDK's `integration_test` pins `vector_math 2.1.4`, so 1.x fails to compile.
- The table is wrapped in `SelectionContainer.disabled` because the app wraps pages in a `SelectionArea`, which otherwise swallows row tap gestures.

## Resolved issues

Resolves [TO-431](https://warthogs.atlassian.net/browse/TO-431)

<!-- Add the GitHub issue reference here if one exists, e.g. `Fixes #123`. -->

## Documentation

No documentation changes required. The rerun queue and priority semantics are already covered in `docs/explanation/test-execution-lifecycle.rst`; this PR adds a UI view over existing concepts and introduces no new domain concepts.

## Web service API changes

### New endpoint

- **Rationale:** powers the Reruns page — returns the priority histogram plus one paginated slice of rerun details in a single call, without the large nested payload that the existing `GET /v1/test-executions/reruns` queue endpoint returns.
- **Verb / URL:** `GET /v1/test-executions/reruns/details` (versioned; intended to be stable).
- **Query parameters:**
  - `family` (**required**) — artefact family (`snap` | `deb` | `charm` | `image` | `solution`).
  - `priority` (optional int, `-1000000..1000000`) — when omitted, the highest priority present is selected.
  - `limit` (int, `1..50`, default `50`).
  - `offset` (int, `>= 0`, default `0`).
- **Success `200` — `RerunDetailsResponse`:**
  ```json
  {
    "priority_summaries": [{ "priority": 10, "count": 8 }],
    "selected_priority": 10,
    "total_count": 310,
    "count": 8,
    "limit": 50,
    "offset": 0,
    "reruns": [
      {
        "test_plan_name": "...",
        "created_at": "2026-08-27T12:00:00Z",
        "priority": 10,
        "architecture": "arm64",
        "environment_name": "..."
      }
    ]
  }
  ```
- **Failure cases:** `403` (missing `view_rerun`); `422` (invalid parameters — e.g. `priority` out of range or `limit > 50`).
- **Authorization:** requires the `view_rerun` permission (same model as the existing rerun endpoints; admins bypass). Tests assert the unauthenticated `403` and the validation `422`s.

### Database queries

Two queries over `test_execution_rerun_request` joined to `artefact_build → artefact` (family filter) and, for the detail rows, `environment` + `test_plan`; ordered by priority / created-at. Uses the existing `idx_rerun_request_priority_created_at` index. Filtering is by family only (no new filter parameters on high-traffic endpoints). **No new migration.**

### Reused endpoint (unchanged)

The row click-through calls the existing `GET /v1/test-executions?test_plans=<name>&limit=1` (results are latest-first) to resolve the latest execution and its artefact — **no new endpoint** was added for navigation.

### Config / migrations

None. The committed `backend/schemata/openapi.json` snapshot is regenerated to include the new endpoint and models.

## Tests

**Backend** (`docker compose exec test-observer-api pytest`):

- 4 new functional tests in `tests/controllers/test_executions/test_reruns.py`:
  1. grouped counts across negative/zero/positive priorities, and default selection of the highest priority;
  2. explicit `priority` → exact five detail fields, FIFO ordering, and two 50-row pages via `offset`;
  3. family isolation, plus an empty response for a family with no reruns;
  4. validation — out-of-range `priority` and `limit > 50` rejected (`422`).
- `test_reruns.py`: **80 passed**. Full backend suite: **1004 passed, 3 skipped**.
- `ruff check`, `ruff format --check`, `mypy`, `alembic check`, the OpenAPI schema diff, and the endpoint-permission check all pass.



[TO-431]: https://warthogs.atlassian.net/browse/TO-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ