### PR TITLE
[New] Missing artefact environments notification backend API

### DIFF
--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -1937,6 +1937,52 @@
         ]
       }
     },
+    "/v1/artefacts/{artefact_id}/missing-environments": {
+      "get": {
+        "tags": [
+          "artefacts",
+          "artefacts"
+        ],
+        "summary": "Get Missing Environments",
+        "operationId": "get_missing_environments_v1_artefacts__artefact_id__missing_environments_get",
+        "parameters": [
+          {
+            "name": "artefact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Artefact Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MissingEnvironmentsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-permissions": [
+          "view_artefact"
+        ]
+      }
+    },
     "/v1/reports/test-results": {
       "get": {
         "tags": [
@@ -7633,6 +7679,34 @@
           "execution_metadata"
         ],
         "title": "MinimalIssueTestResultAttachmentRuleResponse"
+      },
+      "MissingEnvironmentsResponse": {
+        "properties": {
+          "missing_environments": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Missing Environments"
+          },
+          "previous_artefact_link": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Previous Artefact Link"
+          }
+        },
+        "type": "object",
+        "required": [
+          "missing_environments"
+        ],
+        "title": "MissingEnvironmentsResponse",
+        "description": "Environments an artefact is missing versus the C3 source of truth."
       },
       "NotificationResponse": {
         "properties": {

--- a/backend/schemata/openapi.json
+++ b/backend/schemata/openapi.json
@@ -1940,7 +1940,6 @@
     "/v1/artefacts/{artefact_id}/missing-environments": {
       "get": {
         "tags": [
-          "artefacts",
           "artefacts"
         ],
         "summary": "Get Missing Environments",
@@ -7680,11 +7679,29 @@
         ],
         "title": "MinimalIssueTestResultAttachmentRuleResponse"
       },
+      "MissingEnvironment": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "architecture": {
+            "type": "string",
+            "title": "Architecture"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "architecture"
+        ],
+        "title": "MissingEnvironment"
+      },
       "MissingEnvironmentsResponse": {
         "properties": {
           "missing_environments": {
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/MissingEnvironment"
             },
             "type": "array",
             "title": "Missing Environments"

--- a/backend/test_observer/common/config.py
+++ b/backend/test_observer/common/config.py
@@ -28,10 +28,6 @@ ADDITIONAL_CORS_ORIGINS = [
     origin.strip() for origin in os.getenv("ADDITIONAL_CORS_ORIGINS", "").split(",") if origin.strip()
 ]
 FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:30001")
-# C3 (certification.canonical.com) is the source of truth for the set of
-# environments (Testflinger queues) an artefact is expected to be tested on.
-# Only used by the missing-environments feature. When C3_API_TOKEN is empty the
-# feature degrades gracefully (source of truth reported as unavailable).
 C3_API_BASE_URL = os.getenv("C3_API_BASE_URL", "https://certification.canonical.com")
 C3_API_TOKEN = os.getenv("C3_API_TOKEN", "")
 SESSIONS_SECRET = os.getenv("SESSIONS_SECRET", "secret")

--- a/backend/test_observer/common/config.py
+++ b/backend/test_observer/common/config.py
@@ -28,6 +28,12 @@ ADDITIONAL_CORS_ORIGINS = [
     origin.strip() for origin in os.getenv("ADDITIONAL_CORS_ORIGINS", "").split(",") if origin.strip()
 ]
 FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:30001")
+# C3 (certification.canonical.com) is the source of truth for the set of
+# environments (Testflinger queues) an artefact is expected to be tested on.
+# Only used by the missing-environments feature. When C3_API_TOKEN is empty the
+# feature degrades gracefully (source of truth reported as unavailable).
+C3_API_BASE_URL = os.getenv("C3_API_BASE_URL", "https://certification.canonical.com")
+C3_API_TOKEN = os.getenv("C3_API_TOKEN", "")
 SESSIONS_SECRET = os.getenv("SESSIONS_SECRET", "secret")
 SESSIONS_HTTPS_ONLY = os.getenv("SESSIONS_HTTPS_ONLY", "true").lower() == "true"
 IGNORE_PERMISSIONS = {

--- a/backend/test_observer/controllers/artefacts/artefacts.py
+++ b/backend/test_observer/controllers/artefacts/artefacts.py
@@ -55,7 +55,7 @@ from test_observer.data_access.repository import get_artefacts_by_family
 from test_observer.data_access.setup import get_db
 from test_observer.users.user_injection import get_current_user
 
-from . import builds, environment_reviews
+from . import builds, environment_reviews, missing_environments
 from .logic import (
     are_all_environments_approved,
     is_there_a_rejected_environment,
@@ -436,3 +436,4 @@ def get_artefact_versions(
 
 router.include_router(environment_reviews.router)
 router.include_router(builds.router)
+router.include_router(missing_environments.router)

--- a/backend/test_observer/controllers/artefacts/missing_environments.py
+++ b/backend/test_observer/controllers/artefacts/missing_environments.py
@@ -133,9 +133,10 @@ def _pool_matches_artefact(artefact: Artefact, pool: TestingPool) -> bool:
     if field_map is None:
         return False
 
-    keys = field_map.keys() & pool.metadata.keys()
-    return bool(keys) and all(
-        pool.metadata[key] == getattr(artefact, attr) for key, attr in field_map.items() if key in keys
+    # Require every expected metadata key to be present and equal; partial
+    # metadata must not match (e.g. matching a snap by name while ignoring channel).
+    return all(
+        key in pool.metadata and pool.metadata[key] == getattr(artefact, attr) for key, attr in field_map.items()
     )
 
 
@@ -156,6 +157,7 @@ def _get_previous_artefact(db: Session, artefact: Artefact) -> Artefact | None:
     """The version immediately preceding the given artefact, or None."""
     return db.scalars(
         select(Artefact)
+        .where(Artefact.family == artefact.family)
         .where(Artefact.name == artefact.name)
         .where(Artefact.track == artefact.track)
         .where(Artefact.branch == artefact.branch)

--- a/backend/test_observer/controllers/artefacts/missing_environments.py
+++ b/backend/test_observer/controllers/artefacts/missing_environments.py
@@ -1,0 +1,175 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Report the environments an artefact is missing versus the C3 source of truth.
+
+This is a family-specific external integration (C3 only knows about deb/snap) and
+is acknowledged technical debt per the project's generic-platform design principle.
+"""
+
+import logging
+from urllib.parse import urlencode
+
+import requests
+from fastapi import APIRouter, Depends, HTTPException, Security
+from sqlalchemy import select
+from sqlalchemy.orm import Session, selectinload
+
+from test_observer.common.enums import Permission
+from test_observer.common.helpers import get_artefact_url
+from test_observer.common.permissions import permission_checker
+from test_observer.data_access.models import (
+    Artefact,
+    ArtefactBuild,
+    ArtefactBuildEnvironmentReview,
+)
+from test_observer.data_access.models_enums import FamilyName
+from test_observer.data_access.queries import latest_artefact_builds
+from test_observer.data_access.setup import get_db
+from test_observer.external_apis import c3
+from test_observer.external_apis.c3_models import TestingPool
+
+from .models import MissingEnvironmentsResponse
+
+logger = logging.getLogger("test-observer-backend")
+
+router = APIRouter(tags=["artefacts"])
+
+# Families for which C3 has a source of truth (testing pools).
+_C3_FAMILIES = {FamilyName.snap, FamilyName.deb}
+
+# C3 pool metadata key -> Artefact attribute it must equal, per family.
+# For both families the pocket/channel/risk maps to the artefact's stage.
+_DEB_METADATA_FIELDS = {"kernel": "name", "series": "series", "repo": "repo", "source": "stage"}
+_SNAP_METADATA_FIELDS = {"snap": "name", "track": "track", "channel": "stage", "store": "store"}
+_METADATA_FIELDS = {FamilyName.deb: _DEB_METADATA_FIELDS, FamilyName.snap: _SNAP_METADATA_FIELDS}
+
+
+@router.get(
+    "/{artefact_id}/missing-environments",
+    response_model=MissingEnvironmentsResponse,
+    dependencies=[Security(permission_checker, scopes=[Permission.view_artefact])],
+)
+def get_missing_environments(
+    artefact_id: int,
+    db: Session = Depends(get_db),
+) -> MissingEnvironmentsResponse:
+    artefact = db.get(Artefact, artefact_id)
+    if artefact is None:
+        raise HTTPException(status_code=404, detail=f"Artefact with id {artefact_id} not found")
+
+    if FamilyName(artefact.family) not in _C3_FAMILIES:
+        # No source of truth exists for this family.
+        return MissingEnvironmentsResponse(missing_environments=[])
+
+    try:
+        pools = c3.get_testing_pools(artefact.family)
+    except c3.C3NotConfiguredError:
+        return MissingEnvironmentsResponse(missing_environments=[])
+    except requests.RequestException as e:
+        logger.exception("Failed to fetch testing pools from C3 for artefact %s", artefact_id)
+        raise HTTPException(status_code=502, detail="Failed to reach the C3 source of truth") from e
+
+    expected = resolve_expected_environments(artefact, pools)
+    actual = _get_actual_environments(db, artefact_id)
+    missing = sorted({name for name, _arch in expected - actual})
+
+    previous_artefact_link = None
+    if missing:
+        previous = _get_previous_artefact(db, artefact)
+        if previous is not None:
+            previous_artefact_link = _build_filtered_link(previous, missing)
+
+    return MissingEnvironmentsResponse(
+        missing_environments=missing,
+        previous_artefact_link=previous_artefact_link,
+    )
+
+
+def resolve_expected_environments(
+    artefact: Artefact,
+    pools: list[TestingPool],
+) -> set[tuple[str, str]]:
+    """Resolve an artefact's expected environments from C3 pools as (name, arch) pairs.
+
+    Each C3 pool validates exactly one artefact, matched by its structured
+    ``metadata``. Each environment is returned with its architecture so the diff
+    against the artefact's environments is architecture-aware. This function
+    (with its helpers) owns the mapping.
+    """
+    expected: set[tuple[str, str]] = set()
+    family = FamilyName(artefact.family)
+    if family not in _C3_FAMILIES:
+        return expected
+
+    for pool in pools:
+        if not _pool_matches_artefact(artefact, pool):
+            continue
+
+        for environment in pool.environments:
+            expected.add((environment.name, environment.arch))
+
+    return expected
+
+
+def _pool_matches_artefact(artefact: Artefact, pool: TestingPool) -> bool:
+    if pool.family != artefact.family:
+        return False
+
+    field_map = _METADATA_FIELDS.get(FamilyName(artefact.family))
+    if field_map is None:
+        return False
+
+    keys = field_map.keys() & pool.metadata.keys()
+    return bool(keys) and all(
+        pool.metadata[key] == getattr(artefact, attr) for key, attr in field_map.items() if key in keys
+    )
+
+
+def _get_actual_environments(db: Session, artefact_id: int) -> set[tuple[str, str]]:
+    latest_builds = db.scalars(
+        latest_artefact_builds.where(ArtefactBuild.artefact_id == artefact_id).options(
+            selectinload(ArtefactBuild.environment_reviews).selectinload(ArtefactBuildEnvironmentReview.environment)
+        )
+    ).all()
+    return {
+        (review.environment.name, review.environment.architecture)
+        for build in latest_builds
+        for review in build.environment_reviews
+    }
+
+
+def _get_previous_artefact(db: Session, artefact: Artefact) -> Artefact | None:
+    """The version immediately preceding the given artefact, or None."""
+    return db.scalars(
+        select(Artefact)
+        .where(Artefact.name == artefact.name)
+        .where(Artefact.track == artefact.track)
+        .where(Artefact.branch == artefact.branch)
+        .where(Artefact.series == artefact.series)
+        .where(Artefact.repo == artefact.repo)
+        .where(Artefact.os == artefact.os)
+        .where(Artefact.release == artefact.release)
+        .where(Artefact.source == artefact.source)
+        .where(Artefact.bundled_builds_hash == artefact.bundled_builds_hash)
+        .where(Artefact.id < artefact.id)
+        .order_by(Artefact.id.desc())
+        .limit(1)
+    ).first()
+
+
+def _build_filtered_link(artefact: Artefact, environments: list[str]) -> str:
+    query = urlencode([("Environment", name) for name in environments])
+    return f"{get_artefact_url(artefact)}?{query}"

--- a/backend/test_observer/controllers/artefacts/missing_environments.py
+++ b/backend/test_observer/controllers/artefacts/missing_environments.py
@@ -41,11 +41,12 @@ from test_observer.data_access.setup import get_db
 from test_observer.external_apis import c3
 from test_observer.external_apis.c3_models import TestingPool
 
-from .models import MissingEnvironmentsResponse
+from .models import MissingEnvironment, MissingEnvironmentsResponse
 
 logger = logging.getLogger("test-observer-backend")
 
-router = APIRouter(tags=["artefacts"])
+# Tags come from the parent artefacts router; setting them here duplicates them.
+router = APIRouter()
 
 # Families for which C3 has a source of truth (testing pools).
 _C3_FAMILIES = {FamilyName.snap, FamilyName.deb}
@@ -84,7 +85,7 @@ def get_missing_environments(
 
     expected = resolve_expected_environments(artefact, pools)
     actual = _get_actual_environments(db, artefact_id)
-    missing = sorted({name for name, _arch in expected - actual})
+    missing = sorted(expected - actual)
 
     previous_artefact_link = None
     if missing:
@@ -93,7 +94,7 @@ def get_missing_environments(
             previous_artefact_link = _build_filtered_link(previous, missing)
 
     return MissingEnvironmentsResponse(
-        missing_environments=missing,
+        missing_environments=[MissingEnvironment(name=name, architecture=arch) for name, arch in missing],
         previous_artefact_link=previous_artefact_link,
     )
 
@@ -170,6 +171,9 @@ def _get_previous_artefact(db: Session, artefact: Artefact) -> Artefact | None:
     ).first()
 
 
-def _build_filtered_link(artefact: Artefact, environments: list[str]) -> str:
-    query = urlencode([("Environment", name) for name in environments])
+def _build_filtered_link(artefact: Artefact, environments: list[tuple[str, str]]) -> str:
+    # The frontend Environment filter is keyed on name, so dedupe names (an env
+    # missing on multiple arches only needs one filter entry) while preserving order.
+    names = list(dict.fromkeys(name for name, _arch in environments))
+    query = urlencode([("Environment", name) for name in names])
     return f"{get_artefact_url(artefact)}?{query}"

--- a/backend/test_observer/controllers/artefacts/models.py
+++ b/backend/test_observer/controllers/artefacts/models.py
@@ -245,6 +245,19 @@ class ArtefactHistoryResponse(BaseModel):
     items: list[ArtefactHistoryItemResponse]
 
 
+class MissingEnvironmentsResponse(BaseModel):
+    """Environments an artefact is missing versus the C3 source of truth."""
+
+    # Names of expected environments not present in the latest build reviews.
+    # Empty when nothing is missing, or when no C3 source of truth applies
+    # (unsupported family, no matching pool, or C3 not configured).
+    missing_environments: list[str]
+    # Link to the previous artefact version pre-filtered to the missing
+    # environments, so a reviewer can rerun or investigate them. Null when there
+    # is no previous version or nothing is missing.
+    previous_artefact_link: str | None = None
+
+
 class EnvironmentReviewReviewerResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/test_observer/controllers/artefacts/models.py
+++ b/backend/test_observer/controllers/artefacts/models.py
@@ -245,13 +245,18 @@ class ArtefactHistoryResponse(BaseModel):
     items: list[ArtefactHistoryItemResponse]
 
 
+class MissingEnvironment(BaseModel):
+    name: str
+    architecture: str
+
+
 class MissingEnvironmentsResponse(BaseModel):
     """Environments an artefact is missing versus the C3 source of truth."""
 
-    # Names of expected environments not present in the latest build reviews.
-    # Empty when nothing is missing, or when no C3 source of truth applies
+    # Expected environments (name + architecture) not present in the latest build
+    # reviews. Empty when nothing is missing, or when no C3 source of truth applies
     # (unsupported family, no matching pool, or C3 not configured).
-    missing_environments: list[str]
+    missing_environments: list[MissingEnvironment]
     # Link to the previous artefact version pre-filtered to the missing
     # environments, so a reviewer can rerun or investigate them. Null when there
     # is no previous version or nothing is missing.

--- a/backend/test_observer/external_apis/c3.py
+++ b/backend/test_observer/external_apis/c3.py
@@ -19,15 +19,11 @@ NOTE: This is a family-specific external integration (C3 only knows about deb/sn
 and is acknowledged technical debt per the project's generic-platform design principle.
 """
 
-import logging
-
 import requests
 
 from test_observer.common import config
 
 from .c3_models import TestingPool
-
-logger = logging.getLogger("test-observer-backend")
 
 _TIMEOUT_SECONDS = 30
 

--- a/backend/test_observer/external_apis/c3.py
+++ b/backend/test_observer/external_apis/c3.py
@@ -1,0 +1,76 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Client for C3's testing-pools API (the source of truth for expected environments).
+
+NOTE: This is a family-specific external integration (C3 only knows about deb/snap)
+and is acknowledged technical debt per the project's generic-platform design principle.
+"""
+
+import logging
+
+import requests
+
+from test_observer.common import config
+
+from .c3_models import TestingPool
+
+logger = logging.getLogger("test-observer-backend")
+
+_TIMEOUT_SECONDS = 30
+
+
+class C3NotConfiguredError(Exception):
+    """Raised when the C3 API token is not configured."""
+
+
+def is_configured() -> bool:
+    return bool(config.C3_API_TOKEN)
+
+
+def get_testing_pools(family: str) -> list[TestingPool]:
+    """Fetch C3 testing pools for a given artefact family (``deb`` or ``snap``).
+
+    Follows pagination and returns all pools. Raises :class:`C3NotConfiguredError`
+    when no API token is configured so callers can degrade gracefully.
+    """
+    if not is_configured():
+        raise C3NotConfiguredError("C3_API_TOKEN is not set")
+
+    headers = {
+        "Accept": "application/json",
+        "Authorization": f"Bearer {config.C3_API_TOKEN}",
+    }
+    url: str | None = f"{config.C3_API_BASE_URL.rstrip('/')}/api/v2/testing-pools/"
+    params: dict[str, str] | None = {"family": family}
+
+    pools: list[TestingPool] = []
+    while url:
+        response = requests.get(url, headers=headers, params=params, timeout=_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        payload = response.json()
+
+        # C3 (DRF) paginates as {"results": [...], "next": url}; tolerate a bare list too.
+        if isinstance(payload, dict):
+            results = payload.get("results", [])
+            url = payload.get("next")
+        else:
+            results = payload
+            url = None
+        params = None  # `next` already carries the query string
+
+        pools.extend(TestingPool(**item) for item in results)
+
+    return pools

--- a/backend/test_observer/external_apis/c3_models.py
+++ b/backend/test_observer/external_apis/c3_models.py
@@ -1,0 +1,51 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from typing import Annotated, Any
+
+from pydantic import BaseModel, BeforeValidator, Field
+
+# C3 may serialise an unset JSON metadata field as null; treat it as empty.
+Metadata = Annotated[dict[str, Any], BeforeValidator(lambda v: {} if v is None else v)]
+
+
+class TestingPoolEnvironment(BaseModel):
+    """A testing environment within a pool.
+
+    ``name`` is the Test Observer environment name (a deb system-id or snap
+    environment name); ``queue`` is the Testflinger queue the job dispatches to;
+    ``arch`` is the single architecture the environment runs on. Several
+    environments may share a queue and arch (e.g. different core bases/flavors).
+    """
+
+    name: str
+    queue: str
+    arch: str
+    metadata: Metadata = Field(default_factory=dict)
+
+
+class TestingPool(BaseModel):
+    """A C3 testing pool: the set of environments that validate a single artefact.
+
+    Mirrors the response of C3's ``GET /api/v2/testing-pools/`` endpoint. ``metadata``
+    holds structured, family-specific artefact identity (e.g. ``kernel``/``series``/
+    ``repo``/``source`` for deb).
+    """
+
+    name: str
+    family: str
+    metadata: Metadata = Field(default_factory=dict)
+    environments: list[TestingPoolEnvironment] = Field(default_factory=list)
+    description: str = ""

--- a/backend/tests/controllers/artefacts/test_missing_environments.py
+++ b/backend/tests/controllers/artefacts/test_missing_environments.py
@@ -1,0 +1,397 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License version 3, as
+# published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-FileCopyrightText: Copyright 2026 Canonical Ltd.
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import pytest
+import requests
+from fastapi.testclient import TestClient
+from httpx import Response
+from requests_mock import Mocker
+
+from test_observer.common import config
+from test_observer.common.enums import Permission
+from test_observer.data_access.models_enums import FamilyName, StageName
+from tests.conftest import make_authenticated_request
+from tests.data_generator import DataGenerator
+
+C3_BASE_URL = "https://c3.test"
+POOLS_URL = f"{C3_BASE_URL}/api/v2/testing-pools/"
+
+
+def _env(name: str, arch: str = "amd64", *, queue: str | None = None, metadata: dict | None = None) -> dict:
+    return {"name": name, "queue": queue or name, "arch": arch, "metadata": metadata or {}}
+
+
+def _snap_metadata(snap: str = "core", track: str = "latest", channel: str = "beta", store: str = "ubuntu") -> dict:
+    return {"snap": snap, "track": track, "channel": channel, "store": store}
+
+
+@pytest.fixture
+def c3_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config, "C3_API_TOKEN", "test-token")
+    monkeypatch.setattr(config, "C3_API_BASE_URL", C3_BASE_URL)
+
+
+def _get(test_client: TestClient, artefact_id: int) -> Response:
+    return make_authenticated_request(
+        lambda: test_client.get(f"/v1/artefacts/{artefact_id}/missing-environments"),
+        Permission.view_artefact,
+    )
+
+
+def test_get_404_when_artefact_not_found(test_client: TestClient):
+    response = _get(test_client, 1)
+    assert response.status_code == 404
+
+
+def test_no_missing_when_c3_not_configured(
+    test_client: TestClient, generator: DataGenerator, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(config, "C3_API_TOKEN", "")
+    a = generator.gen_artefact(StageName.beta, family=FamilyName.snap)
+
+    response = _get(test_client, a.id)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "missing_environments": [],
+        "previous_artefact_link": None,
+    }
+
+
+@pytest.mark.usefixtures("c3_configured")
+def test_no_missing_for_family_without_c3(test_client: TestClient, generator: DataGenerator):
+    a = generator.gen_artefact(StageName.pending, family=FamilyName.charm)
+
+    response = _get(test_client, a.id)
+
+    assert response.status_code == 200
+    assert response.json()["missing_environments"] == []
+
+
+@pytest.mark.usefixtures("c3_configured")
+def test_c3_outage_returns_502(
+    test_client: TestClient,
+    generator: DataGenerator,
+    requests_mock: Mocker,
+):
+    a = generator.gen_artefact(StageName.beta, family=FamilyName.snap)
+    requests_mock.get(POOLS_URL, exc=requests.exceptions.ConnectionError)
+
+    response = _get(test_client, a.id)
+
+    assert response.status_code == 502
+
+
+@pytest.mark.usefixtures("c3_configured")
+def test_missing_environments_reported_with_previous_link(
+    test_client: TestClient,
+    generator: DataGenerator,
+    requests_mock: Mocker,
+):
+    previous = generator.gen_artefact(StageName.beta, family=FamilyName.snap, version="1.0.0")
+    current = generator.gen_artefact(StageName.beta, family=FamilyName.snap, version="1.0.1")
+    build = generator.gen_artefact_build(current, architecture="amd64")
+    env = generator.gen_environment("queue-a", architecture="amd64")
+    generator.gen_artefact_build_environment_review(build, env)
+
+    requests_mock.get(
+        POOLS_URL,
+        json={
+            "results": [
+                {
+                    "name": "core-latest-beta",
+                    "family": "snap",
+                    "metadata": _snap_metadata(),
+                    "environments": [_env("queue-a"), _env("queue-b")],
+                    "description": "",
+                }
+            ],
+            "next": None,
+        },
+    )
+
+    response = _get(test_client, current.id)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["missing_environments"] == ["queue-b"]
+    assert body["previous_artefact_link"] == (f"http://localhost:30001/snaps/{previous.id}?Environment=queue-b")
+
+
+@pytest.mark.usefixtures("c3_configured")
+def test_no_missing_when_all_expected_present(
+    test_client: TestClient,
+    generator: DataGenerator,
+    requests_mock: Mocker,
+):
+    a = generator.gen_artefact(StageName.beta, family=FamilyName.snap)
+    build = generator.gen_artefact_build(a, architecture="amd64")
+    for name in ("queue-a", "queue-b"):
+        env = generator.gen_environment(name, architecture="amd64")
+        generator.gen_artefact_build_environment_review(build, env)
+
+    requests_mock.get(
+        POOLS_URL,
+        json={
+            "results": [
+                {
+                    "name": "core-latest-beta",
+                    "family": "snap",
+                    "metadata": _snap_metadata(),
+                    "environments": [_env("queue-a"), _env("queue-b")],
+                }
+            ],
+            "next": None,
+        },
+    )
+
+    response = _get(test_client, a.id)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["missing_environments"] == []
+    assert body["previous_artefact_link"] is None
+
+
+@pytest.mark.usefixtures("c3_configured")
+def test_non_matching_pools_yield_no_missing(
+    test_client: TestClient,
+    generator: DataGenerator,
+    requests_mock: Mocker,
+):
+    a = generator.gen_artefact(StageName.beta, family=FamilyName.snap, name="core")
+    generator.gen_artefact_build(a, architecture="amd64")
+
+    requests_mock.get(
+        POOLS_URL,
+        json={
+            "results": [
+                # Different snap, and a matching snap on a different channel:
+                # neither should match on metadata.
+                {
+                    "name": "other-latest-beta",
+                    "family": "snap",
+                    "metadata": _snap_metadata(snap="other"),
+                    "environments": [_env("queue-x")],
+                },
+                {
+                    "name": "core-latest-stable",
+                    "family": "snap",
+                    "metadata": _snap_metadata(channel="stable"),
+                    "environments": [_env("queue-y")],
+                },
+            ],
+            "next": None,
+        },
+    )
+
+    response = _get(test_client, a.id)
+
+    assert response.status_code == 200
+    assert response.json()["missing_environments"] == []
+
+
+@pytest.mark.usefixtures("c3_configured")
+def test_missing_environments_for_deb_matched_by_metadata(
+    test_client: TestClient,
+    generator: DataGenerator,
+    requests_mock: Mocker,
+):
+    a = generator.gen_artefact(StageName.proposed, family=FamilyName.deb, name="linux-raspi", series="jammy")
+    generator.gen_artefact_build(a, architecture="arm64")
+
+    requests_mock.get(
+        POOLS_URL,
+        json={
+            "results": [
+                {
+                    "name": "linux-raspi-jammy-main-proposed",
+                    "family": "deb",
+                    # source maps to the artefact's stage (the SRU pocket).
+                    "metadata": {"kernel": "linux-raspi", "series": "jammy", "repo": "main", "source": "proposed"},
+                    "environments": [_env("cm3-arm64", "arm64"), _env("rpi4b8g-arm64", "arm64")],
+                }
+            ],
+            "next": None,
+        },
+    )
+
+    response = _get(test_client, a.id)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["missing_environments"] == ["cm3-arm64", "rpi4b8g-arm64"]
+
+
+@pytest.mark.usefixtures("c3_configured")
+def test_deb_stage_mismatch_yields_no_missing(
+    test_client: TestClient,
+    generator: DataGenerator,
+    requests_mock: Mocker,
+):
+    a = generator.gen_artefact(StageName.proposed, family=FamilyName.deb, name="linux-raspi", series="jammy")
+    generator.gen_artefact_build(a, architecture="arm64")
+
+    requests_mock.get(
+        POOLS_URL,
+        json={
+            "results": [
+                {
+                    "name": "linux-raspi-jammy-main-updates",
+                    "family": "deb",
+                    # Same kernel/series/repo but a different pocket (updates vs proposed).
+                    "metadata": {"kernel": "linux-raspi", "series": "jammy", "repo": "main", "source": "updates"},
+                    "environments": [_env("cm3-arm64", "arm64")],
+                }
+            ],
+            "next": None,
+        },
+    )
+
+    response = _get(test_client, a.id)
+
+    assert response.status_code == 200
+    assert response.json()["missing_environments"] == []
+
+
+@pytest.mark.usefixtures("c3_configured")
+def test_deb_metadata_mismatch_yields_no_missing(
+    test_client: TestClient,
+    generator: DataGenerator,
+    requests_mock: Mocker,
+):
+    a = generator.gen_artefact(StageName.proposed, family=FamilyName.deb, name="linux-raspi", series="jammy")
+    generator.gen_artefact_build(a, architecture="arm64")
+
+    requests_mock.get(
+        POOLS_URL,
+        json={
+            "results": [
+                {
+                    "name": "noble-linux-raspi-arm64",
+                    "family": "deb",
+                    "metadata": {"kernel": "linux-raspi", "series": "noble"},
+                    "environments": [_env("cm3-arm64", "arm64")],
+                }
+            ],
+            "next": None,
+        },
+    )
+
+    response = _get(test_client, a.id)
+
+    assert response.status_code == 200
+    assert response.json()["missing_environments"] == []
+
+
+@pytest.mark.usefixtures("c3_configured")
+def test_missing_is_computed_per_name_and_arch(
+    test_client: TestClient,
+    generator: DataGenerator,
+    requests_mock: Mocker,
+):
+    a = generator.gen_artefact(StageName.proposed, family=FamilyName.deb, name="linux-raspi", series="jammy")
+    build = generator.gen_artefact_build(a, architecture="arm64")
+    env = generator.gen_environment("rpi400", architecture="arm64")
+    generator.gen_artefact_build_environment_review(build, env)
+
+    requests_mock.get(
+        POOLS_URL,
+        json={
+            "results": [
+                {
+                    "name": "jammy-linux-raspi",
+                    "family": "deb",
+                    "metadata": {"kernel": "linux-raspi", "series": "jammy"},
+                    "environments": [
+                        _env("rpi400", "arm64"),  # present: matched on name + arch
+                        _env("rpi5b8g-server", "arm64"),  # missing
+                        _env("nuc-amd64", "amd64"),  # missing: compared by its own arch
+                    ],
+                }
+            ],
+            "next": None,
+        },
+    )
+
+    response = _get(test_client, a.id)
+
+    assert response.status_code == 200
+    assert response.json()["missing_environments"] == ["nuc-amd64", "rpi5b8g-server"]
+
+
+@pytest.mark.usefixtures("c3_configured")
+def test_multiple_environments_can_share_a_queue(
+    test_client: TestClient,
+    generator: DataGenerator,
+    requests_mock: Mocker,
+):
+    a = generator.gen_artefact(StageName.proposed, family=FamilyName.deb, name="linux-raspi", series="jammy")
+    generator.gen_artefact_build(a, architecture="arm64")
+
+    requests_mock.get(
+        POOLS_URL,
+        json={
+            "results": [
+                {
+                    "name": "jammy-linux-raspi",
+                    "family": "deb",
+                    "metadata": {"kernel": "linux-raspi", "series": "jammy"},
+                    # Distinct environments may share a queue + arch (e.g. flavors).
+                    "environments": [
+                        _env("rpi3b-server", "arm64", queue="rpi3b"),
+                        _env("rpi3b-desktop", "arm64", queue="rpi3b"),
+                    ],
+                }
+            ],
+            "next": None,
+        },
+    )
+
+    response = _get(test_client, a.id)
+
+    assert response.status_code == 200
+    assert response.json()["missing_environments"] == ["rpi3b-desktop", "rpi3b-server"]
+
+
+@pytest.mark.usefixtures("c3_configured")
+def test_null_pool_metadata_is_tolerated(
+    test_client: TestClient,
+    generator: DataGenerator,
+    requests_mock: Mocker,
+):
+    a = generator.gen_artefact(StageName.beta, family=FamilyName.snap)
+    generator.gen_artefact_build(a, architecture="amd64")
+
+    requests_mock.get(
+        POOLS_URL,
+        json={
+            "results": [
+                {
+                    "name": "core-latest-beta-amd64",
+                    "family": "snap",
+                    "metadata": None,
+                    "environments": [_env("queue-a"), _env("queue-b")],
+                }
+            ],
+            "next": None,
+        },
+    )
+
+    response = _get(test_client, a.id)
+
+    # null metadata is coerced to {} (no crash); with no keys it simply doesn't match.
+    assert response.status_code == 200
+    assert response.json()["missing_environments"] == []

--- a/backend/tests/controllers/artefacts/test_missing_environments.py
+++ b/backend/tests/controllers/artefacts/test_missing_environments.py
@@ -126,7 +126,7 @@ def test_missing_environments_reported_with_previous_link(
 
     assert response.status_code == 200
     body = response.json()
-    assert body["missing_environments"] == ["queue-b"]
+    assert body["missing_environments"] == [{"name": "queue-b", "architecture": "amd64"}]
     assert body["previous_artefact_link"] == (f"http://localhost:30001/snaps/{previous.id}?Environment=queue-b")
 
 
@@ -232,7 +232,10 @@ def test_missing_environments_for_deb_matched_by_metadata(
 
     assert response.status_code == 200
     body = response.json()
-    assert body["missing_environments"] == ["cm3-arm64", "rpi4b8g-arm64"]
+    assert body["missing_environments"] == [
+        {"name": "cm3-arm64", "architecture": "arm64"},
+        {"name": "rpi4b8g-arm64", "architecture": "arm64"},
+    ]
 
 
 @pytest.mark.usefixtures("c3_configured")
@@ -329,7 +332,46 @@ def test_missing_is_computed_per_name_and_arch(
     response = _get(test_client, a.id)
 
     assert response.status_code == 200
-    assert response.json()["missing_environments"] == ["nuc-amd64", "rpi5b8g-server"]
+    assert response.json()["missing_environments"] == [
+        {"name": "nuc-amd64", "architecture": "amd64"},
+        {"name": "rpi5b8g-server", "architecture": "arm64"},
+    ]
+
+
+@pytest.mark.usefixtures("c3_configured")
+def test_same_name_on_two_arches_is_disambiguated(
+    test_client: TestClient,
+    generator: DataGenerator,
+    requests_mock: Mocker,
+):
+    a = generator.gen_artefact(StageName.proposed, family=FamilyName.deb, name="linux-raspi", series="jammy")
+    build = generator.gen_artefact_build(a, architecture="arm64")
+    # Same environment name present on arm64 but not amd64.
+    env = generator.gen_environment("rpi400", architecture="arm64")
+    generator.gen_artefact_build_environment_review(build, env)
+
+    requests_mock.get(
+        POOLS_URL,
+        json={
+            "results": [
+                {
+                    "name": "jammy-linux-raspi",
+                    "family": "deb",
+                    "metadata": {"kernel": "linux-raspi", "series": "jammy"},
+                    "environments": [
+                        _env("rpi400", "arm64"),  # present
+                        _env("rpi400", "amd64"),  # missing: same name, different arch
+                    ],
+                }
+            ],
+            "next": None,
+        },
+    )
+
+    response = _get(test_client, a.id)
+
+    assert response.status_code == 200
+    assert response.json()["missing_environments"] == [{"name": "rpi400", "architecture": "amd64"}]
 
 
 @pytest.mark.usefixtures("c3_configured")
@@ -363,7 +405,10 @@ def test_multiple_environments_can_share_a_queue(
     response = _get(test_client, a.id)
 
     assert response.status_code == 200
-    assert response.json()["missing_environments"] == ["rpi3b-desktop", "rpi3b-server"]
+    assert response.json()["missing_environments"] == [
+        {"name": "rpi3b-desktop", "architecture": "arm64"},
+        {"name": "rpi3b-server", "architecture": "arm64"},
+    ]
 
 
 @pytest.mark.usefixtures("c3_configured")

--- a/backend/tests/controllers/artefacts/test_missing_environments.py
+++ b/backend/tests/controllers/artefacts/test_missing_environments.py
@@ -204,6 +204,38 @@ def test_non_matching_pools_yield_no_missing(
 
 
 @pytest.mark.usefixtures("c3_configured")
+def test_partial_pool_metadata_does_not_match(
+    test_client: TestClient,
+    generator: DataGenerator,
+    requests_mock: Mocker,
+):
+    a = generator.gen_artefact(StageName.beta, family=FamilyName.snap, name="core")
+    generator.gen_artefact_build(a, architecture="amd64")
+
+    requests_mock.get(
+        POOLS_URL,
+        json={
+            "results": [
+                # Only the snap name matches; track/channel/store are absent.
+                # A partial metadata overlap must not be treated as a match.
+                {
+                    "name": "core-partial",
+                    "family": "snap",
+                    "metadata": {"snap": "core"},
+                    "environments": [_env("queue-x")],
+                }
+            ],
+            "next": None,
+        },
+    )
+
+    response = _get(test_client, a.id)
+
+    assert response.status_code == 200
+    assert response.json()["missing_environments"] == []
+
+
+@pytest.mark.usefixtures("c3_configured")
 def test_missing_environments_for_deb_matched_by_metadata(
     test_client: TestClient,
     generator: DataGenerator,
@@ -285,7 +317,8 @@ def test_deb_metadata_mismatch_yields_no_missing(
                 {
                     "name": "noble-linux-raspi-arm64",
                     "family": "deb",
-                    "metadata": {"kernel": "linux-raspi", "series": "noble"},
+                    # Same kernel/repo/pocket but a different series (noble vs jammy).
+                    "metadata": {"kernel": "linux-raspi", "series": "noble", "repo": "main", "source": "proposed"},
                     "environments": [_env("cm3-arm64", "arm64")],
                 }
             ],
@@ -317,7 +350,7 @@ def test_missing_is_computed_per_name_and_arch(
                 {
                     "name": "jammy-linux-raspi",
                     "family": "deb",
-                    "metadata": {"kernel": "linux-raspi", "series": "jammy"},
+                    "metadata": {"kernel": "linux-raspi", "series": "jammy", "repo": "main", "source": "proposed"},
                     "environments": [
                         _env("rpi400", "arm64"),  # present: matched on name + arch
                         _env("rpi5b8g-server", "arm64"),  # missing
@@ -357,7 +390,7 @@ def test_same_name_on_two_arches_is_disambiguated(
                 {
                     "name": "jammy-linux-raspi",
                     "family": "deb",
-                    "metadata": {"kernel": "linux-raspi", "series": "jammy"},
+                    "metadata": {"kernel": "linux-raspi", "series": "jammy", "repo": "main", "source": "proposed"},
                     "environments": [
                         _env("rpi400", "arm64"),  # present
                         _env("rpi400", "amd64"),  # missing: same name, different arch
@@ -390,7 +423,7 @@ def test_multiple_environments_can_share_a_queue(
                 {
                     "name": "jammy-linux-raspi",
                     "family": "deb",
-                    "metadata": {"kernel": "linux-raspi", "series": "jammy"},
+                    "metadata": {"kernel": "linux-raspi", "series": "jammy", "repo": "main", "source": "proposed"},
                     # Distinct environments may share a queue + arch (e.g. flavors).
                     "environments": [
                         _env("rpi3b-server", "arm64", queue="rpi3b"),


### PR DESCRIPTION
## Description

This PR adds the backend API for retrieving missing environments for artefacts.
This API gets the ground truth of the environments required of an artefact from C3 (https://github.com/canonical/hexr/pull/1333) and compares the environment list with the artefact ones, returning the missing environments.

> [!NOTE]
> I referenced https://certification.canonical.com/docs/help/how-to/authenticate/, and it looks like we need a Bearer token for this, and I am not quite sure what the best way is to add the token to this repo.

## Resolved issues

https://warthogs.atlassian.net/browse/CER-3551

## Documentation



## Web service API changes

* Adds C3 to external APIs
* New API `GET /v1/artefacts/{artefact_id}/missing-environments`
Example return:
```
{
  "missing_environments": [
    "cm3p",
    "rpi2",
    "rpi3ap",
    "rpi3b",
    "rpi3bp",
    "rpi4b1g",
    "rpi4b2g",
    "rpi4b4g",
    "rpi4b8g",
    "rpicm4l",
    "rpiz2"
  ],
  "previous_artefact_link": "http://localhost:30001/debs/12?Environment=cm3p&Environment=rpi2&Environment=rpi3ap&Environment=rpi3b&Environment=rpi3bp&Environment=rpi4b1g&Environment=rpi4b2g&Environment=rpi4b4g&Environment=rpi4b8g&Environment=rpicm4l&Environment=rpiz2"
}
```

## Tests

Tests added