### PR TITLE
TO-431: add GET /v1/test-executions/reruns/details endpoint

### DIFF
--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -503,6 +503,91 @@
         ]
       }
     },
+    "/v1/test-executions/reruns/details": {
+      "get": {
+        "tags": [
+          "test-executions"
+        ],
+        "summary": "Get Rerun Details",
+        "operationId": "get_rerun_details_v1_test_executions_reruns_details_get",
+        "parameters": [
+          {
+            "name": "family",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/FamilyName"
+            }
+          },
+          {
+            "name": "priority",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "maximum": 1000000,
+                  "minimum": -1000000
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Priority"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 50,
+              "minimum": 1,
+              "default": 50,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RerunDetailsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-permissions": [
+          "view_rerun"
+        ]
+      }
+    },
     "/v1/test-executions/{id}": {
       "get": {
         "tags": [
@@ -8006,6 +8091,114 @@
           "test_result_id"
         ],
         "title": "PreviousTestResult"
+      },
+      "RerunDetail": {
+        "properties": {
+          "test_plan_name": {
+            "type": "string",
+            "title": "Test Plan Name"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "priority": {
+            "type": "integer",
+            "title": "Priority"
+          },
+          "architecture": {
+            "type": "string",
+            "title": "Architecture"
+          },
+          "environment_name": {
+            "type": "string",
+            "title": "Environment Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "test_plan_name",
+          "created_at",
+          "priority",
+          "architecture",
+          "environment_name"
+        ],
+        "title": "RerunDetail"
+      },
+      "RerunDetailsResponse": {
+        "properties": {
+          "priority_summaries": {
+            "items": {
+              "$ref": "#/components/schemas/RerunPrioritySummary"
+            },
+            "type": "array",
+            "title": "Priority Summaries"
+          },
+          "selected_priority": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selected Priority"
+          },
+          "total_count": {
+            "type": "integer",
+            "title": "Total Count"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          },
+          "reruns": {
+            "items": {
+              "$ref": "#/components/schemas/RerunDetail"
+            },
+            "type": "array",
+            "title": "Reruns"
+          }
+        },
+        "type": "object",
+        "required": [
+          "priority_summaries",
+          "selected_priority",
+          "total_count",
+          "count",
+          "limit",
+          "offset",
+          "reruns"
+        ],
+        "title": "RerunDetailsResponse"
+      },
+      "RerunPrioritySummary": {
+        "properties": {
+          "priority": {
+            "type": "integer",
+            "title": "Priority"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "priority",
+          "count"
+        ],
+        "title": "RerunPrioritySummary"
       },
       "RerunRequest": {
         "properties": {

--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -8146,13 +8146,13 @@
             ],
             "title": "Selected Priority"
           },
-          "total_count": {
-            "type": "integer",
-            "title": "Total Count"
-          },
           "count": {
             "type": "integer",
             "title": "Count"
+          },
+          "selected_count": {
+            "type": "integer",
+            "title": "Selected Count"
           },
           "limit": {
             "type": "integer",
@@ -8174,8 +8174,8 @@
         "required": [
           "priority_summaries",
           "selected_priority",
-          "total_count",
           "count",
+          "selected_count",
           "limit",
           "offset",
           "reruns"

--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -369,6 +369,29 @@ class PendingRerun(BaseModel):
     created_at: datetime
 
 
+class RerunPrioritySummary(BaseModel):
+    priority: int
+    count: int
+
+
+class RerunDetail(BaseModel):
+    test_plan_name: str
+    created_at: datetime
+    priority: int
+    architecture: str
+    environment_name: str
+
+
+class RerunDetailsResponse(BaseModel):
+    priority_summaries: list[RerunPrioritySummary]
+    selected_priority: int | None
+    total_count: int
+    count: int
+    limit: int
+    offset: int
+    reruns: list[RerunDetail]
+
+
 class DeleteReruns(BaseModel):
     test_execution_ids: set[int] = Field(default_factory=set)
     test_results_filters: TestResultSearchFilters | None = None

--- a/backend/test_observer/controllers/test_executions/models.py
+++ b/backend/test_observer/controllers/test_executions/models.py
@@ -385,8 +385,8 @@ class RerunDetail(BaseModel):
 class RerunDetailsResponse(BaseModel):
     priority_summaries: list[RerunPrioritySummary]
     selected_priority: int | None
-    total_count: int
     count: int
+    selected_count: int
     limit: int
     offset: int
     reruns: list[RerunDetail]

--- a/backend/test_observer/controllers/test_executions/reruns.py
+++ b/backend/test_observer/controllers/test_executions/reruns.py
@@ -378,17 +378,24 @@ def get_rerun_details(
         return RerunDetailsResponse(
             priority_summaries=[],
             selected_priority=None,
-            total_count=0,
             count=0,
+            selected_count=0,
             limit=limit,
             offset=offset,
             reruns=[],
         )
 
     available_priorities = {s.priority for s in priority_summaries}
+
+    if priority is not None and priority not in available_priorities:
+        raise HTTPException(
+            status_code=422,
+            detail=f"No reruns found for priority {priority} and family {family}",
+        )
+
     # Default to the highest priority present when the caller doesn't request one.
     selected_priority = priority if priority is not None else max(available_priorities)
-    selected_count = next((s.count for s in priority_summaries if s.priority == selected_priority), 0)
+    selected_count = next(s.count for s in priority_summaries if s.priority == selected_priority)
 
     detail_rows = db.execute(
         select(
@@ -428,8 +435,8 @@ def get_rerun_details(
     return RerunDetailsResponse(
         priority_summaries=priority_summaries,
         selected_priority=selected_priority,
-        total_count=total_count,
-        count=selected_count,
+        count=total_count,
+        selected_count=selected_count,
         limit=limit,
         offset=offset,
         reruns=reruns,

--- a/backend/test_observer/controllers/test_executions/reruns.py
+++ b/backend/test_observer/controllers/test_executions/reruns.py
@@ -18,7 +18,7 @@ from typing import Annotated
 
 from fastapi import Depends, HTTPException, Query, Response, Security, status
 from fastapi.security import SecurityScopes
-from sqlalchemy import Select, and_, asc, delete, desc, literal, or_, select, tuple_
+from sqlalchemy import Select, and_, asc, delete, desc, func, literal, or_, select, tuple_
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session, selectinload
 
@@ -47,6 +47,7 @@ from test_observer.data_access.models import (
     FamilyName,
     TestExecution,
     TestExecutionRerunRequest,
+    TestPlan,
     TestResult,
     User,
 )
@@ -54,7 +55,16 @@ from test_observer.data_access.repository import get_or_create
 from test_observer.data_access.setup import get_db
 from test_observer.users.user_injection import get_current_user
 
-from .models import DeleteReruns, PendingRerun, RerunRequest
+from .models import (
+    RERUN_PRIORITY_MAX,
+    RERUN_PRIORITY_MIN,
+    DeleteReruns,
+    PendingRerun,
+    RerunDetail,
+    RerunDetailsResponse,
+    RerunPrioritySummary,
+    RerunRequest,
+)
 from .router import router
 
 
@@ -338,6 +348,92 @@ def get_rerun_requests(
         stmt = stmt.limit(limit)
 
     return db.scalars(stmt)
+
+
+@router.get(
+    "/reruns/details",
+    response_model=RerunDetailsResponse,
+    dependencies=[Security(permission_checker, scopes=[Permission.view_rerun])],
+)
+def get_rerun_details(
+    family: FamilyName,
+    priority: Annotated[int | None, Query(ge=RERUN_PRIORITY_MIN, le=RERUN_PRIORITY_MAX)] = None,
+    limit: Annotated[int, Query(ge=1, le=50)] = 50,
+    offset: Annotated[int, Query(ge=0)] = 0,
+    db: Session = Depends(get_db),
+):
+    summary_rows = db.execute(
+        select(TestExecutionRerunRequest.priority, func.count())
+        .join(TestExecutionRerunRequest.artefact_build)
+        .join(ArtefactBuild.artefact)
+        .where(Artefact.family == family)
+        .group_by(TestExecutionRerunRequest.priority)
+        .order_by(TestExecutionRerunRequest.priority)
+    ).all()
+
+    priority_summaries = [RerunPrioritySummary(priority=p, count=c) for p, c in summary_rows]
+    total_count = sum(s.count for s in priority_summaries)
+
+    if not priority_summaries:
+        return RerunDetailsResponse(
+            priority_summaries=[],
+            selected_priority=None,
+            total_count=0,
+            count=0,
+            limit=limit,
+            offset=offset,
+            reruns=[],
+        )
+
+    available_priorities = {s.priority for s in priority_summaries}
+    # Default to the highest priority present when the caller doesn't request one.
+    selected_priority = priority if priority is not None else max(available_priorities)
+    selected_count = next((s.count for s in priority_summaries if s.priority == selected_priority), 0)
+
+    detail_rows = db.execute(
+        select(
+            TestPlan.name,
+            TestExecutionRerunRequest.created_at,
+            TestExecutionRerunRequest.priority,
+            Environment.architecture,
+            Environment.name,
+        )
+        .join(TestExecutionRerunRequest.artefact_build)
+        .join(ArtefactBuild.artefact)
+        .join(TestExecutionRerunRequest.environment)
+        .join(TestExecutionRerunRequest.test_plan)
+        .where(
+            Artefact.family == family,
+            TestExecutionRerunRequest.priority == selected_priority,
+        )
+        .order_by(
+            asc(TestExecutionRerunRequest.created_at),
+            asc(TestExecutionRerunRequest.id),
+        )
+        .offset(offset)
+        .limit(limit)
+    ).all()
+
+    reruns = [
+        RerunDetail(
+            test_plan_name=test_plan_name,
+            created_at=created_at,
+            priority=row_priority,
+            architecture=architecture,
+            environment_name=environment_name,
+        )
+        for test_plan_name, created_at, row_priority, architecture, environment_name in detail_rows
+    ]
+
+    return RerunDetailsResponse(
+        priority_summaries=priority_summaries,
+        selected_priority=selected_priority,
+        total_count=total_count,
+        count=selected_count,
+        limit=limit,
+        offset=offset,
+        reruns=reruns,
+    )
 
 
 @router.delete(

--- a/backend/test_observer/controllers/test_executions/reruns.py
+++ b/backend/test_observer/controllers/test_executions/reruns.py
@@ -389,8 +389,8 @@ def get_rerun_details(
 
     if priority is not None and priority not in available_priorities:
         raise HTTPException(
-            status_code=422,
-            detail=f"No reruns found for priority {priority} and family {family}",
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            f"No reruns found for priority {priority} and family {family}",
         )
 
     # Default to the highest priority present when the caller doesn't request one.

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -1967,7 +1967,7 @@ def test_post_priority_at_min_is_accepted(post: Post, get: Get, test_execution: 
 
 
 # ==============================================================================
-# GET /reruns/details
+# GET /v1/test-executions/reruns/details
 # ==============================================================================
 
 details_url = "/v1/test-executions/reruns/details"

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -1996,9 +1996,9 @@ def test_details_groups_counts_by_priority_and_defaults_to_highest(test_client: 
         {"priority": 0, "count": 1},
         {"priority": 5, "count": 2},
     ]
-    assert body["total_count"] == 4
+    assert body["count"] == 4
     assert body["selected_priority"] == 5
-    assert body["count"] == 2
+    assert body["selected_count"] == 2
     assert {r["priority"] for r in body["reruns"]} == {5}
 
 
@@ -2046,14 +2046,25 @@ def test_details_filters_by_family_and_is_empty_when_none_exist(test_client: Tes
         generator.gen_rerun_request(te, priority=1)
 
     charm_body = _get_details(test_client, family="charm").json()
-    assert charm_body["total_count"] == 1
+    assert charm_body["count"] == 1
     assert [s["priority"] for s in charm_body["priority_summaries"]] == [1]
 
     deb_body = _get_details(test_client, family="deb").json()
     assert deb_body["priority_summaries"] == []
     assert deb_body["selected_priority"] is None
-    assert deb_body["total_count"] == 0
+    assert deb_body["count"] == 0
     assert deb_body["reruns"] == []
+
+
+def test_details_rejects_priority_with_no_reruns(test_client: TestClient, generator: DataGenerator):
+    a = generator.gen_artefact(StageName.beta, family=FamilyName.charm)
+    ab = generator.gen_artefact_build(a)
+    e = generator.gen_environment("unavailable-priority-env")
+    te = generator.gen_test_execution(ab, e)
+    generator.gen_rerun_request(te, priority=5)
+
+    response = _get_details(test_client, family="charm", priority=1)
+    assert response.status_code == 422
 
 
 def test_details_rejects_out_of_range_priority_and_limit(test_client: TestClient):

--- a/backend/tests/controllers/test_executions/test_reruns.py
+++ b/backend/tests/controllers/test_executions/test_reruns.py
@@ -1964,3 +1964,112 @@ def test_post_priority_at_max_is_accepted(post: Post, get: Get, test_execution: 
 def test_post_priority_at_min_is_accepted(post: Post, get: Get, test_execution: TestExecution):
     post({"test_execution_ids": [test_execution.id], "priority": -1_000_000})
     assert get().json()[0]["priority"] == -1_000_000
+
+
+# ==============================================================================
+# GET /reruns/details
+# ==============================================================================
+
+details_url = "/v1/test-executions/reruns/details"
+
+
+def _get_details(test_client: TestClient, **params: Any) -> Response:  # noqa: ANN401
+    return make_authenticated_request(
+        lambda: test_client.get(details_url, params=params),
+        Permission.view_rerun,
+    )
+
+
+def test_details_groups_counts_by_priority_and_defaults_to_highest(test_client: TestClient, generator: DataGenerator):
+    a = generator.gen_artefact(StageName.beta, family=FamilyName.charm)
+    ab = generator.gen_artefact_build(a)
+    # Distinct environments so each rerun is its own (test_plan, build, environment) group.
+    for i, priority in enumerate([5, 5, 0, -3]):
+        e = generator.gen_environment(f"charm-env-{i}")
+        te = generator.gen_test_execution(ab, e)
+        generator.gen_rerun_request(te, priority=priority)
+
+    body = _get_details(test_client, family="charm").json()
+
+    assert body["priority_summaries"] == [
+        {"priority": -3, "count": 1},
+        {"priority": 0, "count": 1},
+        {"priority": 5, "count": 2},
+    ]
+    assert body["total_count"] == 4
+    assert body["selected_priority"] == 5
+    assert body["count"] == 2
+    assert {r["priority"] for r in body["reruns"]} == {5}
+
+
+def test_details_selected_priority_returns_fields_and_paginates(test_client: TestClient, generator: DataGenerator):
+    a = generator.gen_artefact(StageName.beta, family=FamilyName.charm)
+    ab = generator.gen_artefact_build(a)
+    total = 55
+    for i in range(total):
+        e = generator.gen_environment(f"page-env-{i}", architecture="arm64")
+        te = generator.gen_test_execution(ab, e, test_plan="page-plan")
+        generator.gen_rerun_request(te, priority=7)
+
+    first = _get_details(test_client, family="charm", priority=7).json()
+    assert first["selected_priority"] == 7
+    assert first["count"] == total
+    assert first["limit"] == 50
+    assert first["offset"] == 0
+    assert len(first["reruns"]) == 50
+
+    row = first["reruns"][0]
+    assert set(row.keys()) == {
+        "test_plan_name",
+        "created_at",
+        "priority",
+        "architecture",
+        "environment_name",
+    }
+    assert row["test_plan_name"] == "page-plan"
+    assert row["priority"] == 7
+    assert row["architecture"] == "arm64"
+    assert row["environment_name"].startswith("page-env-")
+
+    second = _get_details(test_client, family="charm", priority=7, offset=50).json()
+    assert second["offset"] == 50
+    assert len(second["reruns"]) == total - 50
+
+
+def test_details_filters_by_family_and_is_empty_when_none_exist(test_client: TestClient, generator: DataGenerator):
+    charm = generator.gen_artefact(StageName.beta, family=FamilyName.charm)
+    snap = generator.gen_artefact(StageName.beta, family=FamilyName.snap)
+    e = generator.gen_environment("family-env")
+    for artefact in (charm, snap):
+        ab = generator.gen_artefact_build(artefact)
+        te = generator.gen_test_execution(ab, e)
+        generator.gen_rerun_request(te, priority=1)
+
+    charm_body = _get_details(test_client, family="charm").json()
+    assert charm_body["total_count"] == 1
+    assert [s["priority"] for s in charm_body["priority_summaries"]] == [1]
+
+    deb_body = _get_details(test_client, family="deb").json()
+    assert deb_body["priority_summaries"] == []
+    assert deb_body["selected_priority"] is None
+    assert deb_body["total_count"] == 0
+    assert deb_body["reruns"] == []
+
+
+def test_details_rejects_out_of_range_priority_and_limit(test_client: TestClient):
+    with override_permissions(Permission.view_rerun):
+        assert test_client.get(details_url, params={"family": "charm", "priority": 1_000_001}).status_code == 422
+        assert test_client.get(details_url, params={"family": "charm", "limit": 51}).status_code == 422
+
+
+def test_details_requires_view_rerun_permission(test_client: TestClient):
+    # Unauthenticated request is rejected.
+    assert test_client.get(details_url, params={"family": "charm"}).status_code == 403
+
+    # Authenticated without view_rerun is rejected.
+    with override_permissions(Permission.view_test):
+        assert test_client.get(details_url, params={"family": "charm"}).status_code == 403
+
+    # view_rerun grants access.
+    with override_permissions(Permission.view_rerun):
+        assert test_client.get(details_url, params={"family": "charm"}).status_code == 200


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

First of a 4-PR stack that adds a **Reruns** page. This PR adds the read-only backend endpoint that powers it. In a single call it returns the per-priority rerun histogram **and** one paginated page of rerun details for a selected artefact family/priority — avoiding the large nested payload of the existing `GET /v1/test-executions/reruns` queue endpoint.

Stack order: **[backend](https://github.com/canonical/test_observer/pull/868)** → [frontend API](https://github.com/canonical/test_observer/pull/869) → [navbar](https://github.com/canonical/test_observer/pull/871) → [page](https://github.com/canonical/test_observer/pull/872). This PR has no user-visible changes on its own.

Reruns page with clickable table: 
<img width="1920" height="928" alt="image" src="https://github.com/user-attachments/assets/b164faaa-7a4e-48c4-bf42-8108aadbf8e3" />

what the link leads to:
<img width="1920" height="916" alt="image" src="https://github.com/user-attachments/assets/4c85d6e2-18dc-4000-8e6b-cb643d04ca74" />

## Resolved issues

Part of [TO-431](https://warthogs.atlassian.net/browse/TO-431).

## Documentation

No changes required. Rerun/priority semantics are already covered in `docs/explanation/test-execution-lifecycle.rst`.

## Web service API changes

- **New endpoint:** `GET /v1/test-executions/reruns/details` (versioned; intended stable).
- **Rationale:** powers the Reruns page — histogram + one detail page in one request.
- **Query params:** `family` (**required**), `priority` (optional int, `-1000000..1000000`; defaults to the highest priority present), `limit` (int `1..50`, default `50`), `offset` (int `>=0`, default `0`).
- **`200` → `RerunDetailsResponse`:** `priority_summaries: [{priority, count}]`, `selected_priority: int|null`, `count`, `selected_count`, `limit`, `offset`, `reruns: [{test_plan_name, created_at, priority, architecture, environment_name}]`.
- **Failures:** `403` (missing `view_rerun`); `422` (invalid params, e.g. priority out of range or `limit > 50`).
- **Authorization:** requires `view_rerun` (same model as existing rerun endpoints; admins bypass).
- **DB queries:** two queries over `test_execution_rerun_request` joined to `artefact_build → artefact` (family filter) and, for details, `environment` + `test_plan`; uses the existing `idx_rerun_request_priority_created_at` index. **No migration.**
- The committed `backend/schemata/openapi.json` is regenerated to include the endpoint and models.

## Tests

- 5 functional tests in `tests/controllers/test_executions/test_reruns.py`: (1) grouped counts across negative/zero/positive priorities + default highest selection; (2) explicit priority → exact fields, FIFO order, two 50-row pages; (3) family isolation + empty response; (4) out-of-range `priority`/`limit` → `422`; (5) `view_rerun` required (`403` unauthenticated / non-matching permission, `200` with `view_rerun`).
- Full backend suite **1004 passed, 3 skipped**; `ruff`, `mypy`, `alembic check`, OpenAPI diff, and endpoint-permission check all pass.


[TO-431]: https://warthogs.atlassian.net/browse/TO-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ