### PR TITLE
TO-431: replace Issues tab with Tracking dropdown

### DIFF
--- a/frontend/lib/routing.dart
+++ b/frontend/lib/routing.dart
@@ -235,6 +235,7 @@ class AppRoutes {
   static const images = '/images';
   static const solutions = '/solutions';
   static const testResults = '/test-results';
+  static const reruns = '/reruns';
 
   static Uri uriFromContext(BuildContext context) =>
       GoRouterState.of(context).uri;

--- a/frontend/lib/ui/navbar.dart
+++ b/frontend/lib/ui/navbar.dart
@@ -50,6 +50,9 @@ class Navbar extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final user = ref.watch(currentUserProvider).valueOrNull;
+    final currentPath = GoRouterState.of(context).uri.path;
+    final isTrackingSelected = currentPath.startsWith('/issues') ||
+        currentPath.startsWith(AppRoutes.reruns);
 
     return Container(
       color: YaruColors.coolGrey,
@@ -96,9 +99,19 @@ class Navbar extends ConsumerWidget {
                     title: 'Search',
                     route: AppRoutes.testResults,
                   ),
-                  const _NavbarEntry(
-                    title: 'Issues',
-                    route: '/issues',
+                  _NavbarDropdownEntry(
+                    label: 'Tracking',
+                    isSelected: isTrackingSelected,
+                    dropdownChildren: [
+                      _NavbarDropdownItem(
+                        label: 'Issues',
+                        onPressed: () => context.go('/issues'),
+                      ),
+                      _NavbarDropdownItem(
+                        label: 'Reruns',
+                        onPressed: () => context.go(AppRoutes.reruns),
+                      ),
+                    ],
                   ),
                   _NavbarDropdownEntry(
                     label: 'Help',
@@ -176,10 +189,12 @@ class _NavbarDropdownEntry extends StatelessWidget {
   const _NavbarDropdownEntry({
     required this.dropdownChildren,
     required this.label,
+    this.isSelected = false,
   });
 
   final String label;
   final List<Widget> dropdownChildren;
+  final bool isSelected;
 
   @override
   Widget build(BuildContext context) {
@@ -192,7 +207,14 @@ class _NavbarDropdownEntry extends StatelessWidget {
             backgroundColor: WidgetStatePropertyAll(YaruColors.coolGrey),
           ),
           menuChildren: dropdownChildren,
-          child: Padding(
+          child: Container(
+            decoration: isSelected
+                ? const BoxDecoration(
+                    border: Border(
+                      bottom: BorderSide(color: Colors.white, width: 2),
+                    ),
+                  )
+                : null,
             padding: const EdgeInsets.all(Spacing.level4),
             child: Text(
               label,


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Stacked on [#2](https://github.com/canonical/test_observer/pull/869). Replaces the top-level **Issues** tab with a hoverable **Tracking** dropdown containing **Issues** and **Reruns**, and adds the `AppRoutes.reruns` route constant. The dropdown reuses the existing navbar submenu pattern and shows a selected indicator for `/issues` and `/reruns`.

Note: the `/reruns` **route** itself is registered in [#4](https://github.com/canonical/test_observer/pull/872), so the Reruns menu item becomes functional once [#4](https://github.com/canonical/test_observer/pull/872) lands. This PR compiles and the rest of the app is unaffected.

Stack order: [backend](https://github.com/canonical/test_observer/pull/868) → [frontend API](https://github.com/canonical/test_observer/pull/869) → **[navbar](https://github.com/canonical/test_observer/pull/871)** → [page](https://github.com/canonical/test_observer/pull/872).

Reruns page with clickable table: 
<img width="1920" height="928" alt="image" src="https://github.com/user-attachments/assets/b164faaa-7a4e-48c4-bf42-8108aadbf8e3" />

what the link leads to:
<img width="1920" height="916" alt="image" src="https://github.com/user-attachments/assets/4c85d6e2-18dc-4000-8e6b-cb643d04ca74" />

## Resolved issues

Part of TO-431.

## Documentation

No changes required.

## Web service API changes

None.

## Tests

`flutter analyze` / `dart format` clean; the existing frontend suite (incl. `routing_test.dart`) passes — the navbar/route-constant change introduces no regressions. No new tests.
