### PR TITLE
[TO-443] Fix? Launchpad logins with proxy

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
     "requests>=2.33.0,<3.0.0",
     "sentry-sdk>=2.56.0,<3.0.0",
     "launchpadlib>=1.11.0,<2.0.0",
+    # httplib2 (via launchpadlib) silently ignores HTTP(S)_PROXY unless socks is importable
+    "pysocks>=1.7.1,<2.0.0",
     "PyGithub>=2.0.0,<3.0.0",
     "jira>=3.10.0,<4.0.0",
     "email-validator>=2.1.0.post1,<3.0.0",

--- a/backend/test_observer/external_apis/launchpad/launchpad_api.py
+++ b/backend/test_observer/external_apis/launchpad/launchpad_api.py
@@ -21,7 +21,9 @@ from .models import LaunchpadUser
 
 class LaunchpadAPI:
     def __init__(self):
-        self.launchpad = Launchpad.login_anonymously("test-observer", "production", version="devel")
+        self.launchpad = Launchpad.login_anonymously(
+            "test-observer", "production", version="devel", timeout=30
+        )
 
     def get_user_by_email(self, email: EmailStr) -> LaunchpadUser | None:
         user = self.launchpad.people.getByEmail(email=email)

--- a/backend/test_observer/external_apis/launchpad/launchpad_api.py
+++ b/backend/test_observer/external_apis/launchpad/launchpad_api.py
@@ -21,9 +21,7 @@ from .models import LaunchpadUser
 
 class LaunchpadAPI:
     def __init__(self):
-        self.launchpad = Launchpad.login_anonymously(
-            "test-observer", "production", version="devel", timeout=30
-        )
+        self.launchpad = Launchpad.login_anonymously("test-observer", "production", version="devel", timeout=30)
 
     def get_user_by_email(self, email: EmailStr) -> LaunchpadUser | None:
         user = self.launchpad.people.getByEmail(email=email)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1249,6 +1249,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1541,6 +1550,7 @@ dependencies = [
     { name = "pg8000" },
     { name = "prometheus-fastapi-instrumentator" },
     { name = "pygithub" },
+    { name = "pysocks" },
     { name = "python-multipart" },
     { name = "python3-saml" },
     { name = "requests" },
@@ -1576,6 +1586,7 @@ requires-dist = [
     { name = "pg8000", specifier = ">=1.29.4,<2.0.0" },
     { name = "prometheus-fastapi-instrumentator", specifier = ">=7.1.0" },
     { name = "pygithub", specifier = ">=2.0.0,<3.0.0" },
+    { name = "pysocks", specifier = ">=1.7.1,<2.0.0" },
     { name = "python-multipart", specifier = ">=0.0.20,<0.1.0" },
     { name = "python3-saml", specifier = ">=1.16.0" },
     { name = "requests", specifier = ">=2.33.0,<3.0.0" },


### PR DESCRIPTION
<!--
Copyright 2024 Canonical Ltd.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

SPDX-FileCopyrightText: Copyright 2024 Canonical Ltd.
SPDX-License-Identifier: Apache-2.0
-->

## Description

The `Launchpad.login_anonymously` method stopped working in environments with certain proxy rules. This appears to be a result of an update to `httplib2`, which we made in https://github.com/canonical/test_observer/commit/5f95ce4c77355d0afc3df8c5bcf57fbebf18cde0 as part of a security update. I believe the culprit is [this commit](https://github.com/httplib2/httplib2/commit/1a6ff781792099e9e14d7beb610bd99112b17b07) from `httplib2`. To properly respect proxy info, I believe we need to explicitly pull in `pysocks`.

To fail faster and provide clearer errors, this PR also sets a 30 second timeout when logging into Launchpad.

## Resolved issues

[TO-443]

## Testing

This was deployed in our staging environment, and I am able to login there.

[TO-443]: https://warthogs.atlassian.net/browse/TO-443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ