### PR TITLE
TO-431: add reruns API models, repository methods and provider

### DIFF
--- a/frontend/lib/models/rerun_details.dart
+++ b/frontend/lib/models/rerun_details.dart
@@ -1,0 +1,61 @@
+// Copyright 2026 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'rerun_details.freezed.dart';
+part 'rerun_details.g.dart';
+
+@freezed
+abstract class RerunPrioritySummary with _$RerunPrioritySummary {
+  const factory RerunPrioritySummary({
+    required int priority,
+    required int count,
+  }) = _RerunPrioritySummary;
+
+  factory RerunPrioritySummary.fromJson(Map<String, Object?> json) =>
+      _$RerunPrioritySummaryFromJson(json);
+}
+
+@freezed
+abstract class RerunDetail with _$RerunDetail {
+  const factory RerunDetail({
+    @JsonKey(name: 'test_plan_name') required String testPlanName,
+    @JsonKey(name: 'created_at') required DateTime createdAt,
+    required int priority,
+    required String architecture,
+    @JsonKey(name: 'environment_name') required String environmentName,
+  }) = _RerunDetail;
+
+  factory RerunDetail.fromJson(Map<String, Object?> json) =>
+      _$RerunDetailFromJson(json);
+}
+
+@freezed
+abstract class RerunDetailsResponse with _$RerunDetailsResponse {
+  const factory RerunDetailsResponse({
+    @JsonKey(name: 'priority_summaries')
+    required List<RerunPrioritySummary> prioritySummaries,
+    @JsonKey(name: 'selected_priority') int? selectedPriority,
+    @JsonKey(name: 'total_count') required int totalCount,
+    required int count,
+    required int limit,
+    required int offset,
+    required List<RerunDetail> reruns,
+  }) = _RerunDetailsResponse;
+
+  factory RerunDetailsResponse.fromJson(Map<String, Object?> json) =>
+      _$RerunDetailsResponseFromJson(json);
+}

--- a/frontend/lib/models/rerun_details.dart
+++ b/frontend/lib/models/rerun_details.dart
@@ -49,8 +49,8 @@ abstract class RerunDetailsResponse with _$RerunDetailsResponse {
     @JsonKey(name: 'priority_summaries')
     required List<RerunPrioritySummary> prioritySummaries,
     @JsonKey(name: 'selected_priority') int? selectedPriority,
-    @JsonKey(name: 'total_count') required int totalCount,
     required int count,
+    @JsonKey(name: 'selected_count') required int selectedCount,
     required int limit,
     required int offset,
     required List<RerunDetail> reruns,

--- a/frontend/lib/providers/rerun_details.dart
+++ b/frontend/lib/providers/rerun_details.dart
@@ -1,0 +1,42 @@
+// Copyright 2026 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../models/family_name.dart';
+import '../models/rerun_details.dart';
+import 'api.dart';
+
+part 'rerun_details.g.dart';
+
+const rerunsPageSize = 50;
+
+@riverpod
+Future<RerunDetailsResponse> rerunDetails(
+  Ref ref, {
+  required FamilyName family,
+  int? priority,
+  int page = 1,
+}) async {
+  final api = ref.watch(apiProvider);
+  final safePage = page < 1 ? 1 : page;
+  return api.getRerunDetails(
+    family: family,
+    priority: priority,
+    limit: rerunsPageSize,
+    offset: (safePage - 1) * rerunsPageSize,
+  );
+}

--- a/frontend/lib/repositories/api_repository.dart
+++ b/frontend/lib/repositories/api_repository.dart
@@ -26,6 +26,7 @@ import '../models/environment_review.dart';
 import '../models/execution_metadata.dart';
 import '../models/family_name.dart';
 import '../models/issue.dart';
+import '../models/rerun_details.dart';
 import '../models/test_event.dart';
 import '../models/test_issue.dart';
 import '../models/test_result.dart';
@@ -177,6 +178,50 @@ class ApiRepository {
     await dio.delete(
       '/v1/test-executions/reruns',
       data: data,
+    );
+  }
+
+  Future<RerunDetailsResponse> getRerunDetails({
+    required FamilyName family,
+    int? priority,
+    int limit = 50,
+    int offset = 0,
+  }) async {
+    final queryParams = <String, dynamic>{
+      'family': family.name,
+      'limit': limit,
+      'offset': offset,
+    };
+    if (priority != null) queryParams['priority'] = priority;
+
+    final response = await dio.get(
+      '/v1/test-executions/reruns/details',
+      queryParameters: queryParams,
+    );
+    return RerunDetailsResponse.fromJson(response.data);
+  }
+
+  Future<({FamilyName family, int artefactId, int testExecutionId})?>
+      getLatestTestExecutionForTestPlan(String testPlanName) async {
+    final response = await dio.get(
+      '/v1/test-executions',
+      queryParameters: {
+        'test_plans': testPlanName,
+        'limit': 1,
+      },
+    );
+    final List executions = response.data['test_executions'] ?? [];
+    if (executions.isEmpty) return null;
+
+    final te = executions.first as Map<String, dynamic>;
+    final artefact = te['artefact'] as Map<String, dynamic>;
+    return (
+      family: FamilyName.values.firstWhere(
+        (f) => f.name == artefact['family'],
+        orElse: () => FamilyName.values.first,
+      ),
+      artefactId: artefact['id'] as int,
+      testExecutionId: te['id'] as int,
     );
   }
 


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Stacked on [#1.](https://github.com/canonical/test_observer/pull/868) Adds the Flutter data layer for the Reruns page — no UI yet:

- `RerunPrioritySummary` / `RerunDetail` / `RerunDetailsResponse` models mirroring the endpoint from [#1](https://github.com/canonical/test_observer/pull/868).
- `ApiRepository.getRerunDetails(...)` to fetch the histogram + detail page.
- `ApiRepository.getLatestTestExecutionForTestPlan(...)` (used by the page's row click-through in [#4](https://github.com/canonical/test_observer/pull/872)), built on the **existing** `GET /v1/test-executions` search.
- A Riverpod `rerunDetails` provider with a shared `rerunsPageSize` constant driving both `limit` and `offset`.

- Stack order: [backend](https://github.com/canonical/test_observer/pull/868) → **[frontend API](https://github.com/canonical/test_observer/pull/869)** → [navbar](https://github.com/canonical/test_observer/pull/871) → [page](https://github.com/canonical/test_observer/pull/872).

Reruns page with clickable table: 
<img width="1920" height="928" alt="image" src="https://github.com/user-attachments/assets/b164faaa-7a4e-48c4-bf42-8108aadbf8e3" />

what the link leads to:
<img width="1920" height="916" alt="image" src="https://github.com/user-attachments/assets/4c85d6e2-18dc-4000-8e6b-cb643d04ca74" />


## Resolved issues

Part of TO-431.

## Documentation

No changes required.

## Web service API changes

No backend changes. Consumes `GET /v1/test-executions/reruns/details` (from [#1](https://github.com/canonical/test_observer/pull/868)) and the existing `GET /v1/test-executions?test_plans=…&limit=1` search endpoint. No new endpoints.

## Tests

`flutter analyze` and `dart format` clean. No new unit tests in this layer (exercised by the page in [#4](https://github.com/canonical/test_observer/pull/872)). Generated `*.g.dart` / `*.freezed.dart` are produced by `build_runner` in CI (gitignored).
