### PR TITLE
TO-431: add Reruns page with priority chart and pagination

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
     "requests>=2.33.0,<3.0.0",
     "sentry-sdk>=2.56.0,<3.0.0",
     "launchpadlib>=1.11.0,<2.0.0",
+    # httplib2 (via launchpadlib) silently ignores HTTP(S)_PROXY unless socks is importable
+    "pysocks>=1.7.1,<2.0.0",
     "PyGithub>=2.0.0,<3.0.0",
     "jira>=3.10.0,<4.0.0",
     "email-validator>=2.1.0.post1,<3.0.0",

--- a/backend/test_observer/external_apis/launchpad/launchpad_api.py
+++ b/backend/test_observer/external_apis/launchpad/launchpad_api.py
@@ -21,7 +21,7 @@ from .models import LaunchpadUser
 
 class LaunchpadAPI:
     def __init__(self):
-        self.launchpad = Launchpad.login_anonymously("test-observer", "production", version="devel")
+        self.launchpad = Launchpad.login_anonymously("test-observer", "production", version="devel", timeout=30)
 
     def get_user_by_email(self, email: EmailStr) -> LaunchpadUser | None:
         user = self.launchpad.people.getByEmail(email=email)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1249,6 +1249,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1541,6 +1550,7 @@ dependencies = [
     { name = "pg8000" },
     { name = "prometheus-fastapi-instrumentator" },
     { name = "pygithub" },
+    { name = "pysocks" },
     { name = "python-multipart" },
     { name = "python3-saml" },
     { name = "requests" },
@@ -1576,6 +1586,7 @@ requires-dist = [
     { name = "pg8000", specifier = ">=1.29.4,<2.0.0" },
     { name = "prometheus-fastapi-instrumentator", specifier = ">=7.1.0" },
     { name = "pygithub", specifier = ">=2.0.0,<3.0.0" },
+    { name = "pysocks", specifier = ">=1.7.1,<2.0.0" },
     { name = "python-multipart", specifier = ">=0.0.20,<0.1.0" },
     { name = "python3-saml", specifier = ">=1.16.0" },
     { name = "requests", specifier = ">=2.33.0,<3.0.0" },

--- a/frontend/lib/routing.dart
+++ b/frontend/lib/routing.dart
@@ -27,6 +27,7 @@ import 'ui/issue_page/issue_page.dart';
 import 'ui/issues_page/issues_page.dart';
 import 'ui/login.dart';
 import 'ui/notifications_page/notifications_page.dart';
+import 'ui/reruns_page/reruns_page.dart';
 import 'ui/skeleton.dart';
 import 'ui/test_results_page/test_results_page.dart';
 import 'utils/dio.dart';
@@ -162,6 +163,12 @@ final appRouter = GoRouter(
             child: IssuePage(
               issueId: int.parse(state.pathParameters['issueId']!),
             ),
+          ),
+        ),
+        GoRoute(
+          path: AppRoutes.reruns,
+          pageBuilder: (_, __) => const NoTransitionPage(
+            child: RerunsPage(),
           ),
         ),
         GoRoute(

--- a/frontend/lib/ui/reruns_page/rerun_priority_chart.dart
+++ b/frontend/lib/ui/reruns_page/rerun_priority_chart.dart
@@ -1,0 +1,166 @@
+// Copyright 2026 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:yaru/yaru.dart';
+
+import '../../models/rerun_details.dart';
+import '../spacing.dart';
+
+/// Bar chart of rerun counts per priority.
+///
+/// Bars sit at sequential x indices and are labelled with the real (signed)
+/// priority, so only priorities that actually have reruns are shown and they
+/// are spaced evenly regardless of the numeric gaps between them.
+class RerunPriorityChart extends StatelessWidget {
+  const RerunPriorityChart({
+    super.key,
+    required this.summaries,
+    required this.selectedPriority,
+    required this.onBarTap,
+  });
+
+  final List<RerunPrioritySummary> summaries;
+  final int? selectedPriority;
+  final void Function(int priority) onBarTap;
+
+  static const _barWidth = 28.0;
+  static const _spacePerBar = 72.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final maxCount =
+        summaries.map((s) => s.count).fold<int>(0, (a, b) => a > b ? a : b);
+    final maxY = (maxCount + 1).toDouble();
+    final rawInterval = (maxY / 5).ceilToDouble();
+    final leftInterval = rawInterval < 1 ? 1.0 : rawInterval;
+
+    return SizedBox(
+      height: 320,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final contentWidth = summaries.length * _spacePerBar;
+          final width = contentWidth < constraints.maxWidth
+              ? constraints.maxWidth
+              : contentWidth;
+
+          return SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: SizedBox(
+              width: width,
+              child: BarChart(
+                BarChartData(
+                  alignment: BarChartAlignment.spaceAround,
+                  minY: 0,
+                  maxY: maxY,
+                  barTouchData: BarTouchData(
+                    touchCallback: (event, response) {
+                      if (event is! FlTapUpEvent) return;
+                      final index = response?.spot?.touchedBarGroupIndex;
+                      if (index != null &&
+                          index >= 0 &&
+                          index < summaries.length) {
+                        onBarTap(summaries[index].priority);
+                      }
+                    },
+                    touchTooltipData: BarTouchTooltipData(
+                      getTooltipItem: (group, groupIndex, rod, rodIndex) {
+                        final summary = summaries[group.x];
+                        return BarTooltipItem(
+                          'Priority ${summary.priority}\n'
+                          '${summary.count} rerun(s)',
+                          const TextStyle(color: Colors.white),
+                        );
+                      },
+                    ),
+                  ),
+                  titlesData: FlTitlesData(
+                    rightTitles: const AxisTitles(
+                      sideTitles: SideTitles(showTitles: false),
+                    ),
+                    topTitles: const AxisTitles(
+                      sideTitles: SideTitles(showTitles: false),
+                    ),
+                    leftTitles: AxisTitles(
+                      axisNameWidget: const Text('Number of reruns'),
+                      sideTitles: SideTitles(
+                        showTitles: true,
+                        reservedSize: 40,
+                        interval: leftInterval,
+                        getTitlesWidget: (value, meta) {
+                          if (value != value.roundToDouble()) {
+                            return const SizedBox.shrink();
+                          }
+                          return Text(
+                            '${value.toInt()}',
+                            style: Theme.of(context).textTheme.bodySmall,
+                          );
+                        },
+                      ),
+                    ),
+                    bottomTitles: AxisTitles(
+                      axisNameWidget: const Text('Priority'),
+                      sideTitles: SideTitles(
+                        showTitles: true,
+                        reservedSize: 32,
+                        getTitlesWidget: (value, meta) {
+                          final index = value.toInt();
+                          if (index < 0 || index >= summaries.length) {
+                            return const SizedBox.shrink();
+                          }
+                          return Padding(
+                            padding: const EdgeInsets.only(top: Spacing.level2),
+                            child: Text(
+                              '${summaries[index].priority}',
+                              style: Theme.of(context).textTheme.bodySmall,
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  ),
+                  gridData: const FlGridData(
+                    show: true,
+                    drawVerticalLine: false,
+                  ),
+                  borderData: FlBorderData(show: false),
+                  barGroups: [
+                    for (var i = 0; i < summaries.length; i++)
+                      BarChartGroupData(
+                        x: i,
+                        barRods: [
+                          BarChartRodData(
+                            toY: summaries[i].count.toDouble(),
+                            width: _barWidth,
+                            color: summaries[i].priority == selectedPriority
+                                ? YaruColors.orange
+                                : Theme.of(context).colorScheme.primary,
+                            borderRadius: const BorderRadius.vertical(
+                              top: Radius.circular(4),
+                            ),
+                          ),
+                        ],
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/frontend/lib/ui/reruns_page/reruns_page.dart
+++ b/frontend/lib/ui/reruns_page/reruns_page.dart
@@ -1,0 +1,369 @@
+// Copyright 2026 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3, as
+// published by the Free Software Foundation.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:yaru/yaru.dart';
+
+import '../../models/family_name.dart';
+import '../../models/rerun_details.dart';
+import '../../providers/api.dart';
+import '../../providers/rerun_details.dart';
+import '../../routing.dart';
+import '../spacing.dart';
+import 'rerun_priority_chart.dart';
+
+class RerunsPage extends ConsumerWidget {
+  const RerunsPage({super.key});
+
+  // Default product shown before the user picks one.
+  static const _defaultFamily = FamilyName.charm;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final uri = AppRoutes.uriFromContext(context);
+    final family = _familyFromUri(uri);
+    final priority = _intParam(uri, 'priority');
+    final page = _intParam(uri, 'page') ?? 1;
+
+    final detailsAsync = ref.watch(
+      rerunDetailsProvider(family: family, priority: priority, page: page),
+    );
+
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.only(
+          left: Spacing.pageHorizontalPadding,
+          right: Spacing.pageHorizontalPadding,
+          top: Spacing.level5,
+          bottom: Spacing.level5,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          spacing: Spacing.level4,
+          children: [
+            Row(
+              children: [
+                Text(
+                  'Reruns',
+                  style: Theme.of(context).textTheme.headlineLarge,
+                ),
+                const SizedBox(width: Spacing.level5),
+                _FamilyDropdown(
+                  family: family,
+                  onChanged: (newFamily) => _goWith(
+                    context,
+                    uri,
+                    family: newFamily,
+                    priority: null,
+                    page: 1,
+                  ),
+                ),
+              ],
+            ),
+            detailsAsync.when(
+              loading: () => const Padding(
+                padding: EdgeInsets.all(Spacing.level6),
+                child: Center(child: YaruCircularProgressIndicator()),
+              ),
+              error: (error, _) => _ErrorView(error: error),
+              data: (data) => _RerunsContent(
+                data: data,
+                onSelectPriority: (p) => _goWith(
+                  context,
+                  uri,
+                  family: family,
+                  priority: p,
+                  page: 1,
+                ),
+                onPageChanged: (p) => _goWith(
+                  context,
+                  uri,
+                  family: family,
+                  priority: data.selectedPriority,
+                  page: p,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static FamilyName _familyFromUri(Uri uri) {
+    final raw = uri.queryParameters['family'];
+    return FamilyName.values.firstWhere(
+      (f) => f.name == raw,
+      orElse: () => _defaultFamily,
+    );
+  }
+
+  static int? _intParam(Uri uri, String key) {
+    final raw = uri.queryParameters[key];
+    return raw == null ? null : int.tryParse(raw);
+  }
+
+  void _goWith(
+    BuildContext context,
+    Uri uri, {
+    required FamilyName family,
+    required int? priority,
+    required int page,
+  }) {
+    final params = <String, String>{
+      'family': family.name,
+      if (priority != null) 'priority': priority.toString(),
+      if (page > 1) 'page': page.toString(),
+    };
+    context.go(uri.replace(queryParameters: params).toString());
+  }
+}
+
+class _FamilyDropdown extends StatelessWidget {
+  const _FamilyDropdown({required this.family, required this.onChanged});
+
+  final FamilyName family;
+  final void Function(FamilyName family) onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return DropdownButton<FamilyName>(
+      value: family,
+      onChanged: (value) {
+        if (value != null) onChanged(value);
+      },
+      items: [
+        for (final f in FamilyName.values)
+          DropdownMenuItem(value: f, child: Text(_familyLabel(f))),
+      ],
+    );
+  }
+
+  static String _familyLabel(FamilyName family) {
+    final name = family.name;
+    return name.isEmpty ? name : name[0].toUpperCase() + name.substring(1);
+  }
+}
+
+class _RerunsContent extends StatelessWidget {
+  const _RerunsContent({
+    required this.data,
+    required this.onSelectPriority,
+    required this.onPageChanged,
+  });
+
+  final RerunDetailsResponse data;
+  final void Function(int priority) onSelectPriority;
+  final void Function(int page) onPageChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    if (data.prioritySummaries.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.all(Spacing.level6),
+        child: Center(child: Text('No reruns found for this product.')),
+      );
+    }
+
+    final selected = data.selectedPriority;
+    final totalPages =
+        data.count == 0 ? 1 : ((data.count + data.limit - 1) ~/ data.limit);
+    final rawPage = (data.offset ~/ data.limit) + 1;
+    final currentPage = rawPage > totalPages ? totalPages : rawPage;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '${data.totalCount} pending rerun(s)',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        const SizedBox(height: Spacing.level4),
+        RerunPriorityChart(
+          summaries: data.prioritySummaries,
+          selectedPriority: selected,
+          onBarTap: onSelectPriority,
+        ),
+        const SizedBox(height: Spacing.level5),
+        if (selected != null) ...[
+          Text(
+            'Priority $selected — ${data.count} rerun(s)',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: Spacing.level3),
+          if (data.reruns.isEmpty)
+            const Padding(
+              padding: EdgeInsets.all(Spacing.level5),
+              child: Text('No reruns for the selected priority.'),
+            )
+          else
+            _RerunsTable(reruns: data.reruns),
+          const SizedBox(height: Spacing.level4),
+          _PaginationControls(
+            currentPage: currentPage,
+            totalPages: totalPages,
+            onPageChanged: onPageChanged,
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _RerunsTable extends ConsumerWidget {
+  const _RerunsTable({required this.reruns});
+
+  final List<RerunDetail> reruns;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      // The app wraps pages in a SelectionArea; disable selection here so row
+      // taps aren't swallowed by text selection.
+      child: SelectionContainer.disabled(
+        child: DataTable(
+          showCheckboxColumn: false,
+          columns: const [
+            DataColumn(label: Text('Test plan')),
+            DataColumn(label: Text('Created at')),
+            DataColumn(label: Text('Priority')),
+            DataColumn(label: Text('Architecture')),
+            DataColumn(label: Text('Environment')),
+          ],
+          rows: [
+            for (final r in reruns)
+              DataRow(
+                onSelectChanged: (_) =>
+                    _openLatestExecution(context, ref, r.testPlanName),
+                cells: [
+                  DataCell(Text(r.testPlanName)),
+                  DataCell(Text(_formatDate(r.createdAt))),
+                  DataCell(Text('${r.priority}')),
+                  DataCell(Text(r.architecture)),
+                  DataCell(Text(r.environmentName)),
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // Query only runs on click: find the latest execution for the row's test plan.
+  Future<void> _openLatestExecution(
+    BuildContext context,
+    WidgetRef ref,
+    String testPlanName,
+  ) async {
+    final router = GoRouter.of(context);
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final result = await ref
+          .read(apiProvider)
+          .getLatestTestExecutionForTestPlan(testPlanName);
+      if (!context.mounted) return;
+      if (result == null) {
+        messenger.showSnackBar(
+          const SnackBar(
+            content: Text('No test execution found for this test plan.'),
+          ),
+        );
+        return;
+      }
+      router.go(
+        getArtefactPagePathForFamily(
+          result.family,
+          result.artefactId,
+          testExecutionId: result.testExecutionId,
+        ),
+      );
+    } catch (e) {
+      debugPrint('Failed to open test execution: $e');
+      if (!context.mounted) return;
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text('Could not open the test execution. Please try again.'),
+        ),
+      );
+    }
+  }
+
+  static String _formatDate(DateTime dt) {
+    final local = dt.toLocal();
+    String two(int n) => n.toString().padLeft(2, '0');
+    return '${local.year}-${two(local.month)}-${two(local.day)} '
+        '${two(local.hour)}:${two(local.minute)}';
+  }
+}
+
+class _PaginationControls extends StatelessWidget {
+  const _PaginationControls({
+    required this.currentPage,
+    required this.totalPages,
+    required this.onPageChanged,
+  });
+
+  final int currentPage;
+  final int totalPages;
+  final void Function(int page) onPageChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        IconButton(
+          icon: const Icon(Icons.chevron_left),
+          onPressed:
+              currentPage > 1 ? () => onPageChanged(currentPage - 1) : null,
+        ),
+        Text('Page $currentPage of $totalPages'),
+        IconButton(
+          icon: const Icon(Icons.chevron_right),
+          onPressed: currentPage < totalPages
+              ? () => onPageChanged(currentPage + 1)
+              : null,
+        ),
+      ],
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({required this.error});
+
+  final Object error;
+
+  @override
+  Widget build(BuildContext context) {
+    debugPrint('Failed to load reruns: $error');
+    return Padding(
+      padding: const EdgeInsets.all(Spacing.level6),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: const [
+            Icon(Icons.error_outline, size: 48, color: Colors.red),
+            SizedBox(height: Spacing.level3),
+            Text('Could not load reruns. Please try again later.'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/ui/reruns_page/reruns_page.dart
+++ b/frontend/lib/ui/reruns_page/reruns_page.dart
@@ -184,7 +184,13 @@ class _RerunsContent extends StatelessWidget {
         ? 1
         : ((data.selectedCount + data.limit - 1) ~/ data.limit);
     final rawPage = (data.offset ~/ data.limit) + 1;
-    final currentPage = rawPage > totalPages ? totalPages : rawPage;
+    final currentPage = rawPage.clamp(1, totalPages);
+
+    if (rawPage != currentPage) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        onPageChanged(currentPage);
+      });
+    }
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/frontend/lib/ui/reruns_page/reruns_page.dart
+++ b/frontend/lib/ui/reruns_page/reruns_page.dart
@@ -180,8 +180,9 @@ class _RerunsContent extends StatelessWidget {
     }
 
     final selected = data.selectedPriority;
-    final totalPages =
-        data.count == 0 ? 1 : ((data.count + data.limit - 1) ~/ data.limit);
+    final totalPages = data.selectedCount == 0
+        ? 1
+        : ((data.selectedCount + data.limit - 1) ~/ data.limit);
     final rawPage = (data.offset ~/ data.limit) + 1;
     final currentPage = rawPage > totalPages ? totalPages : rawPage;
 
@@ -189,7 +190,7 @@ class _RerunsContent extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          '${data.totalCount} pending rerun(s)',
+          '${data.count} pending rerun(s)',
           style: Theme.of(context).textTheme.titleMedium,
         ),
         const SizedBox(height: Spacing.level4),
@@ -201,7 +202,7 @@ class _RerunsContent extends StatelessWidget {
         const SizedBox(height: Spacing.level5),
         if (selected != null) ...[
           Text(
-            'Priority $selected — ${data.count} rerun(s)',
+            'Priority $selected — ${data.selectedCount} rerun(s)',
             style: Theme.of(context).textTheme.titleMedium,
           ),
           const SizedBox(height: Spacing.level3),

--- a/frontend/lib/ui/reruns_page/reruns_page.dart
+++ b/frontend/lib/ui/reruns_page/reruns_page.dart
@@ -248,8 +248,11 @@ class _RerunsTable extends ConsumerWidget {
           rows: [
             for (final r in reruns)
               DataRow(
-                onSelectChanged: (_) =>
-                    _openLatestExecution(context, ref, r.testPlanName),
+                onSelectChanged: (selected) {
+                  if (selected == true) {
+                    _openLatestExecution(context, ref, r.testPlanName);
+                  }
+                },
                 cells: [
                   DataCell(Text(r.testPlanName)),
                   DataCell(Text(_formatDate(r.createdAt))),
@@ -351,7 +354,6 @@ class _ErrorView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    debugPrint('Failed to load reruns: $error');
     return Padding(
       padding: const EdgeInsets.all(Spacing.level6),
       child: Center(

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -321,6 +321,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "3bce007a596ff8b3119c45d68aaef631272537c03d30e5d4534dd24bf4c5eaa2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -353,6 +361,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  fl_chart:
+    dependency: "direct main"
+    description:
+      name: fl_chart
+      sha256: "5276944c6ffc975ae796569a826c38a62d2abcf264e26b88fa6f482e107f4237"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.70.2"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -8,6 +8,7 @@ dependencies:
   dartx: ^1.2.0
   dio: ^5.8.0+1
   dio_smart_retry: ^7.0.1
+  fl_chart: ^0.70.0
   flutter:
     sdk: flutter
   flutter_riverpod: ^2.6.1


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Top of the stack (on [#3](https://github.com/canonical/test_observer/pull/871)). Adds the **Reruns** page at `/reruns`:

- **Product filter** (artefact family) defaulting to **Charm**; the dropdown is data-driven from `FamilyName.values` with no per-family branching.
- **Bar chart** of rerun counts by priority as **evenly-spaced categorical columns** (only priorities with reruns appear), supporting negative/positive values incl. extremes like ±1,000,000; clicking a column selects that priority.
- **Paginated detail table** (50/page) — test plan, created-at, priority, architecture, environment — with previous/next controls; on load the **highest** priority is selected.
- **Row click-through** to the latest test execution for that row's test plan on the artefact page (e.g. `/#/charms/409283?testExecutionId=900710`); the lookup runs only on click.
- Registers the `/reruns` route.

Reviewer notes: adds **`fl_chart`** pinned to **`^0.70.0`** (not 1.x — fl_chart ≥ 1.0 needs `vector_math 2.2.0`, but the Flutter SDK's `integration_test` pins `2.1.4`, so 1.x won't compile). The table is wrapped in `SelectionContainer.disabled` because the app wraps pages in a `SelectionArea` that would otherwise swallow row taps.

Stack order: [backend](https://github.com/canonical/test_observer/pull/868) → [frontend API](https://github.com/canonical/test_observer/pull/869) → [navbar](https://github.com/canonical/test_observer/pull/871) → **[page](https://github.com/canonical/test_observer/pull/872)**.

Reruns page with clickable table: 
<img width="1920" height="928" alt="image" src="https://github.com/user-attachments/assets/b164faaa-7a4e-48c4-bf42-8108aadbf8e3" />

what the link leads to:
<img width="1920" height="916" alt="image" src="https://github.com/user-attachments/assets/4c85d6e2-18dc-4000-8e6b-cb643d04ca74" />


## Resolved issues

Resolves TO-431.

## Documentation

No changes required.

## Web service API changes

None — consumes the endpoints introduced/reused in [#1](https://github.com/canonical/test_observer/pull/868) and [#2](https://github.com/canonical/test_observer/pull/869).

## Tests

`flutter analyze` and `dart format` clean; existing `flutter test --platform chrome` suite passes; `flutter build web` succeeds. No new frontend tests (kept intentionally minimal).

