### PR TITLE
[IQA-3732] Add CODEOWNERS for review routing

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,45 @@
+# Copyright 2023 Canonical Ltd.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-FileCopyrightText: Copyright 2023 Canonical Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+# CODEOWNERS — routes PRs to the most likely reviewer.
+# Rules are evaluated top-to-bottom; the LAST matching rule wins.
+# Docs: https://docs.github.com/articles/about-code-owners
+
+# --- Default owner ---
+# Blanket ownership: Solutions QA reviews everything by default.
+*                @canonical/solutions-qa
+
+# --- Broad ownership by language ---
+*.sh             @canonical/solutions-qa-shell
+*.py             @canonical/solutions-qa-python
+*.svelte         @canonical/solutions-qa-frontend
+*.ts             @canonical/solutions-qa-frontend
+*.tsx            @canonical/solutions-qa-frontend
+*.js             @canonical/solutions-qa-frontend
+*.jsx            @canonical/solutions-qa-frontend
+*.dart           @canonical/solutions-qa-frontend
+*.tf             @canonical/solutions-qa-terraform
+
+# --- Narrow ownership by directory ---
+/backend/        @rpbritton @wctaylor @almeidaraul
+/docs/           @almeidaraul @wctaylor
+/frontend/       @rpbritton @wctaylor
+/terraform/      @wctaylor @rpbritton
+
+# --- Meta ---
+/CODEOWNERS      @canonical/solutions-qa
+/.github/        @canonical/solutions-qa-github-actions

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # 
-# SPDX-FileCopyrightText: Copyright 2023 Canonical Ltd.
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
 # CODEOWNERS — routes PRs to the most likely reviewer.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@
 # --- Narrow ownership by directory ---
 /backend/        @rpbritton @wctaylor @almeidaraul
 /docs/           @almeidaraul @wctaylor
-/frontend/       @rpbritton @wctaylor
+/frontend/       @rpbritton @wctaylor @almeidaraul
 /terraform/      @wctaylor @rpbritton
 
 # --- Meta ---


### PR DESCRIPTION
[IQA-3732](https://warthogs.atlassian.net/browse/IQA-3732)

Adds a layered `CODEOWNERS` so PRs auto-request the right reviewers:

- **Blanket:** `@canonical/solutions-qa` owns everything by default.
- **By language:** routes to subteams — `-shell`, `-go`, `-python`, `-terraform`, `-frontend` (svelte/ts/tsx/js/jsx/dart).
- **By directory:** area maintainers on high-traffic paths (≥2 owners each).
- **Meta:** `/.github/` → `-github-actions`; `CODEOWNERS` self-owned by `solutions-qa`.

[IQA-3732]: https://warthogs.atlassian.net/browse/IQA-3732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ